### PR TITLE
WMSDK-406: `macos-15` instead of `macos-latest`

### DIFF
--- a/.github/workflows/distribute_pushok.yml
+++ b/.github/workflows/distribute_pushok.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   distribution:
     if: github.event.pull_request.merged == true || (github.event_name == 'push' && (startsWith(github.ref, 'refs/heads/release/') || startsWith(github.ref, 'refs/heads/support/')))
-    runs-on: macos-latest
+    runs-on: macos-15
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/linter_and_unit_tests.yml
+++ b/.github/workflows/linter_and_unit_tests.yml
@@ -20,7 +20,7 @@ jobs:
         args: --config .swiftlint.yml
 
   build:
-    runs-on: macos-latest
+    runs-on: macos-15
     timeout-minutes: 15
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/prepare_release_branch.yml
+++ b/.github/workflows/prepare_release_branch.yml
@@ -10,7 +10,7 @@ jobs:
   extract_version:
     if: github.event.created
     name: Extract Version
-    runs-on: macos-latest
+    runs-on: macos-15
     outputs:
       version: ${{ steps.extract.outputs.version }}
     steps:
@@ -26,7 +26,7 @@ jobs:
           
   bump_version:
     name: Bump Version
-    runs-on: macos-latest
+    runs-on: macos-15
     needs: extract_version
     outputs:
       version2: ${{ steps.bump.outputs.version2 }}
@@ -44,7 +44,7 @@ jobs:
           
   check_sdk_version:
     name: Check SDK Version
-    runs-on: macos-latest
+    runs-on: macos-15
     needs: bump_version
     steps:
       - name: Checkout code
@@ -66,7 +66,7 @@ jobs:
 
   create_pull_request:
     name: Create Pull Request
-    runs-on: macos-latest
+    runs-on: macos-15
     needs: check_sdk_version
     steps:
       - name: Checkout code

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   unit-tests:
     if: github.event.pull_request.merged == true
-    runs-on: macos-latest
+    runs-on: macos-15
     steps:
       - uses: actions/checkout@v4
       - uses: maxim-lobanov/setup-xcode@v1
@@ -40,7 +40,7 @@ jobs:
 
   publish-MindboxLogger:
     needs: [set-tag]
-    runs-on: macos-latest
+    runs-on: macos-15
     steps:
       - uses: actions/checkout@v4
       - name: Update bundler
@@ -63,7 +63,7 @@ jobs:
       
   check-podspecs-with-retry:
     needs: [delay]
-    runs-on: macos-latest
+    runs-on: macos-15
     steps:
       - uses: actions/checkout@v4
       - name: Update bundler
@@ -82,7 +82,7 @@ jobs:
   
   publish-Mindbox:
     needs: [check-podspecs-with-retry]
-    runs-on: macos-latest
+    runs-on: macos-15
     steps:
       - uses: actions/checkout@v4
       - name: Update bundler
@@ -100,7 +100,7 @@ jobs:
           
   publish-MindboxNotifications:
     needs: [check-podspecs-with-retry]
-    runs-on: macos-latest
+    runs-on: macos-15
     steps:
       - uses: actions/checkout@v4
       - name: Update bundler


### PR DESCRIPTION
[[iOS] Падает CI/CD из-за отсутствия iOS-SDK 18.2 на GitHub-hosted Runner](https://tracker.yandex.ru/WMSDK-406)