### PR TITLE
Update SwiftLint

### DIFF
--- a/.github/workflows/linter_and_unit_tests.yml
+++ b/.github/workflows/linter_and_unit_tests.yml
@@ -13,12 +13,12 @@ on:
       
 jobs:
   SwiftLint:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/realm/swiftlint:latest
     steps:
     - uses: actions/checkout@v4
-    - uses: cirruslabs/swiftlint-action@v1
-      with:
-        args: --config .swiftlint.yml
+    - run: swiftlint --config .swiftlint.yml --reporter github-actions-logging --strict
 
   build:
     runs-on: macos-15

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -6,6 +6,7 @@ included: # paths to include during linting. `--path` is ignored if present.
 excluded: # paths to ignore during linting. Takes precedence over `included`.
 
 only_rules: # default rules
+  - blanket_disable_command
   - closing_brace
   - closure_parameter_position
   - colon

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -60,7 +60,7 @@ only_rules: # default rules
   - reduce_boolean
   - redundant_discardable_let
   - redundant_objc_attribute
-  - redundant_optional_initialization
+  - implicit_optional_initialization
   - redundant_set_access_control
   - redundant_string_enum_value
   - redundant_void_return

--- a/Mindbox/Mindbox.swift
+++ b/Mindbox/Mindbox.swift
@@ -10,8 +10,6 @@ import Foundation
 import UIKit
 import MindboxLogger
 
