### PR TITLE
MBX-2750 LogLevelError by default

### DIFF
--- a/Mindbox/Mindbox.swift
+++ b/Mindbox/Mindbox.swift
@@ -29,7 +29,7 @@ public class Mindbox: NSObject {
         - In __RELEASE__ schema logs writes _async_ on queue with __qos: .utility__
 
      - Warninig:
-      By default _logLevel_: __.none__
+      By default _logLevel_: __.error__
      */
     public static let logger = MBLogger.shared
 

--- a/MindboxLogger/Shared/MBLogger.swift
+++ b/MindboxLogger/Shared/MBLogger.swift
@@ -25,7 +25,7 @@ public class MBLogger {
      
      - Note: `.error` by default; `.none` for disable logging
      */
-    public var logLevel: LogLevel = .debug
+    public var logLevel: LogLevel = .error
         
     private enum ExecutionMethod {
         case sync(lock: NSRecursiveLock)


### PR DESCRIPTION
[[iOS] Установить дефолтный уровень логирования Error](https://github.com/mindbox-cloud/issues-web-mobile/issues/2750)