### PR TITLE
WMSDK-447: Keepalive

### DIFF
--- a/Mindbox/CoreController/CoreController.swift
+++ b/Mindbox/CoreController/CoreController.swift
@@ -339,7 +339,7 @@ private extension CoreController {
         
         Logger.common(
             message: """
-              [Keepalive] Last sent: \(lastDate.toFullString()), \
+              [Keepalive] Last lastInfoUpdateDate: \(lastDate.toFullString()), \
               earliest next send allowed from: \(thresholdDate.toFullString()), \
               elapsed: \(Int(elapsed))s, \
               required: \(Int(interval))s, \


### PR DESCRIPTION
[WMSDK-447: [iOS] Отправка токена в операции по расписанию из конфига](https://tracker.yandex.ru/WMSDK-447)

[Закрыл тестом кейс отсюда](https://github.com/mindbox-cloud/ios-sdk/pull/538) и исправил лог