### PR TITLE
MBX-3315: InApp starts when state is active

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,10 +19,7 @@ jobs:
     - uses: maxim-lobanov/setup-xcode@v1
       with:
         xcode-version: latest-stable
-    - uses: futureware-tech/simulator-action@v3
-      with:
-        os_version: '>=17.2'
-        
+
     - name: Update bundler
       run: gem install bundler
     - name: Install bundler dependencies

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,6 +19,9 @@ jobs:
     - uses: maxim-lobanov/setup-xcode@v1
       with:
         xcode-version: latest-stable
+    - uses: futureware-tech/simulator-action@v3
+      with:
+        os_version: '>=17.2'
         
     - name: Update bundler
       run: gem install bundler

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,6 +16,10 @@ jobs:
     timeout-minutes: 15
     steps:
     - uses: actions/checkout@v4
+    - uses: maxim-lobanov/setup-xcode@v1
+      with:
+        xcode-version: latest-stable
+        
     - name: Update bundler
       run: gem install bundler
     - name: Install bundler dependencies

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -272,6 +272,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-21
+  arm64-darwin-23
   x86_64-darwin-21
   x86_64-linux
 

--- a/Mindbox.xcodeproj/project.pbxproj
+++ b/Mindbox.xcodeproj/project.pbxproj
@@ -304,6 +304,7 @@
 		B3F4F98A268EEB360092EC3C /* PeriodTypeResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3F4F989268EEB360092EC3C /* PeriodTypeResponse.swift */; };
 		B3F4F98E268EEB4B0092EC3C /* LimitBenefitsResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3F4F98D268EEB4B0092EC3C /* LimitBenefitsResponse.swift */; };
 		BB4D7CC72BDEC51D008E3AB8 /* Notification+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB4D7CC62BDEC51D008E3AB8 /* Notification+Extensions.swift */; };
+		BB6563102BE3BA430090C473 /* UIApplication+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB65630F2BE3BA430090C473 /* UIApplication+Extensions.swift */; };
 		BBAAC17C2BB2FC9100E1E25E /* MockEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBAAC17B2BB2FC9100E1E25E /* MockEvent.swift */; };
 		D2F7E2432BADB89900B24BB8 /* UserVisitManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2F7E2412BADB89900B24BB8 /* UserVisitManager.swift */; };
 		D2F7E2482BADB9EF00B24BB8 /* UserVisitManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2F7E2462BADB9EF00B24BB8 /* UserVisitManagerTests.swift */; };
@@ -832,6 +833,7 @@
 		B3F4F989268EEB360092EC3C /* PeriodTypeResponse.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PeriodTypeResponse.swift; sourceTree = "<group>"; };
 		B3F4F98D268EEB4B0092EC3C /* LimitBenefitsResponse.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LimitBenefitsResponse.swift; sourceTree = "<group>"; };
 		BB4D7CC62BDEC51D008E3AB8 /* Notification+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Notification+Extensions.swift"; sourceTree = "<group>"; };
+		BB65630F2BE3BA430090C473 /* UIApplication+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIApplication+Extensions.swift"; sourceTree = "<group>"; };
 		BBAAC17B2BB2FC9100E1E25E /* MockEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockEvent.swift; sourceTree = "<group>"; };
 		D2F7E2412BADB89900B24BB8 /* UserVisitManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UserVisitManager.swift; sourceTree = "<group>"; };
 		D2F7E2462BADB9EF00B24BB8 /* UserVisitManagerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UserVisitManagerTests.swift; sourceTree = "<group>"; };
@@ -2557,6 +2559,7 @@
 				F37613E02A6A8CFF009F2EE4 /* UIColor+Extensions.swift */,
 				F382F2102BAC6AD100BC97FF /* UNAuthorizationStatus+Extensions.swift */,
 				BB4D7CC62BDEC51D008E3AB8 /* Notification+Extensions.swift */,
+				BB65630F2BE3BA430090C473 /* UIApplication+Extensions.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -3331,6 +3334,7 @@
 				9B4F9DEF28D08897002C9CF0 /* SegmentationCheckResponse.swift in Sources */,
 				F31A94782BC6995500E6C978 /* InappFrequency.swift in Sources */,
 				F3482F212A65DC2C002A41EC /* URLInappMessageDelegate.swift in Sources */,
+				BB6563102BE3BA430090C473 /* UIApplication+Extensions.swift in Sources */,
 				84A312C325DA65690096A017 /* BackgroundTaskManagerType.swift in Sources */,
 				84CC798025CABB0B00C062BD /* Event.swift in Sources */,
 				337C7950265646230092B580 /* ProductGroupRequest.swift in Sources */,

--- a/Mindbox.xcodeproj/project.pbxproj
+++ b/Mindbox.xcodeproj/project.pbxproj
@@ -303,6 +303,7 @@
 		B3F4F982268EEAC90092EC3C /* AmountBenefitsResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3F4F980268EEAC90092EC3C /* AmountBenefitsResponse.swift */; };
 		B3F4F98A268EEB360092EC3C /* PeriodTypeResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3F4F989268EEB360092EC3C /* PeriodTypeResponse.swift */; };
 		B3F4F98E268EEB4B0092EC3C /* LimitBenefitsResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3F4F98D268EEB4B0092EC3C /* LimitBenefitsResponse.swift */; };
+		BB4D7CC72BDEC51D008E3AB8 /* Notification+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB4D7CC62BDEC51D008E3AB8 /* Notification+Extensions.swift */; };
 		BBAAC17C2BB2FC9100E1E25E /* MockEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBAAC17B2BB2FC9100E1E25E /* MockEvent.swift */; };
 		D2F7E2432BADB89900B24BB8 /* UserVisitManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2F7E2412BADB89900B24BB8 /* UserVisitManager.swift */; };
 		D2F7E2482BADB9EF00B24BB8 /* UserVisitManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2F7E2462BADB9EF00B24BB8 /* UserVisitManagerTests.swift */; };
@@ -830,6 +831,7 @@
 		B3F4F985268EEADE0092EC3C /* LimitBenefitsResponse.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LimitBenefitsResponse.swift; sourceTree = "<group>"; };
 		B3F4F989268EEB360092EC3C /* PeriodTypeResponse.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PeriodTypeResponse.swift; sourceTree = "<group>"; };
 		B3F4F98D268EEB4B0092EC3C /* LimitBenefitsResponse.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LimitBenefitsResponse.swift; sourceTree = "<group>"; };
+		BB4D7CC62BDEC51D008E3AB8 /* Notification+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Notification+Extensions.swift"; sourceTree = "<group>"; };
 		BBAAC17B2BB2FC9100E1E25E /* MockEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockEvent.swift; sourceTree = "<group>"; };
 		D2F7E2412BADB89900B24BB8 /* UserVisitManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UserVisitManager.swift; sourceTree = "<group>"; };
 		D2F7E2462BADB9EF00B24BB8 /* UserVisitManagerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UserVisitManagerTests.swift; sourceTree = "<group>"; };
@@ -2554,6 +2556,7 @@
 				F331DD102A83CA7400222120 /* KeyedDecodingContainer+Extensions.swift */,
 				F37613E02A6A8CFF009F2EE4 /* UIColor+Extensions.swift */,
 				F382F2102BAC6AD100BC97FF /* UNAuthorizationStatus+Extensions.swift */,
+				BB4D7CC62BDEC51D008E3AB8 /* Notification+Extensions.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -3105,6 +3108,7 @@
 				D2F7E24A2BADC2AB00B24BB8 /* SessionManager.swift in Sources */,
 				A17958762978AEC600609E91 /* OrTargetingChecker.swift in Sources */,
 				334F3AE1264C199900A6AC00 /* PromoCodeRequest.swift in Sources */,
