### PR TITLE
MBX-3483: Draft solution for only one implementation with raw json

### DIFF
--- a/Mindbox.xcodeproj/project.pbxproj
+++ b/Mindbox.xcodeproj/project.pbxproj
@@ -115,6 +115,7 @@
 		33C81EA4264145CD00863380 /* TimerManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33C81EA3264145CD00863380 /* TimerManager.swift */; };
 		33E42E5C268323E60046CBCB /* CashdeskRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33E42E5B268323E60046CBCB /* CashdeskRequest.swift */; };
 		33EBF0B0264E6283002A35D5 /* MBSessionManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33EBF0AF264E6283002A35D5 /* MBSessionManager.swift */; };
+		47AAFA092C32E15100BC7460 /* Cancelable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47AAFA082C32E15100BC7460 /* Cancelable.swift */; };
 		47D63E2B2C2EABDF0055E7D8 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = F3EC93BA2AF105DA0030D107 /* PrivacyInfo.xcprivacy */; };
 		6F1EAA16266A670E007A335B /* ProductListItemsResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F1EAA15266A670E007A335B /* ProductListItemsResponse.swift */; };
 		6FDD143B266F7BD900A50C35 /* ProcessingStatusResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FDD143A266F7BD900A50C35 /* ProcessingStatusResponse.swift */; };
@@ -643,6 +644,7 @@
 		33C81EA3264145CD00863380 /* TimerManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TimerManager.swift; sourceTree = "<group>"; };
 		33E42E5B268323E60046CBCB /* CashdeskRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CashdeskRequest.swift; sourceTree = "<group>"; };
 		33EBF0AF264E6283002A35D5 /* MBSessionManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MBSessionManager.swift; sourceTree = "<group>"; };
+		47AAFA082C32E15100BC7460 /* Cancelable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Cancelable.swift; sourceTree = "<group>"; };
 		6F1EAA15266A670E007A335B /* ProductListItemsResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductListItemsResponse.swift; sourceTree = "<group>"; };
 		6FDD143A266F7BD900A50C35 /* ProcessingStatusResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProcessingStatusResponse.swift; sourceTree = "<group>"; };
 		6FDD143C266F7BEB00A50C35 /* ItemResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ItemResponse.swift; sourceTree = "<group>"; };
@@ -1485,6 +1487,7 @@
 			children = (
 				847F581E25C8A3F500147A9A /* HTTPTypealiases.swift */,
 				847F57FD25C88BB700147A9A /* HTTPMethod.swift */,
+				47AAFA082C32E15100BC7460 /* Cancelable.swift */,
 			);
 			path = Types;
 			sourceTree = "<group>";
@@ -3375,6 +3378,7 @@
 				330D8CCB26579521005106D5 /* DiscountTypeRequest.swift in Sources */,
 				F382F2112BAC6AD100BC97FF /* UNAuthorizationStatus+Extensions.swift in Sources */,
 				A184654729C32FEF00E64780 /* CategoryIDChecker.swift in Sources */,
+				47AAFA092C32E15100BC7460 /* Cancelable.swift in Sources */,
 				A192786729D389EE00CDB53D /* ProductIDTargeting.swift in Sources */,
 				6FDD1445266F7C2200A50C35 /* CouponResponse.swift in Sources */,
 				F78E92EF282E63320003B4A3 /* DispatchSemaphore.swift in Sources */,

--- a/Mindbox/Info.plist
+++ b/Mindbox/Info.plist
@@ -17,6 +17,6 @@
 	<key>CFBundleShortVersionString</key>
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
-	<string>5614</string>
+	<string>5615</string>
 </dict>
 </plist>

--- a/Mindbox/Mindbox.swift
+++ b/Mindbox/Mindbox.swift
@@ -353,6 +353,28 @@ public class Mindbox: NSObject {
         sendEventToInAppMessagesIfNeeded(operationSystemName, jsonString: json)
         Logger.common(message: "Track executeSyncOperation", level: .info, category: .notification)
     }
