### PR TITLE
MOBILEWEBVIEW-23: Fix crashes from uncalled WebKit completion handlers

### DIFF
--- a/Mindbox/InAppMessages/Presentation/Views/WebView/Bridge/MindboxWebBridge.swift
+++ b/Mindbox/InAppMessages/Presentation/Views/WebView/Bridge/MindboxWebBridge.swift
@@ -131,7 +131,11 @@ extension MindboxWebBridge: WKNavigationDelegate {
     public func webView(_ webView: WKWebView,
                         decidePolicyFor navigationAction: WKNavigationAction,
                         decisionHandler: @escaping (WKNavigationActionPolicy) -> Void) {
-        navigationDelegate?.webBridge(self, decidePolicyFor: navigationAction.request.url, decisionHandler: decisionHandler)
+        if let navigationDelegate = navigationDelegate {
+            navigationDelegate.webBridge(self, decidePolicyFor: navigationAction.request.url, decisionHandler: decisionHandler)
+        } else {
+            decisionHandler(.allow)
+        }
     }
 }
 

--- a/Mindbox/InAppMessages/Presentation/Views/WebView/Debug/MindboxWebViewFacade.swift
+++ b/Mindbox/InAppMessages/Presentation/Views/WebView/Debug/MindboxWebViewFacade.swift
@@ -84,8 +84,13 @@ public final class MindboxWebViewFacade: MindboxInternalWebViewFacadeProtocol {
         bridge.updateContentURL(contentURL)
         
         fetchHTML(from: contentUrl) { [weak webView] html in
-            guard let webView else { return }
-            
+            guard let webView else {
+                DispatchQueue.main.async {
+                    onFailure()
+                }
+                return
+            }
+
             if let html {
                 DispatchQueue.main.async {
                     webView.loadHTMLString(html, baseURL: url)
@@ -135,7 +140,16 @@ public final class MindboxWebViewFacade: MindboxInternalWebViewFacadeProtocol {
 
     public func evaluateJavaScript(_ script: String, completion: @escaping (Result<Any?, Error>) -> Void) {
         DispatchQueue.main.async { [weak webView] in
-            guard let webView else { return }
+            guard let webView else {
+                let error = MindboxError.internalError(
+                    InternalError(
+                        errorKey: .general,
+                        reason: "WebView was deallocated before JavaScript execution"
+                    )
+                )
+                completion(.failure(error))
+                return
+            }
             webView.evaluateJavaScript(script) { result, error in
                 if let error {
                     completion(.failure(error))


### PR DESCRIPTION
- Always call `decisionHandler` in `decidePolicyFor`
- Call `completion` when `webView` is deallocated in `evaluateJavaScript`
- Call `onFailure` when `webView` is deallocated in `loadHTML`