### PR TITLE
WMSDK-411: Rename config JSON key

### DIFF
--- a/Mindbox/Extensions/Notification+Extensions.swift
+++ b/Mindbox/Extensions/Notification+Extensions.swift
@@ -11,5 +11,5 @@ import Foundation
 extension Notification.Name {
     static let initializationCompleted = Notification.Name("MBNotification-initializationCompleted")
     static let shouldDiscardInapps = Notification.Name("MBNotification-shouldDiscardInapps")
-    static let inappConfigDownloaded = Notification.Name("MBNotification-inappConfigDownloaded")
+    static let mobileConfigDownloaded = Notification.Name("MBNotification-mobileConfigDownloaded")
 }

--- a/Mindbox/InAppMessages/Configuration/InAppConfigurationManager.swift
+++ b/Mindbox/InAppMessages/Configuration/InAppConfigurationManager.swift
@@ -153,16 +153,16 @@ class InAppConfigurationManager: InAppConfigurationManagerProtocol {
             SessionTemporaryStorage.shared.operationsFromSettings.insert(viewProduct.systemName.lowercased())
         }
         
-        saveInappSessionToCache(config: settings.slidingExpiration?.config)
+        saveConfigSessionToCache(settings.slidingExpiration?.config)
     }
 
     private func createTTLValidationService() -> TTLValidationProtocol {
         return TTLValidationService(persistenceStorage: self.persistenceStorage)
     }
     
-    private func saveInappSessionToCache(config: String?) {
-        SessionTemporaryStorage.shared.expiredInappSession = config
-        Logger.common(message: "Saved slidingExpiration.config - \(config) to temporary storage.")
-        NotificationCenter.default.post(name: .inappConfigDownloaded, object: nil)
+    private func saveConfigSessionToCache(_ config: String?) {
+        SessionTemporaryStorage.shared.expiredConfigSession = config
+        Logger.common(message: "Saved slidingExpiration.config - \(String(describing: config)) to temporary storage.")
+        NotificationCenter.default.post(name: .mobileConfigDownloaded, object: nil)
     }
 }

--- a/Mindbox/InAppMessages/Configuration/InAppConfigurationManager.swift
+++ b/Mindbox/InAppMessages/Configuration/InAppConfigurationManager.swift
@@ -153,16 +153,16 @@ class InAppConfigurationManager: InAppConfigurationManagerProtocol {
             SessionTemporaryStorage.shared.operationsFromSettings.insert(viewProduct.systemName.lowercased())
         }
         
-        saveInappSessionToCache(inappSession: settings.slidingExpiration?.inappSession)
+        saveInappSessionToCache(config: settings.slidingExpiration?.config)
     }
 
     private func createTTLValidationService() -> TTLValidationProtocol {
         return TTLValidationService(persistenceStorage: self.persistenceStorage)
     }
     
-    private func saveInappSessionToCache(inappSession: String?) {
-        SessionTemporaryStorage.shared.expiredInappSession = inappSession
-        Logger.common(message: "Saved slidingExpiration.inappSession - \(inappSession) to temporary storage.")
+    private func saveInappSessionToCache(config: String?) {
+        SessionTemporaryStorage.shared.expiredInappSession = config
+        Logger.common(message: "Saved slidingExpiration.config - \(config) to temporary storage.")
         NotificationCenter.default.post(name: .inappConfigDownloaded, object: nil)
     }
 }

--- a/Mindbox/InAppMessages/InappSessionManager/InappSessionManager.swift
+++ b/Mindbox/InAppMessages/InappSessionManager/InappSessionManager.swift
@@ -51,7 +51,7 @@ final class InappSessionManager: InappSessionManagerProtocol {
             return
         }
         
