### PR TITLE
MBX-0000: Change Ubuntu version for SwiftLint job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ on:
       - '**'
 jobs:
   SwiftLint:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v4
     - uses: cirruslabs/swiftlint-action@v1


### PR DESCRIPTION
На основании [проблемы в GHA](https://github.com/mindbox-cloud/ios-sdk/actions/runs/12026667620/job/33526422958) после [обновления версии образа GitHub](https://github.com/actions/runner-images/commit/aba30c31f0406e249b1e77f7edfeed574649a3fb)

[Issue for swiftlint-action](https://github.com/cirruslabs/swiftlint-action/issues/55)

```
Run cirruslabs/swiftlint-action@v1
  with:
    args: --config .swiftlint.yml
/usr/bin/unzip -o -q /home/runner/work/_temp/4c6c1a6e-28b5-484d-be15-4dbeb10782af
/home/runner/work/_temp/10e49b85-c55d-4a25-b72a-7ef9f147e67d/swiftlint lint --reporter=json --config .swiftlint.yml
/home/runner/work/_temp/10e49b85-c55d-4a25-b72a-7ef9f147e67d/swiftlint: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.38' not found (required by /home/runner/work/_temp/10e49b85-c55d-4a25-b72a-7ef9f147e67d/swiftlint)
/home/runner/work/_temp/10e49b85-c55d-4a25-b72a-7ef9f147e67d/swiftlint: /lib/x86_64-linux-gnu/libm.so.6: version `GLIBC_2.38' not found (required by /home/runner/work/_temp/10e49b85-c55d-4a25-b72a-7ef9f147e67d/swiftlint)
Error: Unexpected end of JSON input
```