### PR TITLE
Add lockFileMaintenance for Gemfile.lock

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -13,6 +13,12 @@
       "enabled": false
     }
   ],
+  "lockFileMaintenance": {
+    "enabled": true,
+    "extends": [
+      "schedule:monthly"
+    ]
+  },
   "timezone": "Europe/Moscow",
   "schedule": ["* * 11 * * 3L"]
 }


### PR DESCRIPTION
Не работает renovate для lock файла по дефолту. Внес правки.  
https://docs.renovatebot.com/presets-default/#maintainlockfilesmonthly

[Протестил на форке](https://github.com/justSmK/mindbox-test-ios-sdk/blob/develop/.github/renovate.json)

Получаем такой результат в [Dashboard](https://developer.mend.io/github/mindbox-cloud/ios-sdk)
<details>
<img width="1185" alt="image" src="https://github.com/mindbox-cloud/ios-sdk/assets/28645140/9aadf0db-7c51-4b58-8eb8-1fd68452490e">
</details>