-        guard let sessionTimeInSeconds = getInappSession(), sessionTimeInSeconds > 0 else {
+        guard let sessionTimeInSeconds = getConfigSession(), sessionTimeInSeconds > 0 else {
             Logger.common(message: "[InappSessionManager] expiredInappTime is nil/invalid or <= 0 — skip session expiration check.")
             return
         }
@@ -88,9 +88,9 @@ final class InappSessionManager: InappSessionManagerProtocol {
         NotificationCenter.default.post(name: .shouldDiscardInapps, object: nil)
     }
     
-    private func getInappSession() -> Double? {
-        guard let inappSession = SessionTemporaryStorage.shared.expiredInappSession,
-              let sessionTimeInSeconds = try? inappSession.parseTimeStampToSeconds() else {
+    private func getConfigSession() -> Double? {
+        guard let configSession = SessionTemporaryStorage.shared.expiredConfigSession,
+              let sessionTimeInSeconds = try? configSession.parseTimeStampToSeconds() else {
             return nil
         }
         
@@ -99,7 +99,7 @@ final class InappSessionManager: InappSessionManagerProtocol {
     
     private func addObserverToDismissInApp() {
         NotificationCenter.default.addObserver(
-            forName: .inappConfigDownloaded,
+            forName: .mobileConfigDownloaded,
             object: nil,
             queue: nil
         ) { [weak self] _ in
@@ -109,7 +109,7 @@ final class InappSessionManager: InappSessionManagerProtocol {
     
     private func logNearestInappSessionExpirationTime() {
         if let lastTrackVisitTimestamp = lastTrackVisitTimestamp,
-           let sessionTimeInSeconds = self.getInappSession(), sessionTimeInSeconds > 0 {
+           let sessionTimeInSeconds = self.getConfigSession(), sessionTimeInSeconds > 0 {
             let expirationDate = lastTrackVisitTimestamp.addingTimeInterval(sessionTimeInSeconds)
             Logger.common(message: "[InappSessionManager] Nearest session expiration time is \(expirationDate.asDateTimeWithSeconds).")
         }

--- a/Mindbox/InAppMessages/Models/Config/SlidingExpirationModel.swift
+++ b/Mindbox/InAppMessages/Models/Config/SlidingExpirationModel.swift
@@ -10,10 +10,10 @@ import Foundation
 
 extension Settings {
     struct SlidingExpiration: Decodable, Equatable {
-        let inappSession: String?
+        let config: String?
 
         enum CodingKeys: CodingKey {
-            case inappSession
+            case config
         }
     }
 }
@@ -21,10 +21,10 @@ extension Settings {
 extension Settings.SlidingExpiration {
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
-        if let inappSession = try? container.decodeIfPresent(String.self, forKey: .inappSession) {
-            self.inappSession = inappSession
+        if let config = try? container.decodeIfPresent(String.self, forKey: .config) {
+            self.config = config
         } else {
-            throw DecodingError.dataCorruptedError(forKey: .inappSession, in: container, debugDescription: "Missing required key 'inappSession'")
+            throw DecodingError.dataCorruptedError(forKey: .config, in: container, debugDescription: "Missing required key 'config'")
         }
     }
 }

--- a/Mindbox/Utilities/SessionTemporaryStorage.swift
+++ b/Mindbox/Utilities/SessionTemporaryStorage.swift
@@ -30,7 +30,7 @@ final class SessionTemporaryStorage {
         }
     }
 
-    var expiredInappSession: String?
+    var expiredConfigSession: String?
     var isUserVisitSaved = false
     private init() {}
 

--- a/MindboxTests/ConfigParsing/Config/ConfigJsonStub/ConfigABTestsError.json
+++ b/MindboxTests/ConfigParsing/Config/ConfigJsonStub/ConfigABTestsError.json
@@ -404,6 +404,9 @@
     },
     "ttl": {
       "inapps": "1.00:00:00"
+    }, 
+    "slidingExpiration": {
+      "config": "0.00:00:23"
     }
   }
 }

--- a/MindboxTests/ConfigParsing/Config/ConfigJsonStub/ConfigABTestsOneElementError.json
+++ b/MindboxTests/ConfigParsing/Config/ConfigJsonStub/ConfigABTestsOneElementError.json
@@ -404,6 +404,9 @@
     },
     "ttl": {
       "inapps": "1.00:00:00"
+    }, 
+    "slidingExpiration": {
+      "config": "0.00:00:23"
     }
   }
 }

--- a/MindboxTests/ConfigParsing/Config/ConfigJsonStub/ConfigABTestsOneElementTypeError.json
+++ b/MindboxTests/ConfigParsing/Config/ConfigJsonStub/ConfigABTestsOneElementTypeError.json
@@ -373,6 +373,9 @@
     },
     "ttl": {
       "inapps": "1.00:00:00"
+    }, 
+    "slidingExpiration": {
+      "config": "0.00:00:23"
     }
   }
 }

--- a/MindboxTests/ConfigParsing/Config/ConfigJsonStub/ConfigABTestsTypeError.json
+++ b/MindboxTests/ConfigParsing/Config/ConfigJsonStub/ConfigABTestsTypeError.json
@@ -327,6 +327,9 @@
     },
     "ttl": {
       "inapps": "1.00:00:00"
+    }, 
+    "slidingExpiration": {
+      "config": "0.00:00:23"
     }
   }
 }

