### PR TITLE
MBX-3280: Add FileProtectionType.none for MBLogger CoreData

### DIFF
--- a/Mindbox/Mindbox.swift
+++ b/Mindbox/Mindbox.swift
@@ -176,7 +176,7 @@ public class Mindbox: NSObject {
             }
             
             guard persistenceAPNSToken != token else {
-                Logger.common(message: "persistenceAPNSToken not equal to deviceToken. persistenceAPNSToken: \(persistenceAPNSToken)", level: .error, category: .notification)
+                Logger.common(message: "persistenceAPNSToken is equal to deviceToken. persistenceAPNSToken: \(persistenceAPNSToken)", level: .error, category: .notification)
                 return
             }
             coreController?.apnsTokenDidUpdate(token: token)

--- a/MindboxLogger/Shared/LoggerRepository/MBLoggerCoreDataManager.swift
+++ b/MindboxLogger/Shared/LoggerRepository/MBLoggerCoreDataManager.swift
@@ -50,6 +50,7 @@ public class MBLoggerCoreDataManager {
         
         let storeURL = FileManager.storeURL(for: MBLoggerUtilitiesFetcher().applicationGroupIdentifier, databaseName: Constants.model)
         let storeDescription = NSPersistentStoreDescription(url: storeURL)
+        storeDescription.setOption(FileProtectionType.none as NSObject, forKey: NSPersistentStoreFileProtectionKey)
         storeDescription.setValue("DELETE" as NSObject, forPragmaNamed: "journal_mode") // Disabling WAL journal
         container.persistentStoreDescriptions = [storeDescription]
         container.loadPersistentStores {


### PR DESCRIPTION
[iOS] Crashes MindboxLogger CoreData (prewarming)[#3280](https://github.com/mindbox-cloud/issues-web-mobile/issues/3280)


A lot of crashes MBLoggerCoreDataManager.saveContext[#3284](https://github.com/mindbox-cloud/ios-sdk/issues/335)