-// swiftlint:disable line_length
-
 @objcMembers
 public class Mindbox: NSObject {
     /**
@@ -59,6 +57,9 @@ public class Mindbox: NSObject {
         }
     }
 
+    // TODO: Remove after the resolution of https://github.com/realm/SwiftLint/issues/6219
+    // swiftlint:disable line_length
+    
     /**
      A delegate for handling in-app messages.
 
@@ -74,6 +75,7 @@ public class Mindbox: NSObject {
             inappScheduleManager?.delegate = inAppMessagesDelegate
         }
     }
+    // swiftlint:enable line_length
 
     /**
      Method to instruct sdk of its initialization.
@@ -529,6 +531,9 @@ public class Mindbox: NSObject {
         return pushValidator.isValid(item: userInfo)
     }
 
+    // TODO: Remove after the resolution of https://github.com/realm/SwiftLint/issues/6219
+    // swiftlint:disable line_length
+    
     /**
      Converts a `UNNotification` to a `MBPushNotification` model for Mindbox push notifications.
 
@@ -543,6 +548,7 @@ public class Mindbox: NSObject {
     public func getMindboxPushData(userInfo: [AnyHashable: Any]) -> MBPushNotification? {
         return NotificationFormatter.formatNotification(userInfo)
     }
+    // swiftlint:enable line_length
 
     private var initError: Error?
 

--- a/Mindbox/Mindbox.swift
+++ b/Mindbox/Mindbox.swift
@@ -10,6 +10,8 @@ import Foundation
 import UIKit
 import MindboxLogger
 
+// swiftlint:disable line_length
+
 @objcMembers
 public class Mindbox: NSObject {
     /**

--- a/Mindbox/Model/Helpers/SwiftyJSON.swift
+++ b/Mindbox/Model/Helpers/SwiftyJSON.swift
@@ -1284,7 +1284,7 @@ extension JSON: Codable {
             Double.self,
             String.self,
             [JSON].self,
-            [String: JSON].self
+            [String: JSON].self,
         ]
     }
 

--- a/Mindbox/Model/Helpers/SwiftyJSON.swift
+++ b/Mindbox/Model/Helpers/SwiftyJSON.swift
@@ -27,7 +27,6 @@ import MindboxLogger
 
 // MARK: - Error
 
-// swiftlint:disable line_length
 public enum SwiftyJSONError: Int, Swift.Error {
     case unsupportedType = 999
     case indexOutOfBounds = 900
@@ -1285,7 +1284,7 @@ extension JSON: Codable {
             Double.self,
             String.self,
             [JSON].self,
-            [String: JSON].self,
+            [String: JSON].self
         ]
     }
 
@@ -1377,3 +1376,4 @@ extension JSON: Codable {
         }
     }
 }
+// swiftlint:enable all

--- a/Mindbox/Utilities/String+Regex.swift
+++ b/Mindbox/Utilities/String+Regex.swift
@@ -8,8 +8,6 @@
 
 import Foundation
 
-// swiftlint:disable force_unwrapping
-
 extension String {
     var operationNameIsValid: Bool {
         let range = NSRange(location: 0, length: self.utf16.count)
@@ -32,12 +30,14 @@ extension String {
         let secondsRange = Range(match.range(at: 6), in: self)
         let fractionRange = Range(match.range(at: 8), in: self)
 
+        // swiftlint:disable force_unwrapping
         let sign = signRange != nil ? String(self[signRange!]) : ""
         let days = daysRange != nil ? String(self[daysRange!]) : "0"
         let hours = hoursRange != nil ? String(self[hoursRange!]) : "0"
         let minutes = minutesRange != nil ? String(self[minutesRange!]) : "0"
         let seconds = secondsRange != nil ? String(self[secondsRange!]) : "0"
         let fraction = fractionRange != nil ? String(self[fractionRange!]) : "0"
+        // swiftlint:enable force_unwrapping
 
         let daysCorrected = days.isEmpty ? "0" : days
         let fractionCorrected = fraction.isEmpty ? "0" : fraction

--- a/Mindbox/Validators/URLValidator.swift
+++ b/Mindbox/Validators/URLValidator.swift
@@ -9,12 +9,12 @@
 import Foundation
 
 // FIXME: Rewrite this struct in the future
-// swiftlint:disable line_length force_try
 
 struct URLValidator {
 
     let url: URL
 
+    // swiftlint:disable:next line_length
     let urlPattern = "^(http|https|ftp)\\://([a-zA-Z0-9\\.\\-]+(\\:[a-zA-Z0-9\\.&amp;%\\$\\-]+)*@)*((25[0-5]|2[0-4][0-9]|[0-1]{1}[0-9]{2}|[1-9]{1}[0-9]{1}|[1-9])\\.(25[0-5]|2[0-4][0-9]|[0-1]{1}[0-9]{2}|[1-9]{1}[0-9]{1}|[1-9]|0)\\.(25[0-5]|2[0-4][0-9]|[0-1]{1}[0-9]{2}|[1-9]{1}[0-9]{1}|[1-9]|0)\\.(25[0-5]|2[0-4][0-9]|[0-1]{1}[0-9]{2}|[1-9]{1}[0-9]{1}|[0-9])|localhost|([a-zA-Z0-9\\-]+\\.)*[a-zA-Z0-9\\-]+\\.(com|cloud|edu|gov|int|mil|net|org|biz|arpa|info|name|pro|aero|coop|museum|tech|[a-zA-Z]{2}))(\\:[0-9]+)*(/($|[a-zA-Z0-9\\.\\,\\?\\'\\\\\\+&amp;%\\$#\\=~_\\-]+))*$"
 
     func evaluate() -> Bool {
@@ -22,7 +22,7 @@ struct URLValidator {
     }
 
     private func matches(string: String, pattern: String) -> Bool {
-        let regex = try! NSRegularExpression(
+        let regex = try! NSRegularExpression( // swiftlint:disable:this force_try
             pattern: pattern,
             options: [.caseInsensitive])
         return regex.firstMatch(

--- a/MindboxLogger/Shared/Extensions/NSManagedObjectContext+Extension.swift
+++ b/MindboxLogger/Shared/Extensions/NSManagedObjectContext+Extension.swift
@@ -9,8 +9,6 @@
 import Foundation
 import CoreData
 
-// swiftlint:disable force_unwrapping
-
 public extension NSManagedObjectContext {
 
     func executePerformAndWait<T>(_ block: () throws -> T) rethrows -> T {
@@ -49,7 +47,7 @@ public extension NSManagedObjectContext {
         if let e = error {
             return try rescue(e)
         } else {
-            return result!
+            return result! // swiftlint:disable:this force_unwrapping
         }
     }
 }


### PR DESCRIPTION
Use a [Docker container](https://github.com/realm/SwiftLint?tab=readme-ov-file#docker) to fix SwiftLint (14 seconds and without downloading the container - [example with downloading 623.12MB data](https://github.com/mindbox-cloud/ios-sdk/actions/runs/17372380967/job/49310935745)). 
Set the linter to strict.
Fix the deprecated rule. 
```
warning: 'redundant_optional_initialization' has been renamed to 'implicit_optional_initialization' and will be completely removed in a future release.
```

[Example PR](https://github.com/mindbox-cloud/ios-sdk/pull/590)

Root Cause - [SwiftLint 0.60.0](https://newreleases.io/project/github/realm/SwiftLint/release/0.60.0?utm_source=chatgpt.com). `The swiftlint_linux.zip release archive
has been renamed to swiftlint_linux_amd64.zip.` ([Issue](https://github.com/cirruslabs/swiftlint-action/issues/112))

---

Add [`blanket_disable_command` rule](https://realm.github.io/SwiftLint/blanket_disable_command.html). Fix warnings and errors.