--- a/MindboxTests/ConfigParsing/Config/ConfigJsonStub/ConfigInAppsError.json
+++ b/MindboxTests/ConfigParsing/Config/ConfigJsonStub/ConfigInAppsError.json
@@ -326,6 +326,9 @@
     },
     "ttl": {
       "inapps": "1.00:00:00"
+    }, 
+    "slidingExpiration": {
+      "config": "0.00:00:23"
     }
   },
   "abtests": [

--- a/MindboxTests/ConfigParsing/Config/ConfigJsonStub/ConfigInAppsTypeError.json
+++ b/MindboxTests/ConfigParsing/Config/ConfigJsonStub/ConfigInAppsTypeError.json
@@ -34,6 +34,9 @@
     },
     "ttl": {
       "inapps": "1.00:00:00"
+    }, 
+    "slidingExpiration": {
+      "config": "0.00:00:23"
     }
   },
   "abtests": [

--- a/MindboxTests/ConfigParsing/Config/ConfigJsonStub/ConfigMonitoringError.json
+++ b/MindboxTests/ConfigParsing/Config/ConfigJsonStub/ConfigMonitoringError.json
@@ -326,6 +326,9 @@
     },
     "ttl": {
       "inapps": "1.00:00:00"
+    }, 
+    "slidingExpiration": {
+      "config": "0.00:00:23"
     }
   },
   "abtests": [

--- a/MindboxTests/ConfigParsing/Config/ConfigJsonStub/ConfigMonitoringTypeError.json
+++ b/MindboxTests/ConfigParsing/Config/ConfigJsonStub/ConfigMonitoringTypeError.json
@@ -311,6 +311,9 @@
     },
     "ttl": {
       "inapps": "1.00:00:00"
+    }, 
+    "slidingExpiration": {
+      "config": "0.00:00:23"
     }
   },
   "abtests": [

--- a/MindboxTests/ConfigParsing/Config/ConfigJsonStub/ConfigSettingsError.json
+++ b/MindboxTests/ConfigParsing/Config/ConfigJsonStub/ConfigSettingsError.json
@@ -17,6 +17,9 @@
     },
     "ttl": {
       "inapps": "1.00:00:00"
+    }, 
+    "slidingExpiration": {
+      "config": "0.00:00:23"
     }
   },
   "inapps": [

--- a/MindboxTests/ConfigParsing/Config/ConfigJsonStub/ConfigWithSettingsABTestsMonitoringInapps.json
+++ b/MindboxTests/ConfigParsing/Config/ConfigJsonStub/ConfigWithSettingsABTestsMonitoringInapps.json
@@ -322,6 +322,9 @@
     },
     "ttl": {
       "inapps": "1.00:00:00"
+    }, 
+    "slidingExpiration": {
+      "config": "0.00:00:23"
     }
   },
   "abtests": [

--- a/MindboxTests/ConfigParsing/Settings/SettingsConfigParsingTests.swift
+++ b/MindboxTests/ConfigParsing/Settings/SettingsConfigParsingTests.swift
@@ -44,10 +44,13 @@ fileprivate enum SettingsConfig: String, Configurable {
     case ttlInappsError = "SettingsTtlInappsError" // Key is `inappsTest` instead of `inapps`
     case ttlInappsTypeError = "SettingsTtlInappsTypeError" // Type of `ttl` is Int instead of String
     
+    // Sliding Expiration file names
+    
     case settingsSlidingExpirationError = "SettingsSlidingExpirationError"
     case settingsSlidingExpirationTypeError = "SettingsSlidingExpirationTypeError"
-    case settingsSlidingExpirationInappSessionError = "SettingsSlidingExpirationInappSessionError"
-    case settingsSlidingExpirationInappSessionTypeError = "SettingsSlidingExpirationInappSessionTypeError"
+    
+    case settingsSlidingExpirationConfigError = "SettingsSlidingExpirationConfigError"
+    case settingsSlidingExpirationConfigTypeError = "SettingsSlidingExpirationConfigTypeError"
 }
 
 final class SettingsConfigParsingTests: XCTestCase {
@@ -64,6 +67,9 @@ final class SettingsConfigParsingTests: XCTestCase {
 
         XCTAssertNotNil(config.ttl)
         XCTAssertNotNil(config.ttl?.inapps)
+        
+        XCTAssertNotNil(config.slidingExpiration)
+        XCTAssertNotNil(config.slidingExpiration?.config)
     }
 
     // MARK: - Operations
@@ -78,6 +84,9 @@ final class SettingsConfigParsingTests: XCTestCase {
 
         XCTAssertNotNil(config.ttl, "TTL must be successfully parsed")
         XCTAssertNotNil(config.ttl?.inapps, "TTL must be successfully parsed")
+        
+        XCTAssertNotNil(config.slidingExpiration, "SlidingExpiration must be successfully parsed")
+        XCTAssertNotNil(config.slidingExpiration?.config, "SlidingExpiration must be successfully parsed")
     }
 
     func test_SettingsConfig_withOperationsTypeError_shouldSetOperationsToNil() {
@@ -90,6 +99,9 @@ final class SettingsConfigParsingTests: XCTestCase {
 
         XCTAssertNotNil(config.ttl, "TTL must be successfully parsed")
         XCTAssertNotNil(config.ttl?.inapps, "TTL must be successfully parsed")
+        
+        XCTAssertNotNil(config.slidingExpiration, "SlidingExpiration must be successfully parsed")
+        XCTAssertNotNil(config.slidingExpiration?.config, "SlidingExpiration must be successfully parsed")
     }
 
     func test_SettingsConfig_withOperationsViewProductError_shouldSetViewProductToNil() {
@@ -102,6 +114,9 @@ final class SettingsConfigParsingTests: XCTestCase {
 
         XCTAssertNotNil(config.ttl, "TTL must be successfully parsed")
         XCTAssertNotNil(config.ttl?.inapps, "TTL must be successfully parsed")
+        
+        XCTAssertNotNil(config.slidingExpiration, "SlidingExpiration must be successfully parsed")
+        XCTAssertNotNil(config.slidingExpiration?.config, "SlidingExpiration must be successfully parsed")
     }
 
     func test_SettingsConfig_withOperationsViewProductTypeError_shouldSetViewProductToNil() {
@@ -114,6 +129,9 @@ final class SettingsConfigParsingTests: XCTestCase {
 
         XCTAssertNotNil(config.ttl, "TTL must be successfully parsed")
         XCTAssertNotNil(config.ttl?.inapps, "TTL must be successfully parsed")
+        
+        XCTAssertNotNil(config.slidingExpiration, "SlidingExpiration must be successfully parsed")
+        XCTAssertNotNil(config.slidingExpiration?.config, "SlidingExpiration must be successfully parsed")
     }
 
     func test_SettingsConfig_withOperationsViewProductSystemNameError_shouldSetViewProductToNil() {
@@ -126,6 +144,9 @@ final class SettingsConfigParsingTests: XCTestCase {
 
         XCTAssertNotNil(config.ttl, "TTL must be successfully parsed")
         XCTAssertNotNil(config.ttl?.inapps, "TTL must be successfully parsed")
+        
+        XCTAssertNotNil(config.slidingExpiration, "SlidingExpiration must be successfully parsed")
+        XCTAssertNotNil(config.slidingExpiration?.config, "SlidingExpiration must be successfully parsed")
     }
 
     func test_SettingsConfig_withOperationsViewProductSystemNameTypeError_shouldSetViewProductToNil() {
@@ -138,6 +159,9 @@ final class SettingsConfigParsingTests: XCTestCase {
 
         XCTAssertNotNil(config.ttl, "TTL must be successfully parsed")
         XCTAssertNotNil(config.ttl?.inapps, "TTL must be successfully parsed")
+        
+        XCTAssertNotNil(config.slidingExpiration, "SlidingExpiration must be successfully parsed")
+        XCTAssertNotNil(config.slidingExpiration?.config, "SlidingExpiration must be successfully parsed")
     }
 
     func test_SettingsConfig_withAllOperationsWithErrors_shouldSetOperationsToNil() {
@@ -150,6 +174,9 @@ final class SettingsConfigParsingTests: XCTestCase {
 
         XCTAssertNotNil(config.ttl, "TTL must be successfully parsed")
         XCTAssertNotNil(config.ttl?.inapps, "TTL must be successfully parsed")
+        
+        XCTAssertNotNil(config.slidingExpiration, "SlidingExpiration must be successfully parsed")
+        XCTAssertNotNil(config.slidingExpiration?.config, "SlidingExpiration must be successfully parsed")
     }
 
     func test_SettingsConfig_withAllOperationsWithTypeErrors_shouldSetOperationsToNil() {
@@ -162,6 +189,9 @@ final class SettingsConfigParsingTests: XCTestCase {
 
         XCTAssertNotNil(config.ttl, "TTL must be successfully parsed")
         XCTAssertNotNil(config.ttl?.inapps, "TTL must be successfully parsed")
+        
+        XCTAssertNotNil(config.slidingExpiration, "SlidingExpiration must be successfully parsed")
+        XCTAssertNotNil(config.slidingExpiration?.config, "SlidingExpiration must be successfully parsed")
     }
 
     func test_SettingsConfig_withOperationsViewCategoryAndSetCartError_shouldSetViewCategoryAndSetCartToNil() {
@@ -174,6 +204,9 @@ final class SettingsConfigParsingTests: XCTestCase {
 
         XCTAssertNotNil(config.ttl, "TTL must be successfully parsed")
         XCTAssertNotNil(config.ttl?.inapps, "TTL must be successfully parsed")
+        
+        XCTAssertNotNil(config.slidingExpiration, "SlidingExpiration must be successfully parsed")
+        XCTAssertNotNil(config.slidingExpiration?.config, "SlidingExpiration must be successfully parsed")
     }
 
     func test_SettingsConfig_withOperationsViewCategoryAndSetCartTypeError_shouldSetViewCategoryAndSetCartToNil() {
@@ -186,6 +219,9 @@ final class SettingsConfigParsingTests: XCTestCase {
 
         XCTAssertNotNil(config.ttl, "TTL must be successfully parsed")
         XCTAssertNotNil(config.ttl?.inapps, "TTL must be successfully parsed")
+        
+        XCTAssertNotNil(config.slidingExpiration, "SlidingExpiration must be successfully parsed")
+        XCTAssertNotNil(config.slidingExpiration?.config, "SlidingExpiration must be successfully parsed")
     }
 
     func test_SettingsConfig_withOperationsViewCategoryAndSetCartSystemNameError_shouldSetViewCategoryAndSetCartToNil() {
@@ -198,6 +234,9 @@ final class SettingsConfigParsingTests: XCTestCase {
 
         XCTAssertNotNil(config.ttl, "TTL must be successfully parsed")
         XCTAssertNotNil(config.ttl?.inapps, "TTL must be successfully parsed")
+        
+        XCTAssertNotNil(config.slidingExpiration, "SlidingExpiration must be successfully parsed")
+        XCTAssertNotNil(config.slidingExpiration?.config, "SlidingExpiration must be successfully parsed")
     }
 
     func test_SettingsConfig_withOperationsViewCategoryAndSetCartSystemNameTypeError_shouldSetViewCategoryAndSetCartToNil() {
@@ -210,6 +249,9 @@ final class SettingsConfigParsingTests: XCTestCase {
 
         XCTAssertNotNil(config.ttl, "TTL must be successfully parsed")
         XCTAssertNotNil(config.ttl?.inapps, "TTL must be successfully parsed")
+        
+        XCTAssertNotNil(config.slidingExpiration, "SlidingExpiration must be successfully parsed")
+        XCTAssertNotNil(config.slidingExpiration?.config, "SlidingExpiration must be successfully parsed")
     }
 
     func test_SettingsConfig_withOperationsViewCategoryAndSetCartSystemNameMixedError_shouldSetViewCategoryAndSetCartToNil() {
@@ -222,6 +264,9 @@ final class SettingsConfigParsingTests: XCTestCase {
 
         XCTAssertNotNil(config.ttl, "TTL must be successfully parsed")
         XCTAssertNotNil(config.ttl?.inapps, "TTL must be successfully parsed")
+        
+        XCTAssertNotNil(config.slidingExpiration, "SlidingExpiration must be successfully parsed")
+        XCTAssertNotNil(config.slidingExpiration?.config, "SlidingExpiration must be successfully parsed")
     }
 
     // MARK: - TTL
@@ -236,6 +281,9 @@ final class SettingsConfigParsingTests: XCTestCase {
 
         XCTAssertNil(config.ttl, "TTL must be `nil` if the key `ttl` is not found")
         XCTAssertNil(config.ttl?.inapps, "TTL must be nil")
+        
+        XCTAssertNotNil(config.slidingExpiration, "SlidingExpiration must be successfully parsed")
+        XCTAssertNotNil(config.slidingExpiration?.config, "SlidingExpiration must be successfully parsed")
     }
 
     func test_SettingsConfig_withTtlTypeError_shouldSetTtlToNil() {
@@ -248,6 +296,9 @@ final class SettingsConfigParsingTests: XCTestCase {
 
         XCTAssertNil(config.ttl, "TTL must be `nil` if the type of `inapps` is not a `TimeToLive`")
         XCTAssertNil(config.ttl?.inapps, "TTL must be nil")
+        
+        XCTAssertNotNil(config.slidingExpiration, "SlidingExpiration must be successfully parsed")
+        XCTAssertNotNil(config.slidingExpiration?.config, "SlidingExpiration must be successfully parsed")
     }
 
     func test_SettingsConfig_withTtlInappsError_shouldSetTtlToNil() {
@@ -260,6 +311,9 @@ final class SettingsConfigParsingTests: XCTestCase {
 
         XCTAssertNil(config.ttl, "TTL must be `nil` if the key `inapps` is not found")
         XCTAssertNil(config.ttl?.inapps, "TTL must be nil")
+        
+        XCTAssertNotNil(config.slidingExpiration, "SlidingExpiration must be successfully parsed")
+        XCTAssertNotNil(config.slidingExpiration?.config, "SlidingExpiration must be successfully parsed")
     }
 
     func test_SettingsConfig_withTtlInappsTypeError_shouldSetTtlToNil() {
@@ -272,7 +326,12 @@ final class SettingsConfigParsingTests: XCTestCase {
 
         XCTAssertNil(config.ttl, "TTL must be `nil` if the key `inapps` is not a `String`")
         XCTAssertNil(config.ttl?.inapps, "TTL must be `nil` if the key `inapps` is not a `String`")
+        
+        XCTAssertNotNil(config.slidingExpiration, "SlidingExpiration must be successfully parsed")
+        XCTAssertNotNil(config.slidingExpiration?.config, "SlidingExpiration must be successfully parsed")
     }
+    
+    // MARK: - Sliding Expiration
     
     func test_SettingsConfig_withSlidingExpirationError_shouldSetSlidingExpirationToNil() {
         // Key `slidingExpirationTest` вместо `slidingExpiration`
@@ -282,7 +341,7 @@ final class SettingsConfigParsingTests: XCTestCase {
         XCTAssertNotNil(config.ttl, "TTL должен успешно парситься")
 
         XCTAssertNil(config.slidingExpiration, "SlidingExpiration должен быть `nil`, если ключ `slidingExpiration` не найден")
-        XCTAssertNil(config.slidingExpiration?.inappSession, "SlidingExpiration тоже должен быть nil")
+        XCTAssertNil(config.slidingExpiration?.config, "SlidingExpiration тоже должен быть nil")
     }
 
     func test_SettingsConfig_withSlidingExpirationTypeError_shouldSetSlidingExpirationToNil() {
@@ -293,28 +352,28 @@ final class SettingsConfigParsingTests: XCTestCase {
         XCTAssertNotNil(config.ttl, "TTL должен успешно парситься")
 
         XCTAssertNil(config.slidingExpiration, "SlidingExpiration должен быть `nil`, если тип в JSON не соответствует `Settings.SlidingExpiration`")
-        XCTAssertNil(config.slidingExpiration?.inappSession)
+        XCTAssertNil(config.slidingExpiration?.config)
     }
 
     func test_SettingsConfig_withSlidingExpirationInappSessionError_shouldSetSlidingExpirationToNil() {
-        // Ключ `inappSessionTest` вместо `inappSession`
-        let config = try! SettingsConfig.settingsSlidingExpirationInappSessionError.getConfig()
+        // Ключ `inappSessionTest` вместо `config`
+        let config = try! SettingsConfig.settingsSlidingExpirationConfigError.getConfig()
 
         XCTAssertNotNil(config.operations)
         XCTAssertNotNil(config.ttl)
 
-        XCTAssertNil(config.slidingExpiration, "SlidingExpiration должен быть `nil`, если внутренний ключ `inappSession` не найден")
-        XCTAssertNil(config.slidingExpiration?.inappSession)
+        XCTAssertNil(config.slidingExpiration, "SlidingExpiration должен быть `nil`, если внутренний ключ `config` не найден")
+        XCTAssertNil(config.slidingExpiration?.config)
     }
 
     func test_SettingsConfig_withSlidingExpirationInappSessionTypeError_shouldSetSlidingExpirationToNil() {
-        // Тип `inappSession` = Int вместо String
-        let config = try! SettingsConfig.settingsSlidingExpirationInappSessionTypeError.getConfig()
+        // Тип `config` = Int вместо String
+        let config = try! SettingsConfig.settingsSlidingExpirationConfigTypeError.getConfig()
 
         XCTAssertNotNil(config.operations)
         XCTAssertNotNil(config.ttl)
 
-        XCTAssertNil(config.slidingExpiration, "SlidingExpiration должен быть `nil`, если поле `inappSession` имеет неверный тип")
-        XCTAssertNil(config.slidingExpiration?.inappSession)
+        XCTAssertNil(config.slidingExpiration, "SlidingExpiration должен быть `nil`, если поле `config` имеет неверный тип")
+        XCTAssertNil(config.slidingExpiration?.config)
     }
 }

--- a/MindboxTests/ConfigParsing/Settings/SettingsJsonStubs/OperationsErrors/SettingsAllOperationsWithErrors.json
+++ b/MindboxTests/ConfigParsing/Settings/SettingsJsonStubs/OperationsErrors/SettingsAllOperationsWithErrors.json
@@ -16,5 +16,8 @@
   },
   "ttl": {
     "inapps": "1.00:00:00"
+  }, 
+  "slidingExpiration": {
+    "config": "0.00:00:23"
   }
 }

--- a/MindboxTests/ConfigParsing/Settings/SettingsJsonStubs/OperationsErrors/SettingsAllOperationsWithTypeErrors.json
+++ b/MindboxTests/ConfigParsing/Settings/SettingsJsonStubs/OperationsErrors/SettingsAllOperationsWithTypeErrors.json
@@ -10,5 +10,8 @@
   },
   "ttl": {
     "inapps": "1.00:00:00"
+  }, 
+  "slidingExpiration": {
+    "config": "0.00:00:23"
   }
 }

--- a/MindboxTests/ConfigParsing/Settings/SettingsJsonStubs/OperationsErrors/SettingsOperationsError.json
+++ b/MindboxTests/ConfigParsing/Settings/SettingsJsonStubs/OperationsErrors/SettingsOperationsError.json
@@ -16,5 +16,8 @@
   },
   "ttl": {
     "inapps": "1.00:00:00"
+  }, 
+  "slidingExpiration": {
+    "config": "0.00:00:23"
   }
 }

--- a/MindboxTests/ConfigParsing/Settings/SettingsJsonStubs/OperationsErrors/SettingsOperationsTypeError.json
+++ b/MindboxTests/ConfigParsing/Settings/SettingsJsonStubs/OperationsErrors/SettingsOperationsTypeError.json
@@ -6,5 +6,8 @@
   
   "ttl": {
     "inapps": "1.00:00:00"
+  }, 
+  "slidingExpiration": {
+    "config": "0.00:00:23"
   }
 }

--- a/MindboxTests/ConfigParsing/Settings/SettingsJsonStubs/OperationsErrors/SettingsOperationsViewCategoryAndSetCartError.json
+++ b/MindboxTests/ConfigParsing/Settings/SettingsJsonStubs/OperationsErrors/SettingsOperationsViewCategoryAndSetCartError.json
@@ -16,5 +16,8 @@
   },
   "ttl": {
     "inapps": "1.00:00:00"
+  }, 
+  "slidingExpiration": {
+    "config": "0.00:00:23"
   }
 }

--- a/MindboxTests/ConfigParsing/Settings/SettingsJsonStubs/OperationsErrors/SettingsOperationsViewCategoryAndSetCartSystemNameError.json
+++ b/MindboxTests/ConfigParsing/Settings/SettingsJsonStubs/OperationsErrors/SettingsOperationsViewCategoryAndSetCartSystemNameError.json
@@ -16,5 +16,8 @@
   },
   "ttl": {
     "inapps": "1.00:00:00"
+  }, 
+  "slidingExpiration": {
+    "config": "0.00:00:23"
   }
 }

--- a/MindboxTests/ConfigParsing/Settings/SettingsJsonStubs/OperationsErrors/SettingsOperationsViewCategoryAndSetCartSystemNameMixedError.json
+++ b/MindboxTests/ConfigParsing/Settings/SettingsJsonStubs/OperationsErrors/SettingsOperationsViewCategoryAndSetCartSystemNameMixedError.json
@@ -16,5 +16,8 @@
   },
   "ttl": {
     "inapps": "1.00:00:00"
+  }, 
+  "slidingExpiration": {
+    "config": "0.00:00:23"
   }
 }

--- a/MindboxTests/ConfigParsing/Settings/SettingsJsonStubs/OperationsErrors/SettingsOperationsViewCategoryAndSetCartSystemNameTypeError.json
+++ b/MindboxTests/ConfigParsing/Settings/SettingsJsonStubs/OperationsErrors/SettingsOperationsViewCategoryAndSetCartSystemNameTypeError.json
@@ -16,5 +16,8 @@
   },
   "ttl": {
     "inapps": "1.00:00:00"
+  }, 
+  "slidingExpiration": {
+    "config": "0.00:00:23"
   }
 }

--- a/MindboxTests/ConfigParsing/Settings/SettingsJsonStubs/OperationsErrors/SettingsOperationsViewCategoryAndSetCartTypeError.json
+++ b/MindboxTests/ConfigParsing/Settings/SettingsJsonStubs/OperationsErrors/SettingsOperationsViewCategoryAndSetCartTypeError.json
@@ -12,5 +12,8 @@
   },
   "ttl": {
     "inapps": "1.00:00:00"
+  }, 
+  "slidingExpiration": {
+    "config": "0.00:00:23"
   }
 }

--- a/MindboxTests/ConfigParsing/Settings/SettingsJsonStubs/OperationsErrors/SettingsOperationsViewProductError.json
+++ b/MindboxTests/ConfigParsing/Settings/SettingsJsonStubs/OperationsErrors/SettingsOperationsViewProductError.json
@@ -16,5 +16,8 @@
   },
   "ttl": {
     "inapps": "1.00:00:00"
+  }, 
+  "slidingExpiration": {
+    "config": "0.00:00:23"
   }
 }