+				BB4D7CC72BDEC51D008E3AB8 /* Notification+Extensions.swift in Sources */,
 				F39116F52AA9AF7A00852298 /* InappFilter.swift in Sources */,
 				F331DD032A83A56500222120 /* ModalPresentationStrategy.swift in Sources */,
 				A17958792978AEC600609E91 /* GeoTargetingChecker.swift in Sources */,

--- a/Mindbox.xcodeproj/xcshareddata/xcschemes/Mindbox.xcscheme
+++ b/Mindbox.xcodeproj/xcshareddata/xcschemes/Mindbox.xcscheme
@@ -34,6 +34,11 @@
             value = "disable"
             isEnabled = "YES">
          </EnvironmentVariable>
+         <EnvironmentVariable
+            key = "IDEPreferLogStreaming"
+            value = "YES"
+            isEnabled = "YES">
+         </EnvironmentVariable>
       </EnvironmentVariables>
       <Testables>
          <TestableReference

--- a/Mindbox.xcodeproj/xcshareddata/xcschemes/Mindbox.xcscheme
+++ b/Mindbox.xcodeproj/xcshareddata/xcschemes/Mindbox.xcscheme
@@ -27,7 +27,8 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "NO"
-      systemAttachmentLifetime = "keepNever">
+      systemAttachmentLifetime = "keepNever"
+      codeCoverageEnabled = "YES">
       <EnvironmentVariables>
          <EnvironmentVariable
             key = "OS_ACTIVITY_MODE"

--- a/Mindbox/CoreController/CoreController.swift
+++ b/Mindbox/CoreController/CoreController.swift
@@ -39,20 +39,7 @@ final class CoreController {
             self.guaranteedDeliveryManager.canScheduleOperations = true
         }
         
-        DispatchQueue.main.async {
-            let stateDescription: String
-            switch UIApplication.shared.applicationState {
-            case .active:
-                stateDescription = "active"
-            case .inactive:
-                stateDescription = "inactive"
-            case .background:
-                stateDescription = "background"
-            @unknown default:
-                stateDescription = "unknown"
-            }
-            Logger.common(message: "[App State]: \(stateDescription)", level: .info, category: .general)
-        }
+        Logger.common(message: "[App State]: \(UIApplication.shared.appStateDescription)", level: .info, category: .general)
         Logger.common(message: "[Configuration]: \(configuration)", level: .info, category: .general)
         Logger.common(message: "[SDK Version]: \(self.utilitiesFetcher.sdkVersion ?? "null")", level: .info, category: .general)
         Logger.common(message: "[APNS Token]: \(self.persistenceStorage.apnsToken ?? "null")", level: .info, category: .general)
