### PR TITLE
MBX-3507: New image size for rich push notifications

### DIFF
--- a/Mindbox/Info.plist
+++ b/Mindbox/Info.plist
@@ -17,6 +17,6 @@
 	<key>CFBundleShortVersionString</key>
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
-	<string>5614</string>
+	<string>5615</string>
 </dict>
 </plist>

--- a/MindboxNotifications/MindboxNotificationService.swift
+++ b/MindboxNotifications/MindboxNotificationService.swift
@@ -157,17 +157,24 @@ public class MindboxNotificationService: NSObject {
             return
         }
 
-        let imageView = UIImageView(image: UIImage(data: data))
-        imageView.contentMode = .scaleAspectFill
+        let image = UIImage(data: data)
+        let imageView = UIImageView(image: image)
+        imageView.contentMode = .scaleAspectFit
         imageView.translatesAutoresizingMaskIntoConstraints = false
         view.addSubview(imageView)
+        
+        let imageHeight = image?.size.height ?? 0
+        let imageWidth = image?.size.width ?? 0
+        
+        let imageRatio = imageHeight / imageWidth
+        let imageViewHeight = view.bounds.width * imageRatio
+        
         NSLayoutConstraint.activate([
-            imageView.widthAnchor.constraint(equalTo: view.widthAnchor),
-            imageView.leftAnchor.constraint(equalTo: view.leftAnchor),
-            imageView.rightAnchor.constraint(equalTo: view.rightAnchor),
+            imageView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            imageView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
             imageView.topAnchor.constraint(equalTo: view.topAnchor),
             imageView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
-            imageView.heightAnchor.constraint(lessThanOrEqualToConstant: 300),
+            imageView.heightAnchor.constraint(lessThanOrEqualToConstant: imageViewHeight),
         ])
     }
 

--- a/MindboxNotifications/MindboxNotificationService.swift
+++ b/MindboxNotifications/MindboxNotificationService.swift
@@ -121,6 +121,9 @@ public class MindboxNotificationService: NSObject {
 
         if let attachment = notification.request.content.attachments.first,
            attachment.url.startAccessingSecurityScopedResource() {
+            defer {
+                attachment.url.stopAccessingSecurityScopedResource()
+            }
             createImageView(with: attachment.url.path, view: viewController?.view)
         }
         createActions(with: payload, context: context)
@@ -166,7 +169,7 @@ public class MindboxNotificationService: NSObject {
         let imageHeight = image?.size.height ?? 0
         let imageWidth = image?.size.width ?? 0
         
-        let imageRatio = imageHeight / imageWidth
+        let imageRatio = (imageWidth > 0) ? imageHeight / imageWidth : 0
         let imageViewHeight = view.bounds.width * imageRatio
         
         NSLayoutConstraint.activate([


### PR DESCRIPTION
[iOS] Ресайз картинок в пушах[#3507](https://github.com/mindbox-cloud/issues-web-mobile/issues/3507)

Не стал выносить расчет imageRatio в расширение какое-нибудь или выставлять размеры ImageView вообще через intrinsicContentSize. Посчитал, что здесь это будет перебор и нужно оставить как проще и как уже было проверено. 