--- a/MindboxTests/ConfigParsing/Settings/SettingsJsonStubs/OperationsErrors/SettingsOperationsViewProductSystemNameError.json
+++ b/MindboxTests/ConfigParsing/Settings/SettingsJsonStubs/OperationsErrors/SettingsOperationsViewProductSystemNameError.json
@@ -16,5 +16,8 @@
   },
   "ttl": {
     "inapps": "1.00:00:00"
+  }, 
+  "slidingExpiration": {
+    "config": "0.00:00:23"
   }
 }

--- a/MindboxTests/ConfigParsing/Settings/SettingsJsonStubs/OperationsErrors/SettingsOperationsViewProductSystemNameTypeError.json
+++ b/MindboxTests/ConfigParsing/Settings/SettingsJsonStubs/OperationsErrors/SettingsOperationsViewProductSystemNameTypeError.json
@@ -16,5 +16,8 @@
   },
   "ttl": {
     "inapps": "1.00:00:00"
+  }, 
+  "slidingExpiration": {
+    "config": "0.00:00:23"
   }
 }

--- a/MindboxTests/ConfigParsing/Settings/SettingsJsonStubs/OperationsErrors/SettingsOperationsViewProductTypeError.json
+++ b/MindboxTests/ConfigParsing/Settings/SettingsJsonStubs/OperationsErrors/SettingsOperationsViewProductTypeError.json
@@ -14,5 +14,8 @@
   },
   "ttl": {
     "inapps": "1.00:00:00"
+  }, 
+  "slidingExpiration": {
+    "config": "0.00:00:23"
   }
 }