@@ -275,8 +262,10 @@ final class CoreController {
         sessionManager.sessionHandler = { [weak self] isActive in
             if isActive && SessionTemporaryStorage.shared.isInitializationCalled {
                 self?.checkNotificationStatus()
-                self?.userVisitManager.saveUserVisit()
-                self?.inAppMessagesManager.start()
+                self?.controllerQueue.async {
+                    self?.userVisitManager.saveUserVisit()
+                    self?.inAppMessagesManager.start()
+                }
             }
         }
 

--- a/Mindbox/CoreController/CoreController.swift
+++ b/Mindbox/CoreController/CoreController.swift
@@ -10,7 +10,7 @@ import Foundation
 import UIKit
 import MindboxLogger
 
-class CoreController {
+final class CoreController {
     private let persistenceStorage: PersistenceStorage
     private let utilitiesFetcher: UtilitiesFetcher
     private let notificationStatusProvider: UNAuthorizationStatusProviding
@@ -19,7 +19,7 @@ class CoreController {
     private let trackVisitManager: TrackVisitManager
     private let uuidDebugService: UUIDDebugService
     private var configValidation = ConfigValidation()
-    private let userVisitManager: UserVisitManager
+    private let userVisitManager: UserVisitManagerProtocol
     private let sessionManager: SessionManager
     private let inAppMessagesManager: InAppCoreManagerProtocol
 
@@ -28,7 +28,7 @@ class CoreController {
     func initialization(configuration: MBConfiguration) {
         
         controllerQueue.async {
-            SessionTemporaryStorage.shared.isInitialiazionCalled = true
+            SessionTemporaryStorage.shared.isInitializationCalled = true
             self.configValidation.compare(configuration, self.persistenceStorage.configuration)
             self.persistenceStorage.configuration = configuration
             if !self.persistenceStorage.isInstalled {
@@ -258,7 +258,7 @@ class CoreController {
         inAppMessagesManager: InAppCoreManagerProtocol,
         uuidDebugService: UUIDDebugService,
         controllerQueue: DispatchQueue = DispatchQueue(label: "com.Mindbox.controllerQueue"),
-        userVisitManager: UserVisitManager
+        userVisitManager: UserVisitManagerProtocol
     ) {
         self.persistenceStorage = persistenceStorage
         self.utilitiesFetcher = utilitiesFetcher

--- a/Mindbox/CoreController/CoreController.swift
+++ b/Mindbox/CoreController/CoreController.swift
@@ -29,6 +29,7 @@ final class CoreController {
         
         controllerQueue.async {
             SessionTemporaryStorage.shared.isInitializationCalled = true
+            self.userVisitManager.saveUserVisit()
             self.configValidation.compare(configuration, self.persistenceStorage.configuration)
             self.persistenceStorage.configuration = configuration
             if !self.persistenceStorage.isInstalled {
@@ -37,8 +38,6 @@ final class CoreController {
                 self.repeatInitialization(with: configuration)
             }
             self.guaranteedDeliveryManager.canScheduleOperations = true
-            
-            self.userVisitManager.saveUserVisit()
             self.inAppMessagesManager.start()
         }
         

--- a/Mindbox/CoreController/CoreController.swift
+++ b/Mindbox/CoreController/CoreController.swift
@@ -29,7 +29,6 @@ final class CoreController {
         
         controllerQueue.async {
             SessionTemporaryStorage.shared.isInitializationCalled = true
-            self.userVisitManager.saveUserVisit()
             self.configValidation.compare(configuration, self.persistenceStorage.configuration)
             self.persistenceStorage.configuration = configuration
             if !self.persistenceStorage.isInstalled {
@@ -38,7 +37,6 @@ final class CoreController {
                 self.repeatInitialization(with: configuration)
             }
             self.guaranteedDeliveryManager.canScheduleOperations = true
-            self.inAppMessagesManager.start()
         }
         
         DispatchQueue.main.async {
@@ -275,7 +273,7 @@ final class CoreController {
         self.userVisitManager = userVisitManager
 
         sessionManager.sessionHandler = { [weak self] isActive in
-            if isActive {
+            if isActive && SessionTemporaryStorage.shared.isInitializationCalled {
                 self?.checkNotificationStatus()
                 self?.userVisitManager.saveUserVisit()
                 self?.inAppMessagesManager.start()

--- a/Mindbox/CoreController/CoreController.swift
+++ b/Mindbox/CoreController/CoreController.swift
@@ -37,6 +37,9 @@ final class CoreController {
                 self.repeatInitialization(with: configuration)
             }
             self.guaranteedDeliveryManager.canScheduleOperations = true
+            
+            self.userVisitManager.saveUserVisit()
+            self.inAppMessagesManager.start()
         }
         
         DispatchQueue.main.async {

--- a/Mindbox/CoreController/CoreController.swift
+++ b/Mindbox/CoreController/CoreController.swift
@@ -28,7 +28,9 @@ final class CoreController {
     func initialization(configuration: MBConfiguration) {
         
         controllerQueue.async {
+            SessionTemporaryStorage.shared.isInstalledFromPersistenceStorageBeforeInitSDK = self.persistenceStorage.isInstalled
             SessionTemporaryStorage.shared.isInitializationCalled = true
+            
             self.configValidation.compare(configuration, self.persistenceStorage.configuration)
             self.persistenceStorage.configuration = configuration
             if !self.persistenceStorage.isInstalled {
@@ -37,9 +39,11 @@ final class CoreController {
                 self.repeatInitialization(with: configuration)
             }
             self.guaranteedDeliveryManager.canScheduleOperations = true
+            
+            let appStateMessage = "[App State]: \(UIApplication.shared.appStateDescription)"
+            Logger.common(message: appStateMessage, level: .info, category: .general)
         }
         
-        Logger.common(message: "[App State]: \(UIApplication.shared.appStateDescription)", level: .info, category: .general)
         Logger.common(message: "[Configuration]: \(configuration)", level: .info, category: .general)
         Logger.common(message: "[SDK Version]: \(self.utilitiesFetcher.sdkVersion ?? "null")", level: .info, category: .general)
         Logger.common(message: "[APNS Token]: \(self.persistenceStorage.apnsToken ?? "null")", level: .info, category: .general)

--- a/Mindbox/CoreController/CoreController.swift
+++ b/Mindbox/CoreController/CoreController.swift
@@ -29,7 +29,6 @@ class CoreController {
         
         controllerQueue.async {
             SessionTemporaryStorage.shared.isInitialiazionCalled = true
-            self.userVisitManager.saveUserVisit()
             self.configValidation.compare(configuration, self.persistenceStorage.configuration)
             self.persistenceStorage.configuration = configuration
             if !self.persistenceStorage.isInstalled {
@@ -38,9 +37,22 @@ class CoreController {
                 self.repeatInitialization(with: configuration)
             }
             self.guaranteedDeliveryManager.canScheduleOperations = true
-            self.inAppMessagesManager.start()
         }
         
+        DispatchQueue.main.async {
+            let stateDescription: String
+            switch UIApplication.shared.applicationState {
+            case .active:
+                stateDescription = "active"
+            case .inactive:
+                stateDescription = "inactive"
+            case .background:
+                stateDescription = "background"
+            @unknown default:
+                stateDescription = "unknown"
+            }
+            Logger.common(message: "[App State]: \(stateDescription)", level: .info, category: .general)
+        }
         Logger.common(message: "[Configuration]: \(configuration)", level: .info, category: .general)
         Logger.common(message: "[SDK Version]: \(self.utilitiesFetcher.sdkVersion ?? "null")", level: .info, category: .general)
         Logger.common(message: "[APNS Token]: \(self.persistenceStorage.apnsToken ?? "null")", level: .info, category: .general)
@@ -264,6 +276,7 @@ class CoreController {
             if isActive {
                 self?.checkNotificationStatus()
                 self?.userVisitManager.saveUserVisit()
+                self?.inAppMessagesManager.start()
             }
         }
 

--- a/Mindbox/DI/DependencyContainer.swift
+++ b/Mindbox/DI/DependencyContainer.swift
@@ -30,7 +30,7 @@ protocol DependencyContainer {
     var inappFilterService: InappFilterProtocol { get }
     var pushValidator: MindboxPushValidator { get }
     var inAppConfigurationDataFacade: InAppConfigurationDataFacadeProtocol { get }
-    var userVisitManager: UserVisitManager { get }
+    var userVisitManager: UserVisitManagerProtocol { get }
     var ttlValidationService: TTLValidationProtocol { get }
     var frequencyValidator: InappFrequencyValidator { get }
 }

--- a/Mindbox/DI/DependencyProvider.swift
+++ b/Mindbox/DI/DependencyProvider.swift
@@ -112,8 +112,7 @@ final class DependencyProvider: DependencyContainer {
             persistenceStorage: persistenceStorage,
             ttlValidationService: ttlValidationService),
             presentationManager: presentationManager,
-            persistenceStorage: persistenceStorage, 
-            sessionManager: sessionManager
+            persistenceStorage: persistenceStorage
         )
         inappMessageEventSender = InappMessageEventSender(inAppMessagesManager: inAppMessagesManager)
 
@@ -124,7 +123,7 @@ final class DependencyProvider: DependencyContainer {
         )
         
         pushValidator = MindboxPushValidator()
-        userVisitManager = UserVisitManager(persistenceStorage: persistenceStorage, sessionManager: sessionManager)
+        userVisitManager = UserVisitManager(persistenceStorage: persistenceStorage)
     }
 }
 

--- a/Mindbox/DI/DependencyProvider.swift
+++ b/Mindbox/DI/DependencyProvider.swift
@@ -32,7 +32,7 @@ final class DependencyProvider: DependencyContainer {
     var inappFilterService: InappFilterProtocol
     var pushValidator: MindboxPushValidator
     var inAppConfigurationDataFacade: InAppConfigurationDataFacadeProtocol
-    var userVisitManager: UserVisitManager
+    var userVisitManager: UserVisitManagerProtocol
     var ttlValidationService: TTLValidationProtocol
     var frequencyValidator: InappFrequencyValidator
 

--- a/Mindbox/DI/DependencyProvider.swift
+++ b/Mindbox/DI/DependencyProvider.swift
@@ -112,7 +112,8 @@ final class DependencyProvider: DependencyContainer {
             persistenceStorage: persistenceStorage,
             ttlValidationService: ttlValidationService),
             presentationManager: presentationManager,
-            persistenceStorage: persistenceStorage
+            persistenceStorage: persistenceStorage, 
+            sessionManager: sessionManager
         )
         inappMessageEventSender = InappMessageEventSender(inAppMessagesManager: inAppMessagesManager)
 

--- a/Mindbox/Database/DatabaseLoader.swift
+++ b/Mindbox/Database/DatabaseLoader.swift
@@ -56,9 +56,9 @@ class DataBaseLoader {
         self.persistentStoreDescriptions = persistentStoreDescriptions
         if let persistentStoreDescriptions = persistentStoreDescriptions {
             persistentContainer.persistentStoreDescriptions = persistentStoreDescriptions
-            persistentContainer.persistentStoreDescriptions.forEach { $0.setOption(FileProtectionType.none as NSObject, forKey: NSPersistentStoreFileProtectionKey) }
         }
         persistentContainer.persistentStoreDescriptions.forEach {
+            $0.setOption(FileProtectionType.none as NSObject, forKey: NSPersistentStoreFileProtectionKey)
             $0.shouldMigrateStoreAutomatically = true
             $0.shouldInferMappingModelAutomatically = true
         }

--- a/Mindbox/Database/DatabaseLoader.swift
+++ b/Mindbox/Database/DatabaseLoader.swift
@@ -56,6 +56,7 @@ class DataBaseLoader {
         self.persistentStoreDescriptions = persistentStoreDescriptions
         if let persistentStoreDescriptions = persistentStoreDescriptions {
             persistentContainer.persistentStoreDescriptions = persistentStoreDescriptions
+            persistentContainer.persistentStoreDescriptions.forEach { $0.setOption(FileProtectionType.none as NSObject, forKey: NSPersistentStoreFileProtectionKey) }
         }
         persistentContainer.persistentStoreDescriptions.forEach {
             $0.shouldMigrateStoreAutomatically = true

--- a/Mindbox/Extensions/Notification+Extensions.swift
+++ b/Mindbox/Extensions/Notification+Extensions.swift
@@ -1,0 +1,13 @@
+//
+//  Notification+Extensions.swift
+//  Mindbox
+//
+//  Created by Sergei Semko on 4/28/24.
+//  Copyright © 2024 Mindbox. All rights reserved.
+//
+
+import Foundation
+
+extension Notification.Name {
+    static let initializationCompleted = Notification.Name("sdkCoreControllerInitializationCompleted")
+}

--- a/Mindbox/Extensions/Notification+Extensions.swift
+++ b/Mindbox/Extensions/Notification+Extensions.swift
@@ -9,5 +9,5 @@
 import Foundation
 
 extension Notification.Name {
-    static let initializationCompleted = Notification.Name("sdkCoreControllerInitializationCompleted")
+    static let initializationCompleted = Notification.Name("MBNotification-initializationCompleted")
 }

--- a/Mindbox/Extensions/UIApplication+Extensions.swift
+++ b/Mindbox/Extensions/UIApplication+Extensions.swift
@@ -1,0 +1,34 @@
+//
+//  UIApplication+Extensions.swift
+//  Mindbox
+//
+//  Created by Sergei Semko on 5/2/24.
+//  Copyright © 2024 Mindbox. All rights reserved.
+//
+
+import UIKit
+
+extension UIApplication {
+    var appStateDescription: String {
+        if Thread.isMainThread {
+            return describeApplicationState
+        } else {
+            return DispatchQueue.main.sync {
+                describeApplicationState
+            }
+        }
+    }
+    
+    private var describeApplicationState: String {
+        switch applicationState {
+        case .active:
+            return "active"
+        case .inactive:
+            return "inactive"
+        case .background:
+            return "background"
+        @unknown default:
+            return "unknown"
+        }
+    }
+}

--- a/Mindbox/InAppMessages/InAppCoreManager.swift
+++ b/Mindbox/InAppMessages/InAppCoreManager.swift
@@ -52,11 +52,13 @@ final class InAppCoreManager: InAppCoreManagerProtocol {
         configManager: InAppConfigurationManagerProtocol,
         presentationManager: InAppPresentationManagerProtocol,
         persistenceStorage: PersistenceStorage,
+        sessionManager: SessionManager,
         serialQueue: DispatchQueue = DispatchQueue(label: "com.Mindbox.InAppCoreManager.eventsQueue")
     ) {
         self.configManager = configManager
         self.presentationManager = presentationManager
         self.persistenceStorage = persistenceStorage
+        self.sessionManager = sessionManager
         self.serialQueue = serialQueue
     }
 
@@ -65,6 +67,7 @@ final class InAppCoreManager: InAppCoreManagerProtocol {
     private let configManager: InAppConfigurationManagerProtocol
     private let presentationManager: InAppPresentationManagerProtocol
     private let persistenceStorage: PersistenceStorage
+    private let sessionManager: SessionManager
     private var isConfigurationReady = false
     private var isInAppManagerLaunched: Bool = false
     private let serialQueue: DispatchQueue
@@ -77,6 +80,18 @@ final class InAppCoreManager: InAppCoreManagerProtocol {
             Logger.common(message: "Skip launching InAppManager because it is already launched", level: .info, category: .visit)
             return
         }
+        
+        let isActive = sessionManager.isActiveNow
+        let isInit = SessionTemporaryStorage.shared.isInitializationCalled
+        guard isActive && isInit else {
+            if (!isActive) {
+                Logger.common(message: "Skip launching InAppManager because it is initialized in an not active state.", level: .info, category: .visit)
+            } else {
+                Logger.common(message: "Skip launching InAppManager because it is not initialized.", level: .info, category: .visit)
+            }
+            return
+        }
+        
         isInAppManagerLaunched = true
         sendEvent(.start)
         configManager.delegate = self

--- a/Mindbox/InAppMessages/InAppCoreManager.swift
+++ b/Mindbox/InAppMessages/InAppCoreManager.swift
@@ -52,13 +52,11 @@ final class InAppCoreManager: InAppCoreManagerProtocol {
         configManager: InAppConfigurationManagerProtocol,
         presentationManager: InAppPresentationManagerProtocol,
         persistenceStorage: PersistenceStorage,
-        sessionManager: SessionManager,
         serialQueue: DispatchQueue = DispatchQueue(label: "com.Mindbox.InAppCoreManager.eventsQueue")
     ) {
         self.configManager = configManager
         self.presentationManager = presentationManager
         self.persistenceStorage = persistenceStorage
-        self.sessionManager = sessionManager
         self.serialQueue = serialQueue
     }
 
@@ -67,7 +65,6 @@ final class InAppCoreManager: InAppCoreManagerProtocol {
     private let configManager: InAppConfigurationManagerProtocol
     private let presentationManager: InAppPresentationManagerProtocol
     private let persistenceStorage: PersistenceStorage
-    private let sessionManager: SessionManager
     private var isConfigurationReady = false
     private var isInAppManagerLaunched: Bool = false
     private let serialQueue: DispatchQueue
@@ -76,19 +73,9 @@ final class InAppCoreManager: InAppCoreManagerProtocol {
     /// This method called on app start.
     /// The config file will be loaded here or fetched from the cache.
     func start() {
+        Logger.common(message: "InApp trying to start", level: .default, category: .notification, subsystem: "semkoTest")
         guard !isInAppManagerLaunched else {
             Logger.common(message: "Skip launching InAppManager because it is already launched", level: .info, category: .visit)
-            return
-        }
-        
-        let isActive = sessionManager.isActiveNow
-        let isInit = SessionTemporaryStorage.shared.isInitializationCalled
-        guard isActive && isInit else {
-            if (!isActive) {
-                Logger.common(message: "Skip launching InAppManager because it is initialized in an not active state.", level: .info, category: .visit)
-            } else {
-                Logger.common(message: "Skip launching InAppManager because it is not initialized.", level: .info, category: .visit)
-            }
             return
         }
         
@@ -96,6 +83,8 @@ final class InAppCoreManager: InAppCoreManagerProtocol {
         sendEvent(.start)
         configManager.delegate = self
         configManager.prepareConfiguration()
+        
+        Logger.common(message: "InApp started", level: .default, category: .notification, subsystem: "semkoTest")
     }
 
     /// This method handles events and decides if in-app message should be shown

--- a/Mindbox/InAppMessages/InAppCoreManager.swift
+++ b/Mindbox/InAppMessages/InAppCoreManager.swift
@@ -66,12 +66,18 @@ final class InAppCoreManager: InAppCoreManagerProtocol {
     private let presentationManager: InAppPresentationManagerProtocol
     private let persistenceStorage: PersistenceStorage
     private var isConfigurationReady = false
+    private var isInAppManagerLaunched: Bool = false
     private let serialQueue: DispatchQueue
     private var unhandledEvents: [InAppMessageTriggerEvent] = []
 
     /// This method called on app start.
     /// The config file will be loaded here or fetched from the cache.
     func start() {
+        guard !isInAppManagerLaunched else {
+            Logger.common(message: "Skip launching InAppManager because it is already launched", level: .info, category: .visit)
+            return
+        }
+        isInAppManagerLaunched = true
         sendEvent(.start)
         configManager.delegate = self
         configManager.prepareConfiguration()

--- a/Mindbox/InAppMessages/InAppCoreManager.swift
+++ b/Mindbox/InAppMessages/InAppCoreManager.swift
@@ -73,7 +73,6 @@ final class InAppCoreManager: InAppCoreManagerProtocol {
     /// This method called on app start.
     /// The config file will be loaded here or fetched from the cache.
     func start() {
-        Logger.common(message: "InApp trying to start", level: .default, category: .notification, subsystem: "semkoTest")
         guard !isInAppManagerLaunched else {
             Logger.common(message: "Skip launching InAppManager because it is already launched", level: .info, category: .visit)
             return
@@ -83,8 +82,6 @@ final class InAppCoreManager: InAppCoreManagerProtocol {
         sendEvent(.start)
         configManager.delegate = self
         configManager.prepareConfiguration()
-        
-        Logger.common(message: "InApp started", level: .default, category: .notification, subsystem: "semkoTest")
     }
 
     /// This method handles events and decides if in-app message should be shown

--- a/Mindbox/Info.plist
+++ b/Mindbox/Info.plist
@@ -17,6 +17,6 @@
 	<key>CFBundleShortVersionString</key>
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
-	<string>5422</string>
+	<string>5425</string>
 </dict>
 </plist>

--- a/Mindbox/Info.plist
+++ b/Mindbox/Info.plist
@@ -17,6 +17,6 @@
 	<key>CFBundleShortVersionString</key>
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
-	<string>5395</string>
+	<string>5399</string>
 </dict>
 </plist>

--- a/Mindbox/Info.plist
+++ b/Mindbox/Info.plist
@@ -17,6 +17,6 @@
 	<key>CFBundleShortVersionString</key>
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
-	<string>5403</string>
+	<string>5411</string>
 </dict>
 </plist>

--- a/Mindbox/Info.plist
+++ b/Mindbox/Info.plist
@@ -17,6 +17,6 @@
 	<key>CFBundleShortVersionString</key>
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
-	<string>5411</string>
+	<string>5415</string>
 </dict>
 </plist>

--- a/Mindbox/Info.plist
+++ b/Mindbox/Info.plist
@@ -17,6 +17,6 @@
 	<key>CFBundleShortVersionString</key>
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
-	<string>5452</string>
+	<string>5498</string>
 </dict>
 </plist>

--- a/Mindbox/Info.plist
+++ b/Mindbox/Info.plist
@@ -17,6 +17,6 @@
 	<key>CFBundleShortVersionString</key>
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
-	<string>5399</string>
+	<string>5403</string>
 </dict>
 </plist>

--- a/Mindbox/Info.plist
+++ b/Mindbox/Info.plist
@@ -17,6 +17,6 @@
 	<key>CFBundleShortVersionString</key>
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
-	<string>5415</string>
+	<string>5422</string>
 </dict>
 </plist>

--- a/Mindbox/Info.plist
+++ b/Mindbox/Info.plist
@@ -17,6 +17,6 @@
 	<key>CFBundleShortVersionString</key>
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
-	<string>5425</string>
+	<string>5452</string>
 </dict>
 </plist>

--- a/Mindbox/SessionManager/MBSessionManager.swift
+++ b/Mindbox/SessionManager/MBSessionManager.swift
@@ -49,15 +49,18 @@ final class MBSessionManager: SessionManager {
         NotificationCenter.default.addObserver(
             forName: UIApplication.didBecomeActiveNotification,
             object: nil,
-            queue: nil) { [weak self] _ in
+            queue: OperationQueue.main
+        ) { [weak self] _ in
             if UIApplication.shared.applicationState == .active {
                 self?.isActive = true
             }
         }
+        
         NotificationCenter.default.addObserver(
             forName: UIApplication.didEnterBackgroundNotification,
             object: nil,
-            queue: nil) { [weak self] _ in
+            queue: nil
+        ) { [weak self] _ in
             self?.isActive = false
         }
     }

--- a/Mindbox/SessionManager/MBSessionManager.swift
+++ b/Mindbox/SessionManager/MBSessionManager.swift
@@ -9,33 +9,17 @@
 import UIKit
 import MindboxLogger
 
-final class MBSessionManager: SessionManager {
-    init(trackVisitManager: TrackVisitManager) {
-        self.trackVisitManager = trackVisitManager
-
-        subscribe()
-    }
-
+final class MBSessionManager {
+    
     var sessionHandler: ((Bool) -> Void)?
     var isActiveNow: Bool { return isActive }
     
-    func trackDirect() {
-        do {
-            try trackVisitManager.trackDirect()
-        } catch {
-            Logger.common(message: "Track Visit failed with error: \(error)", level: .info, category: .visit)
-        }
-    }
-
-    func trackForeground() {
-        do {
-            try trackVisitManager.trackForeground()
-        } catch {
-            Logger.common(message: "Track Visit failed with error: \(error)", level: .info, category: .visit)
-        }
-    }
-
     private let trackVisitManager: TrackVisitManager
+    
+    init(trackVisitManager: TrackVisitManager) {
+        self.trackVisitManager = trackVisitManager
+        subscribe()
+    }
 
     private var isActive: Bool = false {
         didSet {
@@ -49,11 +33,9 @@ final class MBSessionManager: SessionManager {
         NotificationCenter.default.addObserver(
             forName: UIApplication.didBecomeActiveNotification,
             object: nil,
-            queue: OperationQueue.main
+            queue: nil
         ) { [weak self] _ in
-            if UIApplication.shared.applicationState == .active {
-                self?.isActive = true
-            }
+            self?.isActive = true
         }
         
         NotificationCenter.default.addObserver(
@@ -62,6 +44,37 @@ final class MBSessionManager: SessionManager {
             queue: nil
         ) { [weak self] _ in
             self?.isActive = false
+        }
+        
+        NotificationCenter.default.addObserver(
+            forName: .initializationCompleted,
+            object: nil,
+            queue: nil
+        ) { [weak self] _ in
+            guard let self else { return }
+            if self.isActive {
+                self.sessionHandler?(isActive)
+            }
+        }
+    }
+}
+
+// MARK: - SessionManager
+
+extension MBSessionManager: SessionManager {
+    func trackDirect() {
+        do {
+            try trackVisitManager.trackDirect()
+        } catch {
+            Logger.common(message: "Track Visit failed with error: \(error)", level: .info, category: .visit)
+        }
+    }
+
+    func trackForeground() {
+        do {
+            try trackVisitManager.trackForeground()
+        } catch {
+            Logger.common(message: "Track Visit failed with error: \(error)", level: .info, category: .visit)
         }
     }
 }

--- a/Mindbox/UserVisitManager/UserVisitManager.swift
+++ b/Mindbox/UserVisitManager/UserVisitManager.swift
@@ -32,15 +32,25 @@ extension UserVisitManager: UserVisitManagerProtocol {
         }
         
         isVisitSaved = true
-        let deviceUUID = persistenceStorage.deviceUUID
-        var previosUserVisitCount = persistenceStorage.userVisitCount ?? 0
-        if (deviceUUID != nil && previosUserVisitCount == 0) {
-            previosUserVisitCount = 1
+        
+        var previousUserVisitCount = persistenceStorage.userVisitCount ?? UVMConstants.noAppVisits
+        
+        // Handling the first launch when SDK version has been updated to 2.9.0 or higher from versions below 2.9.0
+        let isInstalled = SessionTemporaryStorage.shared.isInstalledFromPersistenceStorageBeforeInitSDK
+        if (isInstalled && previousUserVisitCount == UVMConstants.noAppVisits) {
+            previousUserVisitCount = UVMConstants.appVisitsWhenSDKHasBeenUpdated
         }
         
-        let userVisitCount = previosUserVisitCount + 1
+        let userVisitCount = previousUserVisitCount + 1
       
         persistenceStorage.userVisitCount = userVisitCount
-        Logger.common(message: "UserVisit has been changed from \(previosUserVisitCount) to \(userVisitCount)", level: .info, category: .visit)
+        
+        let message = "UserVisit has been changed from \(previousUserVisitCount) to \(userVisitCount)"
+        Logger.common(message: message, level: .info, category: .visit)
     }
+}
+
+fileprivate enum UVMConstants {
+    static let noAppVisits = 0
+    static let appVisitsWhenSDKHasBeenUpdated = 1
 }

--- a/Mindbox/UserVisitManager/UserVisitManager.swift
+++ b/Mindbox/UserVisitManager/UserVisitManager.swift
@@ -9,7 +9,11 @@
 import Foundation
 import MindboxLogger
 
-class UserVisitManager {
+protocol UserVisitManagerProtocol {
+    func saveUserVisit()
+}
+
+final class UserVisitManager {
     private let persistenceStorage: PersistenceStorage
     private let sessionManager: SessionManager
     private var isVisitSaved: Bool = false
@@ -18,25 +22,15 @@ class UserVisitManager {
         self.persistenceStorage = persistenceStorage
         self.sessionManager = sessionManager
     }
-    
+}
+
+extension UserVisitManager: UserVisitManagerProtocol {
     func saveUserVisit() {
         guard !isVisitSaved else {
             Logger.common(message: "Skip changing userVisit because it is already saved", level: .info, category: .visit)
             return
         }
-        
-        let isActive = sessionManager.isActiveNow
-        let isInit = SessionTemporaryStorage.shared.isInitialiazionCalled
-        guard isActive && isInit else {
-            if (!isActive) {
-                Logger.common(message: "Skip changing userVisit because it is initialized in an not active state.", level: .info, category: .visit)
-            } else {
-                Logger.common(message: "Skip changing userVisit it is not initialized.", level: .info, category: .visit)
-            }
-            return
-        }
-        
-        self.isVisitSaved = true
+        isVisitSaved = true
         let deviceUUID = persistenceStorage.deviceUUID
         var previosUserVisitCount = persistenceStorage.userVisitCount ?? 0
         if (deviceUUID != nil && previosUserVisitCount == 0) {
@@ -48,5 +42,4 @@ class UserVisitManager {
         persistenceStorage.userVisitCount = userVisitCount
         Logger.common(message: "UserVisit has been changed from \(previosUserVisitCount) to \(userVisitCount)", level: .info, category: .visit)
     }
-
 }

--- a/Mindbox/UserVisitManager/UserVisitManager.swift
+++ b/Mindbox/UserVisitManager/UserVisitManager.swift
@@ -30,6 +30,18 @@ extension UserVisitManager: UserVisitManagerProtocol {
             Logger.common(message: "Skip changing userVisit because it is already saved", level: .info, category: .visit)
             return
         }
+        
+        let isActive = sessionManager.isActiveNow
+        let isInit = SessionTemporaryStorage.shared.isInitializationCalled
+        guard isActive && isInit else {
+            if (!isActive) {
+                Logger.common(message: "Skip changing userVisit because it is initialized in an not active state.", level: .info, category: .visit)
+            } else {
+                Logger.common(message: "Skip changing userVisit it is not initialized.", level: .info, category: .visit)
+            }
+            return
+        }
+        
         isVisitSaved = true
         let deviceUUID = persistenceStorage.deviceUUID
         var previosUserVisitCount = persistenceStorage.userVisitCount ?? 0

--- a/Mindbox/UserVisitManager/UserVisitManager.swift
+++ b/Mindbox/UserVisitManager/UserVisitManager.swift
@@ -32,18 +32,6 @@ extension UserVisitManager: UserVisitManagerProtocol {
             Logger.common(message: "Skip changing userVisit because it is already saved", level: .info, category: .visit)
             return
         }
-        
-        let isActive = sessionManager.isActiveNow
-        let isInit = SessionTemporaryStorage.shared.isInitializationCalled
-        guard isActive && isInit else {
-            if (!isActive) {
-                Logger.common(message: "Skip changing userVisit because it is initialized in an not active state.", level: .info, category: .visit)
-            } else {
-                Logger.common(message: "Skip changing userVisit it is not initialized.", level: .info, category: .visit)
-            }
-            return
-        }
-        
         isVisitSaved = true
         let deviceUUID = persistenceStorage.deviceUUID
         var previosUserVisitCount = persistenceStorage.userVisitCount ?? 0

--- a/Mindbox/UserVisitManager/UserVisitManager.swift
+++ b/Mindbox/UserVisitManager/UserVisitManager.swift
@@ -24,6 +24,8 @@ final class UserVisitManager {
     }
 }
 
+// MARK: - UserVisitManagerProtocol
+
 extension UserVisitManager: UserVisitManagerProtocol {
     func saveUserVisit() {
         guard !isVisitSaved else {

--- a/Mindbox/UserVisitManager/UserVisitManager.swift
+++ b/Mindbox/UserVisitManager/UserVisitManager.swift
@@ -32,6 +32,18 @@ extension UserVisitManager: UserVisitManagerProtocol {
             Logger.common(message: "Skip changing userVisit because it is already saved", level: .info, category: .visit)
             return
         }
+        
+        let isActive = sessionManager.isActiveNow
+        let isInit = SessionTemporaryStorage.shared.isInitializationCalled
+        guard isActive && isInit else {
+            if (!isActive) {
+                Logger.common(message: "Skip changing userVisit because it is initialized in an not active state.", level: .info, category: .visit)
+            } else {
+                Logger.common(message: "Skip changing userVisit because it is not initialized.", level: .info, category: .visit)
+            }
+            return
+        }
+        
         isVisitSaved = true
         let deviceUUID = persistenceStorage.deviceUUID
         var previosUserVisitCount = persistenceStorage.userVisitCount ?? 0

--- a/Mindbox/UserVisitManager/UserVisitManager.swift
+++ b/Mindbox/UserVisitManager/UserVisitManager.swift
@@ -15,12 +15,10 @@ protocol UserVisitManagerProtocol {
 
 final class UserVisitManager {
     private let persistenceStorage: PersistenceStorage
-    private let sessionManager: SessionManager
     private var isVisitSaved: Bool = false
     
-    init(persistenceStorage: PersistenceStorage, sessionManager: SessionManager) {
+    init(persistenceStorage: PersistenceStorage) {
         self.persistenceStorage = persistenceStorage
-        self.sessionManager = sessionManager
     }
 }
 
@@ -30,17 +28,6 @@ extension UserVisitManager: UserVisitManagerProtocol {
     func saveUserVisit() {
         guard !isVisitSaved else {
             Logger.common(message: "Skip changing userVisit because it is already saved", level: .info, category: .visit)
-            return
-        }
-        
-        let isActive = sessionManager.isActiveNow
-        let isInit = SessionTemporaryStorage.shared.isInitializationCalled
-        guard isActive && isInit else {
-            if (!isActive) {
-                Logger.common(message: "Skip changing userVisit because it is initialized in an not active state.", level: .info, category: .visit)
-            } else {
-                Logger.common(message: "Skip changing userVisit because it is not initialized.", level: .info, category: .visit)
-            }
             return
         }
         

--- a/Mindbox/Utilities/SessionTemporaryStorage.swift
+++ b/Mindbox/Utilities/SessionTemporaryStorage.swift
@@ -21,6 +21,7 @@ final class SessionTemporaryStorage {
     var isPresentingInAppMessage = false
     var pushPermissionStatus: UNAuthorizationStatus = .denied
     var sessionShownInApps: Set<String> = []
+    var isInstalledFromPersistenceStorageBeforeInitSDK: Bool = false
     var isInitializationCalled = false {
         didSet {
             if isInitializationCalled, isInitializationCalled != oldValue {

--- a/Mindbox/Utilities/SessionTemporaryStorage.swift
+++ b/Mindbox/Utilities/SessionTemporaryStorage.swift
@@ -20,7 +20,7 @@ final class SessionTemporaryStorage {
     var checkProductSegmentsRequestCompleted = false
     var isPresentingInAppMessage = false
     var pushPermissionStatus: UNAuthorizationStatus = .denied
-    var isInitialiazionCalled = false
+    var isInitializationCalled = false
     var sessionShownInApps: Set<String> = []
     
     private init() {

--- a/Mindbox/Utilities/SessionTemporaryStorage.swift
+++ b/Mindbox/Utilities/SessionTemporaryStorage.swift
@@ -20,8 +20,14 @@ final class SessionTemporaryStorage {
     var checkProductSegmentsRequestCompleted = false
     var isPresentingInAppMessage = false
     var pushPermissionStatus: UNAuthorizationStatus = .denied
-    var isInitializationCalled = false
     var sessionShownInApps: Set<String> = []
+    var isInitializationCalled = false {
+        didSet {
+            if isInitializationCalled, isInitializationCalled != oldValue {
+                NotificationCenter.default.post(name: .initializationCompleted, object: nil)
+            }
+        }
+    }
     
     private init() {
         

--- a/MindboxTests/DI/TestDependencyProvider.swift
+++ b/MindboxTests/DI/TestDependencyProvider.swift
@@ -32,7 +32,7 @@ final class TestDependencyProvider: DependencyContainer {
     var inappFilterService: InappFilterProtocol
     var pushValidator: MindboxPushValidator
     var inAppConfigurationDataFacade: InAppConfigurationDataFacadeProtocol
-    var userVisitManager: UserVisitManager
+    var userVisitManager: UserVisitManagerProtocol
     var ttlValidationService: TTLValidationProtocol
     var frequencyValidator: InappFrequencyValidator
     

--- a/MindboxTests/DI/TestDependencyProvider.swift
+++ b/MindboxTests/DI/TestDependencyProvider.swift
@@ -92,7 +92,7 @@ final class TestDependencyProvider: DependencyContainer {
                                                  sdkVersionValidator: sdkVersionValidator, 
                                                  frequencyValidator: frequencyValidator)
         pushValidator = MindboxPushValidator()
-        userVisitManager = UserVisitManager(persistenceStorage: persistenceStorage, sessionManager: sessionManager)
+        userVisitManager = UserVisitManager(persistenceStorage: persistenceStorage)
     }
 }
 

--- a/MindboxTests/EventRepository/EventRepositoryTestCase.swift
+++ b/MindboxTests/EventRepository/EventRepositoryTestCase.swift
@@ -92,7 +92,7 @@ class EventRepositoryTestCase: XCTestCase {
     
     private func waitForInitializationFinished() {
         let expectation = self.expectation(description: "controller initialization")
-        controllerQueue.sync { expectation.fulfill() }
+        controllerQueue.async { expectation.fulfill() }
         self.wait(for: [expectation], timeout: 2)
     }
 }

--- a/MindboxTests/UserVisitManagerTests/UserVisitManagerTests.swift
+++ b/MindboxTests/UserVisitManagerTests/UserVisitManagerTests.swift
@@ -12,7 +12,7 @@ import XCTest
 final class UserVisitManagerTests: XCTestCase {
     
     private var persistenceStorageMock: PersistenceStorage!
-    private var userVisitManager: UserVisitManager!
+    private var userVisitManager: UserVisitManagerProtocol!
     private var sessionManagerMock: MockSessionManager!
     private var container: TestDependencyProvider!
     
@@ -22,7 +22,7 @@ final class UserVisitManagerTests: XCTestCase {
         persistenceStorageMock = MockPersistenceStorage()
         sessionManagerMock = MockSessionManager()
         userVisitManager = UserVisitManager(persistenceStorage: persistenceStorageMock, sessionManager: sessionManagerMock)
-        SessionTemporaryStorage.shared.isInitialiazionCalled = true
+        SessionTemporaryStorage.shared.isInitializationCalled = true
         persistenceStorageMock.deviceUUID = "00000000-0000-0000-0000-000000000000"
         sessionManagerMock._isActiveNow = true
     }
@@ -53,7 +53,7 @@ final class UserVisitManagerTests: XCTestCase {
     }
     
     func test_save_first_user_visit_no_init() throws {
-        SessionTemporaryStorage.shared.isInitialiazionCalled = false
+        SessionTemporaryStorage.shared.isInitializationCalled = false
         
         userVisitManager.saveUserVisit()
         
@@ -62,7 +62,7 @@ final class UserVisitManagerTests: XCTestCase {
     
     func test_save_not_first_user_visit_no_init() throws {
         persistenceStorageMock.userVisitCount = 42
-        SessionTemporaryStorage.shared.isInitialiazionCalled = false
+        SessionTemporaryStorage.shared.isInitializationCalled = false
         
         userVisitManager.saveUserVisit()
         

--- a/MindboxTests/UserVisitManagerTests/UserVisitManagerTests.swift
+++ b/MindboxTests/UserVisitManagerTests/UserVisitManagerTests.swift
@@ -23,10 +23,8 @@ final class UserVisitManagerTests: XCTestCase {
         userVisitManager = UserVisitManager(persistenceStorage: persistenceStorageMock)
         persistenceStorageMock.deviceUUID = "00000000-0000-0000-0000-000000000000"
     }
-
+    
     func test_save_first_user_visit_for_first_initialization() throws {
-        persistenceStorageMock.deviceUUID = nil
-        
         userVisitManager.saveUserVisit()
         
         XCTAssertEqual(persistenceStorageMock.userVisitCount, 1)
@@ -46,7 +44,8 @@ final class UserVisitManagerTests: XCTestCase {
 
     func test_save_not_first_user_visit_for_first_initialization() throws {
         persistenceStorageMock.userVisitCount = 10
-        persistenceStorageMock.deviceUUID = nil
+        persistenceStorageMock.installationDate = Date()
+        SessionTemporaryStorage.shared.isInstalledFromPersistenceStorageBeforeInitSDK = persistenceStorageMock.isInstalled
         
         userVisitManager.saveUserVisit()
         
@@ -54,6 +53,9 @@ final class UserVisitManagerTests: XCTestCase {
     }
     
     func test_save_first_user_visit_for_not_first_initialization() throws {
+        persistenceStorageMock.installationDate = Date()
+        SessionTemporaryStorage.shared.isInstalledFromPersistenceStorageBeforeInitSDK = persistenceStorageMock.isInstalled
+        
         userVisitManager.saveUserVisit()
         
         XCTAssertEqual(persistenceStorageMock.userVisitCount, 2)

--- a/MindboxTests/UserVisitManagerTests/UserVisitManagerTests.swift
+++ b/MindboxTests/UserVisitManagerTests/UserVisitManagerTests.swift
@@ -22,7 +22,51 @@ final class UserVisitManagerTests: XCTestCase {
         persistenceStorageMock = MockPersistenceStorage()
         sessionManagerMock = MockSessionManager()
         userVisitManager = UserVisitManager(persistenceStorage: persistenceStorageMock, sessionManager: sessionManagerMock)
+        SessionTemporaryStorage.shared.isInitializationCalled = true
         persistenceStorageMock.deviceUUID = "00000000-0000-0000-0000-000000000000"
+        sessionManagerMock._isActiveNow = true
+    }
+    
+    func test_save_first_user_visit_no_active() throws {
+        sessionManagerMock._isActiveNow = false
+        
+        userVisitManager.saveUserVisit()
+        
+        XCTAssertEqual(persistenceStorageMock.userVisitCount, 0)
+    }
+    
+    func test_save_not_first_user_visit_no_active() throws {
+        persistenceStorageMock.userVisitCount = 42
+        sessionManagerMock._isActiveNow = false
+        
+        userVisitManager.saveUserVisit()
+        
+        XCTAssertEqual(persistenceStorageMock.userVisitCount, 42)
+    }
+    
+    func test_save_first_user_visit_no_init_and_no_active() throws {
+        sessionManagerMock._isActiveNow = false
+        
+        userVisitManager.saveUserVisit()
+        
+        XCTAssertEqual(persistenceStorageMock.userVisitCount, 0)
+    }
+    
+    func test_save_first_user_visit_no_init() throws {
+        SessionTemporaryStorage.shared.isInitializationCalled = false
+        
+        userVisitManager.saveUserVisit()
+        
+        XCTAssertEqual(persistenceStorageMock.userVisitCount, 0)
+    }
+    
+    func test_save_not_first_user_visit_no_init() throws {
+        persistenceStorageMock.userVisitCount = 42
+        SessionTemporaryStorage.shared.isInitializationCalled = false
+        
+        userVisitManager.saveUserVisit()
+        
+        XCTAssertEqual(persistenceStorageMock.userVisitCount, 42)
     }
 
     func test_save_first_user_visit_for_first_initialization() throws {

--- a/MindboxTests/UserVisitManagerTests/UserVisitManagerTests.swift
+++ b/MindboxTests/UserVisitManagerTests/UserVisitManagerTests.swift
@@ -20,53 +20,8 @@ final class UserVisitManagerTests: XCTestCase {
         super.setUp()
         container = try! TestDependencyProvider()
         persistenceStorageMock = MockPersistenceStorage()
-        sessionManagerMock = MockSessionManager()
-        userVisitManager = UserVisitManager(persistenceStorage: persistenceStorageMock, sessionManager: sessionManagerMock)
-        SessionTemporaryStorage.shared.isInitializationCalled = true
+        userVisitManager = UserVisitManager(persistenceStorage: persistenceStorageMock)
         persistenceStorageMock.deviceUUID = "00000000-0000-0000-0000-000000000000"
-        sessionManagerMock._isActiveNow = true
-    }
-    
-    func test_save_first_user_visit_no_active() throws {
-        sessionManagerMock._isActiveNow = false
-        
-        userVisitManager.saveUserVisit()
-        
-        XCTAssertEqual(persistenceStorageMock.userVisitCount, 0)
-    }
-    
-    func test_save_not_first_user_visit_no_active() throws {
-        persistenceStorageMock.userVisitCount = 42
-        sessionManagerMock._isActiveNow = false
-        
-        userVisitManager.saveUserVisit()
-        
-        XCTAssertEqual(persistenceStorageMock.userVisitCount, 42)
-    }
-    
-    func test_save_first_user_visit_no_init_and_no_active() throws {
-        sessionManagerMock._isActiveNow = false
-        
-        userVisitManager.saveUserVisit()
-        
-        XCTAssertEqual(persistenceStorageMock.userVisitCount, 0)
-    }
-    
-    func test_save_first_user_visit_no_init() throws {
-        SessionTemporaryStorage.shared.isInitializationCalled = false
-        
-        userVisitManager.saveUserVisit()
-        
-        XCTAssertEqual(persistenceStorageMock.userVisitCount, 0)
-    }
-    
-    func test_save_not_first_user_visit_no_init() throws {
-        persistenceStorageMock.userVisitCount = 42
-        SessionTemporaryStorage.shared.isInitializationCalled = false
-        
-        userVisitManager.saveUserVisit()
-        
-        XCTAssertEqual(persistenceStorageMock.userVisitCount, 42)
     }
 
     func test_save_first_user_visit_for_first_initialization() throws {
@@ -83,7 +38,7 @@ final class UserVisitManagerTests: XCTestCase {
         userVisitManager.saveUserVisit()
         XCTAssertEqual(persistenceStorageMock.userVisitCount, 2)
         
-        userVisitManager = UserVisitManager(persistenceStorage: persistenceStorageMock, sessionManager: sessionManagerMock)
+        userVisitManager = UserVisitManager(persistenceStorage: persistenceStorageMock)
         userVisitManager.saveUserVisit()
         
         XCTAssertEqual(persistenceStorageMock.userVisitCount, 3)

--- a/MindboxTests/UserVisitManagerTests/UserVisitManagerTests.swift
+++ b/MindboxTests/UserVisitManagerTests/UserVisitManagerTests.swift
@@ -22,51 +22,7 @@ final class UserVisitManagerTests: XCTestCase {
         persistenceStorageMock = MockPersistenceStorage()
         sessionManagerMock = MockSessionManager()
         userVisitManager = UserVisitManager(persistenceStorage: persistenceStorageMock, sessionManager: sessionManagerMock)
-        SessionTemporaryStorage.shared.isInitializationCalled = true
         persistenceStorageMock.deviceUUID = "00000000-0000-0000-0000-000000000000"
-        sessionManagerMock._isActiveNow = true
-    }
-
-    func test_save_first_user_visit_no_active() throws {
-        sessionManagerMock._isActiveNow = false
-        
-        userVisitManager.saveUserVisit()
-        
-        XCTAssertEqual(persistenceStorageMock.userVisitCount, 0)
-    }
-    
-    func test_save_not_first_user_visit_no_active() throws {
-        persistenceStorageMock.userVisitCount = 42
-        sessionManagerMock._isActiveNow = false
-        
-        userVisitManager.saveUserVisit()
-        
-        XCTAssertEqual(persistenceStorageMock.userVisitCount, 42)
-    }
-    
-    func test_save_first_user_visit_no_init_and_no_active() throws {
-        sessionManagerMock._isActiveNow = false
-        
-        userVisitManager.saveUserVisit()
-        
-        XCTAssertEqual(persistenceStorageMock.userVisitCount, 0)
-    }
-    
-    func test_save_first_user_visit_no_init() throws {
-        SessionTemporaryStorage.shared.isInitializationCalled = false
-        
-        userVisitManager.saveUserVisit()
-        
-        XCTAssertEqual(persistenceStorageMock.userVisitCount, 0)
-    }
-    
-    func test_save_not_first_user_visit_no_init() throws {
-        persistenceStorageMock.userVisitCount = 42
-        SessionTemporaryStorage.shared.isInitializationCalled = false
-        
-        userVisitManager.saveUserVisit()
-        
-        XCTAssertEqual(persistenceStorageMock.userVisitCount, 42)
     }
 
     func test_save_first_user_visit_for_first_initialization() throws {

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Mindbox SDK aids in handling push notifications. Configuration and usage instruc
 
 ## Troubleshooting
 
-An [Example of integration](https://github.com/mindbox-cloud/ios-sdk/tree/example) is provided in case of any issues.
+An [Example of integration](https://github.com/mindbox-cloud/ios-sdk/tree/develop/Example) is provided in case of any issues.
 
 ## Further Help
 


### PR DESCRIPTION
[iOS] Запуск модуля InApp'ов в активном состоянии приложения[#3315](https://github.com/mindbox-cloud/issues-web-mobile/issues/3315)

Не стал логирование состояния выносить даже в отдельную функцию, не то что в MindboxLogger отдельно. Вроде вполне органично смотрится и свою функцию выполняет. 