+    
+    public func executeSyncOperationTest(
+        operationSystemName: String,
+        json: String,
+        completion: @escaping (Result<OperationResponse, MindboxError>) -> Void
+    ) -> Cancelable? {
+        guard operationSystemName.operationNameIsValid else {
+            Logger.common(message: "Invalid operation name: \(operationSystemName)", level: .error, category: .notification)
+            return nil
+        }
+        guard let jsonData = json.data(using: .utf8),
+              let _ = try? JSONSerialization.jsonObject(with: jsonData) else {
+            Logger.common(message: "Operation body is not valid JSON", level: .error, category: .notification)
+            return nil
+        }
+        let customEvent = CustomEvent(name: operationSystemName, payload: json)
+        let event = Event(type: .syncEvent, body: BodyEncoder(encodable: customEvent).body)
+        let cancelable = container?.instanceFactory.makeEventRepository().sendTest(type: OperationResponse.self, event: event, completion: completion)
+        sendEventToInAppMessagesIfNeeded(operationSystemName, jsonString: json)
+        Logger.common(message: "Track executeSyncOperation", level: .info, category: .notification)
+        return cancelable
+    }
 
     /**
      Method for executing an operation synchronously.

--- a/Mindbox/Network/Abstract/NetworkFetcher.swift
+++ b/Mindbox/Network/Abstract/NetworkFetcher.swift
@@ -21,4 +21,11 @@ protocol NetworkFetcher {
         route: Route,
         completion: @escaping ((Result<Void, MindboxError>) -> Void)
     )
+    
+    func requestTest<T>(
+        type: T.Type,
+        route: Route,
+        needBaseResponse: Bool,
+        completion: @escaping (Result<T, MindboxError>) -> Void
+    ) -> Cancelable? where T: Decodable
 }

--- a/Mindbox/Network/Types/Cancelable.swift
+++ b/Mindbox/Network/Types/Cancelable.swift
@@ -1,0 +1,36 @@
+//
+//  Cancelable.swift
+//  Mindbox
+//
+//  Created by Sergei Semko on 7/1/24.
+//  Copyright © 2024 Mindbox. All rights reserved.
+//
+
+import Foundation
+
+public protocol Cancelable {
+    func cancel()
+}
+
+public class MBCancelable {
+    private var isCancelled = false
+    private var task: URLSessionTask?
+    
+    func checkIfCanceled() -> Bool {
+        return isCancelled
+    }
+    
+    func setTask(_ task: URLSessionTask) {
+        self.task = task
+        if isCancelled {
+            task.cancel()
+        }
+    }
+}
+
+extension MBCancelable: Cancelable {
+    public func cancel() {
+        isCancelled = true
+        task?.cancel()
+    }
+}

--- a/Mindbox/NetworkRepository/Event/EventRepository.swift
+++ b/Mindbox/NetworkRepository/Event/EventRepository.swift
@@ -12,4 +12,5 @@ import MindboxLogger
 protocol EventRepository {
     func send(event: Event, completion: @escaping (Result<Void, MindboxError>) -> Void)
     func send<T>(type: T.Type, event: Event, completion: @escaping (Result<T, MindboxError>) -> Void) where T: Decodable
+    func sendTest<T>(type: T.Type, event: Event, completion: @escaping (Result<T, MindboxError>) -> Void) -> Cancelable? where T: Decodable
 }


### PR DESCRIPTION
Пример работы с методом. Воспроизводил с симуляцией 3G интернета

```swift
    func testSendSyncOperaion(_ completion: @escaping (String) -> Void) {
        let text = operationNameText.trimmingCharacters(in: .whitespaces)
        var json = """
{
        "viewProductCategory": {
            "productCategory": {
                "ids": {
                    "website": "82"
                }
            }
        }
    }
"""
        let cancellable = Mindbox.shared.executeSyncOperationTest(operationSystemName: text, json: json) { result in
            completion(self.getOperationDescription(result))
        }
        
        DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(100)) {
            cancellable?.cancel()
        }
    }
```

<details>
<img width="893" alt="image" src="https://github.com/mindbox-cloud/ios-sdk/assets/28645140/200f176c-7e91-46ae-8ac7-136dd3f93a96">
</details >

Тесты упали, потому что я контракты некоторые расширил, но не имплементировал их в тестовом таргете 