### PR TITLE
позволяет использовать appGroup отличную от дефолтной

### DIFF
--- a/Mindbox/Utilities/UtilitiesFetcher/MBUtilitiesFetcher.swift
+++ b/Mindbox/Utilities/UtilitiesFetcher/MBUtilitiesFetcher.swift
@@ -30,6 +30,17 @@ class MBUtilitiesFetcher: UtilitiesFetcher {
     }()
 
     var applicationGroupIdentifier: String {
+        if let groups = Bundle.main.object(forInfoDictionaryKey: "com.apple.security.application-groups") as? [String],
+            let first = groups.first,
+               !first.isEmpty,
+               FileManager.default.containerURL(forSecurityApplicationGroupIdentifier: first) != nil {
+                return first
+            }
+            if let explicit = Bundle.main.object(forInfoDictionaryKey: "MindboxApplicationGroup") as? String,
+               !explicit.isEmpty,
+               FileManager.default.containerURL(forSecurityApplicationGroupIdentifier: explicit) != nil {
+            return explicit
+        }
         guard let hostApplicationName = hostApplicationName else {
             fatalError("CFBundleShortVersionString not found for host app")
         }

--- a/MindboxLogger/Shared/Extensions/MBLoggerUtilitiesFetcher.swift
+++ b/MindboxLogger/Shared/Extensions/MBLoggerUtilitiesFetcher.swift
@@ -17,6 +17,17 @@ class MBLoggerUtilitiesFetcher {
     }()
 
     var applicationGroupIdentifier: String {
+        if let groups = Bundle.main.object(forInfoDictionaryKey: "com.apple.security.application-groups") as? [String],
+            let first = groups.first,
+               !first.isEmpty,
+               FileManager.default.containerURL(forSecurityApplicationGroupIdentifier: first) != nil {
+                return first
+            }
+            if let explicit = Bundle.main.object(forInfoDictionaryKey: "MindboxApplicationGroup") as? String,
+               !explicit.isEmpty,
+               FileManager.default.containerURL(forSecurityApplicationGroupIdentifier: explicit) != nil {
+            return explicit
+        }
         guard let hostApplicationName = hostApplicationName else {
             fatalError("CFBundleShortVersionString not found for host app")
         }


### PR DESCRIPTION
После переноса приложения из аккаунта старого разработчика в наш аккаунт уперлись в то, что не можем в кабинете разработчика эпд создать апп групп, которая будет соответствовать дефолтному неймингу сдк.
правка позволяет использовать группу с другим именем 