### PR TITLE
WMSDK-468 VisitTargeting > 0

### DIFF
--- a/Mindbox/InAppMessages/Configuration/API/Targetings/VisitTargeting.swift
+++ b/Mindbox/InAppMessages/Configuration/API/Targetings/VisitTargeting.swift
@@ -24,8 +24,8 @@ struct VisitTargeting: ITargeting, Decodable {
         kind = try container.decode(VisitTargetingKindType.self, forKey: .kind)
         value = try container.decode(Int.self, forKey: .value)
     
-        guard value >= 0 else {
-            throw DecodingError.dataCorruptedError(forKey: .value, in: container, debugDescription: "VisitTargeting value must be >= 0")
+        guard value > 0 else {
+            throw DecodingError.dataCorruptedError(forKey: .value, in: container, debugDescription: "VisitTargeting value must be > 0")
         }
     }
     

--- a/MindboxTests/InApp/Tests/InAppResponseModelTests/InAppResponseModelTests.swift
+++ b/MindboxTests/InApp/Tests/InAppResponseModelTests/InAppResponseModelTests.swift
@@ -94,7 +94,7 @@ final class InAppResponseModelTests: XCTestCase {
 
         XCTAssertNotNil(config)
         XCTAssertEqual(config.kind, .equals)
-        XCTAssertEqual(config.value, 0)
+        XCTAssertEqual(config.value, 1)
     }
     
     func test_visit_targeting_negativeValue_false() throws {

--- a/MindboxTests/InApp/Tests/InAppResponseModelTests/JSONStubs/VisitTargetingModelValid.json
+++ b/MindboxTests/InApp/Tests/InAppResponseModelTests/JSONStubs/VisitTargetingModelValid.json
@@ -1,5 +1,5 @@
 {
     "$type": "visit",
     "kind": "equals",
-    "value": 0
+    "value": 1
 }


### PR DESCRIPTION
[WMSDK-468: [Bug] [iOS] При невалидном значении все равно обрабатываем инаппы/абтесты](https://tracker.yandex.ru/WMSDK-468)