--- a/MindboxTests/ConfigParsing/Settings/SettingsJsonStubs/SettingsConfig.json
+++ b/MindboxTests/ConfigParsing/Settings/SettingsJsonStubs/SettingsConfig.json
@@ -12,5 +12,8 @@
   },
   "ttl": {
     "inapps": "1.00:00:00"
+  }, 
+  "slidingExpiration": {
+    "config": "0.00:00:23"
   }
 }

--- a/MindboxTests/ConfigParsing/Settings/SettingsJsonStubs/SlidingExpirationsError/SettingsSlidingExpirationConfigError.json
+++ b/MindboxTests/ConfigParsing/Settings/SettingsJsonStubs/SlidingExpirationsError/SettingsSlidingExpirationConfigError.json
@@ -14,6 +14,6 @@
         "inapps": "2.00:00:00"
     },
     "slidingExpiration": {
-        "inappSession": 123
+        "configTest": "2.00:00:00"
     }
 }

--- a/MindboxTests/ConfigParsing/Settings/SettingsJsonStubs/SlidingExpirationsError/SettingsSlidingExpirationConfigTypeError.json
+++ b/MindboxTests/ConfigParsing/Settings/SettingsJsonStubs/SlidingExpirationsError/SettingsSlidingExpirationConfigTypeError.json
@@ -14,6 +14,6 @@
         "inapps": "2.00:00:00"
     },
     "slidingExpiration": {
-        "inappSessionTest": "2.00:00:00"
+        "config": 123
     }
 }

