### PR TITLE
Poziev/change worfklow dispatch to gitlab

### DIFF
--- a/.github/workflows/distribute_pushok.yml
+++ b/.github/workflows/distribute_pushok.yml
@@ -1,13 +1,18 @@
 name: Distribute PushOk
 
 on:
+  pull_request:
+    types: [ closed ]
+    branches:
+      - develop
   push:
     branches:
-      - poziev/change-worfklow-dispatch-to-gitlab
+      - 'release/*'
+      - 'support/*'
 
 jobs:
   distribution:
-    #if: github.event.pull_request.merged == true || (github.event_name == 'push' && (startsWith(github.ref, 'refs/heads/release/') || startsWith(github.ref, 'refs/heads/support/')))
+    if: github.event.pull_request.merged == true || (github.event_name == 'push' && (startsWith(github.ref, 'refs/heads/release/') || startsWith(github.ref, 'refs/heads/support/')))
     runs-on: macos-15
     steps:
       - name: Checkout repository

--- a/.github/workflows/distribute_pushok.yml
+++ b/.github/workflows/distribute_pushok.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   distribution:
-    if: github.event.pull_request.merged == true || (github.event_name == 'push' && (startsWith(github.ref, 'refs/heads/release/') || startsWith(github.ref, 'refs/heads/support/')))
+    #if: github.event.pull_request.merged == true || (github.event_name == 'push' && (startsWith(github.ref, 'refs/heads/release/') || startsWith(github.ref, 'refs/heads/support/')))
     runs-on: macos-15
     steps:
       - name: Checkout repository

--- a/.github/workflows/distribute_pushok.yml
+++ b/.github/workflows/distribute_pushok.yml
@@ -1,14 +1,9 @@
 name: Distribute PushOk
 
 on:
-  pull_request:
-    types: [ closed ]
-    branches:
-      - develop
   push:
     branches:
-      - 'release/*'
-      - 'support/*'
+      - poziev/change-worfklow-dispatch-to-gitlab
 
 jobs:
   distribution:
@@ -38,11 +33,11 @@ jobs:
           echo "sdkVersion: ${{ env.sdkVersion }}"
 
       - name: Trigger build workflow in ios-app repo
-        uses: benc-uk/workflow-dispatch@v1
-        with:
-          token: ${{ secrets.PAT_IOS_APP }}
-          workflow: connected_publish_workflow.yml
-          repo: mindbox-cloud/ios-app
-          ref: develop
-          inputs: '{"branch": "${{ github.ref_name }}", "commits": "${{ env.commits }}", "sdkVersion": "${{ env.sdkVersion }}"}'
+        run: |
+          curl --location 'https://mindbox.gitlab.yandexcloud.net/api/v4/projects/966/trigger/pipeline' \
+            --form 'token="${{ secrets.GITLAB_TRIGGER_TOKEN }}"' \
+            --form 'ref="test_branch"' \
+            --form "variables[INPUT_BRANCH]=\"${{ github.ref_name }}\"" \
+            --form "variables[INPUT_COMMITS]=\"${{ env.commits }}\"" \
+            --form "variables[INPUT_SDK_VERSION]=\"${{ env.sdkVersion }}\""
  

--- a/.github/workflows/distribute_pushok.yml
+++ b/.github/workflows/distribute_pushok.yml
@@ -41,7 +41,7 @@ jobs:
         run: |
           curl --location 'https://mindbox.gitlab.yandexcloud.net/api/v4/projects/966/trigger/pipeline' \
             --form 'token="${{ secrets.GITLAB_TRIGGER_TOKEN }}"' \
-            --form 'ref="test_branch"' \
+            --form 'ref="develop"' \
             --form "variables[INPUT_BRANCH]=\"${{ github.ref_name }}\"" \
             --form "variables[INPUT_COMMITS]=\"${{ env.commits }}\"" \
             --form "variables[INPUT_SDK_VERSION]=\"${{ env.sdkVersion }}\""

--- a/.github/workflows/distribute_pushok.yml
+++ b/.github/workflows/distribute_pushok.yml
@@ -39,7 +39,7 @@ jobs:
 
       - name: Trigger build workflow in ios-app repo
         run: |
-          curl --location 'https://mindbox.gitlab.yandexcloud.net/api/v4/projects/966/trigger/pipeline' \
+          curl --location 'https://mindbox.gitlab.yandexcloud.net/api/v4/projects/1021/trigger/pipeline' \
             --form 'token="${{ secrets.GITLAB_TRIGGER_TOKEN }}"' \
             --form 'ref="develop"' \
             --form "variables[INPUT_BRANCH]=\"${{ github.ref_name }}\"" \


### PR DESCRIPTION
В рамках перехода на gitlab, необходимо поменять workflow_dispatch триггер на гитлабовский аналог

- Добавлен секрет GITLAB_TRIGGER_TOKEN для триггера джобы в GitLab
- Добавлен триггер GitLab пайплайна, аналогично android-sdk

Что изменится при переводе в PR:
- id проекта изменится на id импортированного проекта: 966 -> x (на данный момент это id тестового CI/CD проекта)
