### PR TITLE
MBX-3568: Package managers

### DIFF
--- a/Mindbox.podspec
+++ b/Mindbox.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
   spec.homepage     = "https://github.com/mindbox-cloud/ios-sdk"
   spec.license      = { :type => "CC BY-NC-ND 4.0", :file => "LICENSE.md" }
   spec.author       = { "Mindbox" => "ios-sdk@mindbox.ru" }
-  spec.platform     = :ios, "10.0"
+  spec.platform     = :ios, "12.0"
   spec.source       = { :git => "https://github.com/mindbox-cloud/ios-sdk.git", :tag => spec.version }
   spec.source_files  = "Mindbox/**/*.{swift}", "SDKVersionProvider/**/*.{swift}"
   spec.exclude_files = "Classes/Exclude"

--- a/MindboxLogger.podspec
+++ b/MindboxLogger.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
   spec.homepage     = "https://github.com/mindbox-cloud/ios-sdk"
   spec.license      = { :type => "CC BY-NC-ND 4.0", :file => "LICENSE.md" }
   spec.author       = { "Mindbox" => "ios-sdk@mindbox.ru" }
-  spec.platform     = :ios, "10.0"
+  spec.platform     = :ios, "12.0"
   spec.source       = { :git => "https://github.com/mindbox-cloud/ios-sdk.git", :tag => "#{spec.version}" }
   spec.source_files  = "MindboxLogger/**/*.{swift}", "SDKVersionProvider/**/*.{swift}"
   spec.exclude_files = "Classes/Exclude"

--- a/MindboxNotifications.podspec
+++ b/MindboxNotifications.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
   spec.homepage     = "https://github.com/mindbox-cloud/ios-sdk"
   spec.license      = { :type => "CC BY-NC-ND 4.0", :file => "LICENSE.md" }
   spec.author       = { "Mindbox" => "ios-sdk@mindbox.ru" }
-  spec.platform     = :ios, "10.0"
+  spec.platform     = :ios, "12.0"
   spec.source       = { :git => "https://github.com/mindbox-cloud/ios-sdk.git", :tag => spec.version }
   spec.source_files  = "MindboxNotifications/**/*.{swift}", "SDKVersionProvider/**/*.{swift}"
   spec.exclude_files = "Classes/Exclude"

--- a/Package.swift
+++ b/Package.swift
@@ -4,7 +4,7 @@ import PackageDescription
 
 let package = Package(
     name: "Mindbox",
-    platforms: [.iOS(.v10)],
+    platforms: [.iOS(.v12)],
     products: [
         .library(
             name: "Mindbox",


### PR DESCRIPTION
[iOS] Поднять минимальную версию iOS с 10.0 до 12.0[#3568](https://github.com/mindbox-cloud/issues-web-mobile/issues/3568)

[Проверка `pod lib lint` на `master` ветке](https://mindbox.loop.ru/mindbox/pl/1h6c4x47sbdz987mzabi47o1uc)