--- a/MindboxTests/ConfigParsing/Settings/SettingsJsonStubs/SlidingExpirationsError/SettingsSlidingExpirationError.json
+++ b/MindboxTests/ConfigParsing/Settings/SettingsJsonStubs/SlidingExpirationsError/SettingsSlidingExpirationError.json
@@ -14,6 +14,6 @@
         "inapps": "2.00:00:00"
     },
     "slidingExpirationTest": {
-        "inappSession": "2.00:00:00"
+        "config": "2.00:00:00"
     }
 }

--- a/MindboxTests/ConfigParsing/Settings/SettingsJsonStubs/TtlErrors/SettingsTtlError.json
+++ b/MindboxTests/ConfigParsing/Settings/SettingsJsonStubs/TtlErrors/SettingsTtlError.json
@@ -16,5 +16,8 @@
       
       
     "inapps": "1.00:00:00"
+  }, 
+  "slidingExpiration": {
+    "config": "0.00:00:23"
   }
 }

--- a/MindboxTests/ConfigParsing/Settings/SettingsJsonStubs/TtlErrors/SettingsTtlInappsError.json
+++ b/MindboxTests/ConfigParsing/Settings/SettingsJsonStubs/TtlErrors/SettingsTtlInappsError.json
@@ -16,5 +16,8 @@
     "inappsTest": "1.00:00:00"
     
     
+  }, 
+  "slidingExpiration": {
+    "config": "0.00:00:23"
   }
 }

--- a/MindboxTests/ConfigParsing/Settings/SettingsJsonStubs/TtlErrors/SettingsTtlInappsTypeError.json
+++ b/MindboxTests/ConfigParsing/Settings/SettingsJsonStubs/TtlErrors/SettingsTtlInappsTypeError.json
@@ -16,5 +16,8 @@
     "inapps": 123
     
     
+  }, 
+  "slidingExpiration": {
+    "config": "0.00:00:23"
   }
 }

--- a/MindboxTests/ConfigParsing/Settings/SettingsJsonStubs/TtlErrors/SettingsTtlTypeError.json
+++ b/MindboxTests/ConfigParsing/Settings/SettingsJsonStubs/TtlErrors/SettingsTtlTypeError.json
@@ -12,7 +12,11 @@
   },
   
   
-  "ttl": 123
+  "ttl": 123, 
+  
+  "slidingExpiration": {
+    "config": "0.00:00:23"
+  }
   
   
 }

--- a/MindboxTests/InApp/Tests/InappSessionManagerTests/InappSessionManagerTests.swift
+++ b/MindboxTests/InApp/Tests/InappSessionManagerTests/InappSessionManagerTests.swift
@@ -22,13 +22,13 @@ final class InappSessionManagerTests: XCTestCase {
         coreManagerMock = DI.injectOrFail(InAppCoreManagerProtocol.self) as? InAppCoreManagerMock
         persistenceStorage = DI.injectOrFail(PersistenceStorage.self)
         targetingChecker = DI.injectOrFail(InAppTargetingCheckerProtocol.self)
-        SessionTemporaryStorage.shared.expiredInappSession = ""
+        SessionTemporaryStorage.shared.expiredConfigSession = ""
     }
 
     override func tearDown() {
         manager = nil
         coreManagerMock = nil
-        SessionTemporaryStorage.shared.expiredInappSession = nil
+        SessionTemporaryStorage.shared.expiredConfigSession = nil
         super.tearDown()
     }
 
@@ -42,7 +42,7 @@ final class InappSessionManagerTests: XCTestCase {
         manager.lastTrackVisitTimestamp = Date().addingTimeInterval(-100)
         let oldTimestamp = manager.lastTrackVisitTimestamp
 
-        SessionTemporaryStorage.shared.expiredInappSession = nil
+        SessionTemporaryStorage.shared.expiredConfigSession = nil
 
         manager.checkInappSession()
 
@@ -58,7 +58,7 @@ final class InappSessionManagerTests: XCTestCase {
         manager.lastTrackVisitTimestamp = Date().addingTimeInterval(-100)
         let oldTimestamp = manager.lastTrackVisitTimestamp
 
-        SessionTemporaryStorage.shared.expiredInappSession = "0.00:00:00.0000000"
+        SessionTemporaryStorage.shared.expiredConfigSession = "0.00:00:00.0000000"
 
         manager.checkInappSession()
 
@@ -74,7 +74,7 @@ final class InappSessionManagerTests: XCTestCase {
         manager.lastTrackVisitTimestamp = Date().addingTimeInterval(-100)
         let oldTimestamp = manager.lastTrackVisitTimestamp
 
-        SessionTemporaryStorage.shared.expiredInappSession = "-0.00:00:01.0000000"
+        SessionTemporaryStorage.shared.expiredConfigSession = "-0.00:00:01.0000000"
 
         manager.checkInappSession()
 
@@ -90,7 +90,7 @@ final class InappSessionManagerTests: XCTestCase {
         manager.lastTrackVisitTimestamp = Date().addingTimeInterval(-100)
         let oldTimestamp = manager.lastTrackVisitTimestamp
 
-        SessionTemporaryStorage.shared.expiredInappSession = "100"
+        SessionTemporaryStorage.shared.expiredConfigSession = "100"
 
         manager.checkInappSession()
 
@@ -107,7 +107,7 @@ final class InappSessionManagerTests: XCTestCase {
         manager.lastTrackVisitTimestamp = now.addingTimeInterval(-2400)
         let oldTimestamp = manager.lastTrackVisitTimestamp
 
-        SessionTemporaryStorage.shared.expiredInappSession = "0.00:59:00.0000000"
+        SessionTemporaryStorage.shared.expiredConfigSession = "0.00:59:00.0000000"
 
         manager.checkInappSession()
 
@@ -123,7 +123,7 @@ final class InappSessionManagerTests: XCTestCase {
         manager.lastTrackVisitTimestamp = Date().addingTimeInterval(-2400)
         let oldTimestamp = manager.lastTrackVisitTimestamp
 
-        SessionTemporaryStorage.shared.expiredInappSession = "0.00:30:00.0000000"
+        SessionTemporaryStorage.shared.expiredConfigSession = "0.00:30:00.0000000"
 
         manager.checkInappSession()
 
@@ -140,7 +140,7 @@ final class InappSessionManagerTests: XCTestCase {
         manager.lastTrackVisitTimestamp = now.addingTimeInterval(-2400)
         let oldUserVisitCount = persistenceStorage.userVisitCount
 
-        SessionTemporaryStorage.shared.expiredInappSession = "0.00:59:00.0000000"
+        SessionTemporaryStorage.shared.expiredConfigSession = "0.00:59:00.0000000"
         
         manager.checkInappSession()
         XCTAssertEqual(persistenceStorage.userVisitCount, oldUserVisitCount)
@@ -151,7 +151,7 @@ final class InappSessionManagerTests: XCTestCase {
 
         let oldUserVisitCount = persistenceStorage.userVisitCount
 
-        SessionTemporaryStorage.shared.expiredInappSession = "0.00:30:00.0000000"
+        SessionTemporaryStorage.shared.expiredConfigSession = "0.00:30:00.0000000"
 
         manager.checkInappSession()
         XCTAssertNotEqual(persistenceStorage.userVisitCount, oldUserVisitCount)
@@ -162,7 +162,7 @@ final class InappSessionManagerTests: XCTestCase {
     
     func test_sessionUpdate_ResetStorages() {
         manager.lastTrackVisitTimestamp = Date().addingTimeInterval(-2400)
-        SessionTemporaryStorage.shared.expiredInappSession = "0.00:30:00.0000000"
+        SessionTemporaryStorage.shared.expiredConfigSession = "0.00:30:00.0000000"
 
         SessionTemporaryStorage.shared.observedCustomOperations = ["Test"]
         SessionTemporaryStorage.shared.operationsFromSettings = ["Test2"]


### PR DESCRIPTION
[[iOS]: Поддержать изменение контракта в секции slidingExpiration](https://tracker.yandex.ru/WMSDK-411)

[Previous Pull Request](https://github.com/mindbox-cloud/ios-sdk/pull/496/files)

Основные изменения в 
`Mindbox/InAppMessages/Configuration/InAppConfigurationManager.swift`
`Mindbox/InAppMessages/Models/Config/SlidingExpirationModel.swift`
Остальное в конфигах тестов и самих тестах. Где-то добавил проверки парсинга.