### PR TITLE
MOBILE-72: Refactor HTTP response handling to prioritize HTTP status code

### DIFF
--- a/Mindbox.xcodeproj/project.pbxproj
+++ b/Mindbox.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		0A3D045A2BC6803E00E1FC52 /* ImageFormat.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A3D04592BC6803E00E1FC52 /* ImageFormat.swift */; };
 		0E7A224A082FA2DA35706CC7 /* MotionServiceResolvePositionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C8192B8B7043EF74D05B36B /* MotionServiceResolvePositionTests.swift */; };
 		0E7A224A082FA2DA35706CC8 /* MotionServiceShakeToEditTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C8192B8B7043EF74D05B36C /* MotionServiceShakeToEditTests.swift */; };
+		1E3BD63AB3F1521C253CB818 /* MBNetworkFetcherResponseHandlingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 97FEDDEB5F71A67F1C4C675F /* MBNetworkFetcherResponseHandlingTests.swift */; };
 		302E35788CBDA959283569F4 /* MotionServiceBehaviorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0DB93A7997961CA7C2BE917 /* MotionServiceBehaviorTests.swift */; };
 		313B233A25ADEA0F00A1CB72 /* Mindbox.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 313B233025ADEA0F00A1CB72 /* Mindbox.framework */; };
 		313B233F25ADEA0F00A1CB72 /* MindboxTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 313B233E25ADEA0F00A1CB72 /* MindboxTests.swift */; };
@@ -1054,6 +1055,7 @@
 		84FCD3B825CA109E00D1E574 /* MockNetworkFetcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockNetworkFetcher.swift; sourceTree = "<group>"; };
 		84FCD3BC25CA10F600D1E574 /* SuccessResponse.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = SuccessResponse.json; sourceTree = "<group>"; };
 		9778038796A8426ABDED1E97 /* FeatureTogglesModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeatureTogglesModel.swift; sourceTree = "<group>"; };
+		97FEDDEB5F71A67F1C4C675F /* MBNetworkFetcherResponseHandlingTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MBNetworkFetcherResponseHandlingTests.swift; sourceTree = "<group>"; };
 		9B24FAAB28C74B8300F10B5D /* InAppConfigurationRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InAppConfigurationRepository.swift; sourceTree = "<group>"; };
 		9B24FAAD28C74BA500F10B5D /* InAppCoreManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InAppCoreManager.swift; sourceTree = "<group>"; };
 		9B24FAB028C74BD200F10B5D /* InAppConfigurationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InAppConfigurationManager.swift; sourceTree = "<group>"; };
@@ -1613,6 +1615,7 @@
 				84DC49D525D185A600D5D758 /* Supporting Files */,
 				313B234025ADEA0F00A1CB72 /* Info.plist */,
 				73662EFB100A1A3520058D4E /* TrackVisitManager */,
+				64FD3F7576619DCF106D10B6 /* Network */,
 			);
 			path = MindboxTests;
 			sourceTree = "<group>";
@@ -2247,6 +2250,15 @@
 			children = (
 			);
 			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		64FD3F7576619DCF106D10B6 /* Network */ = {
+			isa = PBXGroup;
+			children = (
+				97FEDDEB5F71A67F1C4C675F /* MBNetworkFetcherResponseHandlingTests.swift */,
+			);
+			name = Network;
+			path = Network;
 			sourceTree = "<group>";
 		};
 		73662EFB100A1A3520058D4E /* TrackVisitManager */ = {
@@ -4709,6 +4721,7 @@
 				0E7A224A082FA2DA35706CC7 /* MotionServiceResolvePositionTests.swift in Sources */,
 				0E7A224A082FA2DA35706CC8 /* MotionServiceShakeToEditTests.swift in Sources */,
 				302E35788CBDA959283569F4 /* MotionServiceBehaviorTests.swift in Sources */,
+				1E3BD63AB3F1521C253CB818 /* MBNetworkFetcherResponseHandlingTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Mindbox/Network/Abstract/NetworkFetcher.swift
+++ b/Mindbox/Network/Abstract/NetworkFetcher.swift
@@ -21,7 +21,17 @@ protocol NetworkFetcher {
         route: Route,
         completion: @escaping ((Result<Void, MindboxError>) -> Void)
     )
-    
+
     /// Cancels all ongoing network tasks.
     func cancelAllTasks()
+}
+
+extension NetworkFetcher {
+    func request<T>(
+        type: T.Type,
+        route: Route,
+        completion: @escaping ((Result<T, MindboxError>) -> Void)
+    ) where T: Decodable {
+        request(type: type, route: route, needBaseResponse: true, completion: completion)
+    }
 }

--- a/Mindbox/Network/MBNetworkFetcher.swift
+++ b/Mindbox/Network/MBNetworkFetcher.swift
@@ -211,85 +211,128 @@ class MBNetworkFetcher: NetworkFetcher {
         needBaseResponse: Bool,
         completion: @escaping ((Result<Data, MindboxError>) -> Void)
     ) {
-        if context.statusCode == .serverError {
-            let body = String(data: data, encoding: .utf8)
-            completion(.failure(internalServerError(httpStatusCode: context.httpResponse.statusCode, networkTimeMs: context.networkTimeMs, responseBody: body)))
-            return
-        }
-
-        do {
-            try decodeResponseData(
+        switch context.statusCode {
+        case .success:
+            handleSuccessResponseData(
                 data,
                 context: context,
+                emptyData: emptyData,
                 needBaseResponse: needBaseResponse,
                 completion: completion
             )
-        } catch let decodingError {
-            handleDecodingError(
-                decodingError,
-                data: data,
+        case .clientError:
+            handleClientErrorResponseData(
+                data,
                 context: context,
-                emptyData: emptyData,
                 completion: completion
             )
+        case .serverError:
+            handleServerErrorResponseData(
+                data,
+                context: context,
+                completion: completion
+            )
+        case .redirection:
+            completion(.failure(.invalidResponse(context.response)))
         }
     }
 
-    private func decodeResponseData(
+    // MARK: - 2xx Success
+
+    private func handleSuccessResponseData(
         _ data: Data,
         context: ResponseContext,
+        emptyData: Bool,
         needBaseResponse: Bool,
         completion: @escaping ((Result<Data, MindboxError>) -> Void)
-    ) throws {
+    ) {
         if !needBaseResponse {
             completion(.success(data))
             return
         }
 
         let decoder = JSONDecoder()
-        // Decoding to structure with `status` field
-        let base = try decoder.decode(BaseResponse.self, from: data)
-        // Figure out what server returned
-        switch base.status {
-        case .success, .transactionAlreadyProcessed:
-            completion(.success(data))
-        case .validationError:
-            let error = try decoder.decode(ValidationError.self, from: data)
-            completion(.failure(.validationError(error)))
-        case .protocolError:
-            let error = try decoder.decode(ProtocolError.self, from: data)
-            completion(.failure(.protocolError(error)))
-        case .internalServerError:
-            let error = try decoder.decode(ProtocolError.self, from: data)
-            completion(.failure(.serverError(error)))
-        case .unknown:
-            completion(.failure(.invalidResponse(context.response)))
+        do {
+            let base = try decoder.decode(BaseResponse.self, from: data)
+            switch base.status {
+            case .success, .transactionAlreadyProcessed:
+                completion(.success(data))
+            case .validationError:
+                let error = try decoder.decode(ValidationError.self, from: data)
+                completion(.failure(.validationError(error)))
+            case .protocolError, .internalServerError, .unknown:
+                completion(.failure(.invalidResponse(context.response)))
+            }
+        } catch {
+            if emptyData {
+                completion(.success(data))
+            } else {
+                completion(.failure(.internalError(.init(errorKey: .parsing, rawError: error))))
+            }
         }
     }
 
-    private func handleDecodingError(
-        _ decodingError: Error,
-        data: Data,
+    // MARK: - 4xx Client Error
+
+    private func handleClientErrorResponseData(
+        _ data: Data,
         context: ResponseContext,
-        emptyData: Bool,
         completion: @escaping ((Result<Data, MindboxError>) -> Void)
     ) {
-        switch context.statusCode {
-        case .serverError:
-            let body = String(data: data, encoding: .utf8)
-            completion(.failure(internalServerError(httpStatusCode: context.httpResponse.statusCode, networkTimeMs: context.networkTimeMs, responseBody: body)))
-        default:
-            if emptyData {
-                completion(.success(data))
-            } else if context.httpResponse.statusCode == 404 {
+        let httpCode = context.httpResponse.statusCode
+        let decoder = JSONDecoder()
+
+        do {
+            let base = try decoder.decode(BaseResponse.self, from: data)
+            switch base.status {
+            case .protocolError:
+                let error = try decoder.decode(ProtocolError.self, from: data)
+                completion(.failure(.protocolError(error)))
+            case .validationError:
+                let error = try decoder.decode(ValidationError.self, from: data)
+                completion(.failure(.validationError(error)))
+            default:
+                completion(.failure(.protocolError(.init(
+                    status: .protocolError,
+                    errorMessage: "Client error",
+                    httpStatusCode: httpCode
+                ))))
+            }
+        } catch {
+            if httpCode == 404 {
                 completion(.failure(.protocolError(.init(
                     status: .protocolError,
                     errorMessage: "Invalid request url",
-                    httpStatusCode: context.httpResponse.statusCode
+                    httpStatusCode: httpCode
                 ))))
             } else {
-                completion(.failure(.internalError(.init(errorKey: .parsing, rawError: decodingError))))
+                completion(.failure(.protocolError(.init(
+                    status: .protocolError,
+                    errorMessage: "Client error",
+                    httpStatusCode: httpCode
+                ))))
             }
+        }
+    }
+
+    // MARK: - 5xx Server Error
+
+    private func handleServerErrorResponseData(
+        _ data: Data,
+        context: ResponseContext,
+        completion: @escaping ((Result<Data, MindboxError>) -> Void)
+    ) {
+        let decoder = JSONDecoder()
+        do {
+            let error = try decoder.decode(ProtocolError.self, from: data)
+            completion(.failure(.serverError(error)))
+        } catch {
+            let body = String(data: data, encoding: .utf8)
+            completion(.failure(internalServerError(
+                httpStatusCode: context.httpResponse.statusCode,
+                networkTimeMs: context.networkTimeMs,
+                responseBody: body
+            )))
         }
     }
 

--- a/Mindbox/NetworkRepository/Event/MBEventRepository.swift
+++ b/Mindbox/NetworkRepository/Event/MBEventRepository.swift
@@ -68,7 +68,7 @@ class MBEventRepository: EventRepository {
             deviceUUID: deviceUUID
         )
         let route = makeRoute(wrapper: wrapper)
-        fetcher.request(type: type, route: route, needBaseResponse: true, completion: { result in
+        fetcher.request(type: type, route: route, completion: { result in
             DispatchQueue.main.async {
                 switch result {
                 case let .failure(error):

--- a/MindboxTests/Network/MBNetworkFetcherResponseHandlingTests.swift
+++ b/MindboxTests/Network/MBNetworkFetcherResponseHandlingTests.swift
@@ -1,0 +1,400 @@
+//
+//  MBNetworkFetcherResponseHandlingTests.swift
+//  MindboxTests
+//
+//  Created on 2026-04-02.
+//
+
+import XCTest
+@testable import Mindbox
+
+final class MBNetworkFetcherResponseHandlingTests: XCTestCase {
+
+    // MARK: - Setup
+
+    private func makeFetcher() throws -> MBNetworkFetcher {
+        let persistenceStorage = MockPersistenceStorage()
+        persistenceStorage.configuration = try MBConfiguration(
+            endpoint: "test-endpoint",
+            domain: "api.mindbox.ru"
+        )
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [StubURLProtocol.self]
+        let session = URLSession(configuration: configuration)
+        return MBNetworkFetcher(persistenceStorage: persistenceStorage, session: session)
+    }
+
+    private func stubResponse(statusCode: Int, body: Data? = nil) {
+        StubURLProtocol.requestHandler = { request in
+            let response = try XCTUnwrap(
+                HTTPURLResponse(
+                    url: try XCTUnwrap(request.url),
+                    statusCode: statusCode,
+                    httpVersion: nil,
+                    headerFields: nil
+                )
+            )
+            return (response, body)
+        }
+    }
+
+    private func baseResponseData(status: String) -> Data {
+        // swiftlint:disable:next force_try
+        try! JSONSerialization.data(withJSONObject: ["status": status])
+    }
+
+    private func protocolErrorData(status: String, message: String, httpCode: Int) -> Data {
+        // swiftlint:disable:next force_try
+        try! JSONSerialization.data(withJSONObject: [
+            "status": status,
+            "errorMessage": message,
+            "httpStatusCode": httpCode
+        ])
+    }
+
+    private func validationErrorData() -> Data {
+        // swiftlint:disable:next force_try
+        try! JSONSerialization.data(withJSONObject: [
+            "status": "ValidationError",
+            "validationMessages": [
+                ["message": "Invalid email", "location": "/customer/email"]
+            ]
+        ])
+    }
+
+    // MARK: - 2xx + Success status → success
+
+    func test_http200_statusSuccess_returnsSuccess() throws {
+        let fetcher = try makeFetcher()
+        let body = baseResponseData(status: "Success")
+        stubResponse(statusCode: 200, body: body)
+
+        let expectation = expectation(description: "completion")
+        fetcher.request(route: FetchInAppGeoRoute()) { result in
+            switch result {
+            case .success:
+                break // expected
+            case .failure(let error):
+                XCTFail("Expected success, got \(error)")
+            }
+            expectation.fulfill()
+        }
+        waitForExpectations(timeout: 1)
+    }
+
+    // MARK: - 2xx + TransactionAlreadyProcessed → success
+
+    func test_http200_statusTransactionAlreadyProcessed_returnsSuccess() throws {
+        let fetcher = try makeFetcher()
+        let body = baseResponseData(status: "TransactionAlreadyProcessed")
+        stubResponse(statusCode: 200, body: body)
+
+        let expectation = expectation(description: "completion")
+        fetcher.request(route: FetchInAppGeoRoute()) { result in
+            switch result {
+            case .success:
+                break // expected
+            case .failure(let error):
+                XCTFail("Expected success, got \(error)")
+            }
+            expectation.fulfill()
+        }
+        waitForExpectations(timeout: 1)
+    }
+
+    // MARK: - 2xx + ValidationError → .validationError
+
+    func test_http200_statusValidationError_returnsValidationError() throws {
+        let fetcher = try makeFetcher()
+        let body = validationErrorData()
+        stubResponse(statusCode: 200, body: body)
+
+        let expectation = expectation(description: "completion")
+        fetcher.request(route: FetchInAppGeoRoute()) { result in
+            switch result {
+            case .success:
+                XCTFail("Expected validationError")
+            case .failure(let error):
+                guard case .validationError = error else {
+                    XCTFail("Expected validationError, got \(error)")
+                    expectation.fulfill()
+                    return
+                }
+            }
+            expectation.fulfill()
+        }
+        waitForExpectations(timeout: 1)
+    }
+
+    // MARK: - 4xx + status "Success" in body → protocolError (NOT success)
+
+    func test_http400_statusSuccess_returnsProtocolError() throws {
+        let fetcher = try makeFetcher()
+        let body = baseResponseData(status: "Success")
+        stubResponse(statusCode: 400, body: body)
+
+        let expectation = expectation(description: "completion")
+        fetcher.request(route: FetchInAppGeoRoute()) { result in
+            switch result {
+            case .success:
+                XCTFail("HTTP 400 with Success status should NOT be treated as success")
+            case .failure(let error):
+                guard case .protocolError = error else {
+                    XCTFail("Expected protocolError, got \(error)")
+                    expectation.fulfill()
+                    return
+                }
+            }
+            expectation.fulfill()
+        }
+        waitForExpectations(timeout: 1)
+    }
+
+    // MARK: - 400 + ProtocolError → .protocolError
+
+    func test_http400_statusProtocolError_returnsProtocolError() throws {
+        let fetcher = try makeFetcher()
+        let body = protocolErrorData(status: "ProtocolError", message: "Bad request", httpCode: 400)
+        stubResponse(statusCode: 400, body: body)
+
+        let expectation = expectation(description: "completion")
+        fetcher.request(route: FetchInAppGeoRoute()) { result in
+            switch result {
+            case .success:
+                XCTFail("Expected protocolError")
+            case .failure(let error):
+                guard case .protocolError(let pe) = error else {
+                    XCTFail("Expected protocolError, got \(error)")
+                    expectation.fulfill()
+                    return
+                }
+                XCTAssertEqual(pe.httpStatusCode, 400)
+                XCTAssertEqual(pe.errorMessage, "Bad request")
+            }
+            expectation.fulfill()
+        }
+        waitForExpectations(timeout: 1)
+    }
+
+    // MARK: - 404 with unparseable body → protocolError "Invalid request url"
+
+    func test_http404_unparseableBody_returnsProtocolErrorInvalidUrl() throws {
+        let fetcher = try makeFetcher()
+        let body = "not json".data(using: .utf8)
+        stubResponse(statusCode: 404, body: body)
+
+        let expectation = expectation(description: "completion")
+        fetcher.request(route: FetchInAppGeoRoute()) { result in
+            switch result {
+            case .success:
+                XCTFail("Expected protocolError for 404")
+            case .failure(let error):
+                guard case .protocolError(let pe) = error else {
+                    XCTFail("Expected protocolError, got \(error)")
+                    expectation.fulfill()
+                    return
+                }
+                XCTAssertEqual(pe.httpStatusCode, 404)
+                XCTAssertEqual(pe.errorMessage, "Invalid request url")
+            }
+            expectation.fulfill()
+        }
+        waitForExpectations(timeout: 1)
+    }
+
+    // MARK: - 429 + ProtocolError → .protocolError
+
+    func test_http429_statusProtocolError_returnsProtocolError() throws {
+        let fetcher = try makeFetcher()
+        let body = protocolErrorData(status: "ProtocolError", message: "Rate limit exceeded", httpCode: 429)
+        stubResponse(statusCode: 429, body: body)
+
+        let expectation = expectation(description: "completion")
+        fetcher.request(route: FetchInAppGeoRoute()) { result in
+            switch result {
+            case .success:
+                XCTFail("Expected protocolError")
+            case .failure(let error):
+                guard case .protocolError(let pe) = error else {
+                    XCTFail("Expected protocolError, got \(error)")
+                    expectation.fulfill()
+                    return
+                }
+                XCTAssertEqual(pe.httpStatusCode, 429)
+            }
+            expectation.fulfill()
+        }
+        waitForExpectations(timeout: 1)
+    }
+
+    // MARK: - 5xx + InternalServerError body → .serverError with decoded body
+
+    func test_http500_statusInternalServerError_returnsServerError() throws {
+        let fetcher = try makeFetcher()
+        let body = protocolErrorData(status: "InternalServerError", message: "Temporary unavailability", httpCode: 500)
+        stubResponse(statusCode: 500, body: body)
+
+        let expectation = expectation(description: "completion")
+        fetcher.request(route: FetchInAppGeoRoute()) { result in
+            switch result {
+            case .success:
+                XCTFail("Expected serverError")
+            case .failure(let error):
+                guard case .serverError(let pe) = error else {
+                    XCTFail("Expected serverError, got \(error)")
+                    expectation.fulfill()
+                    return
+                }
+                XCTAssertEqual(pe.httpStatusCode, 500)
+                XCTAssertEqual(pe.errorMessage, "Temporary unavailability")
+            }
+            expectation.fulfill()
+        }
+        waitForExpectations(timeout: 1)
+    }
+
+    // MARK: - 502 with no status body → .serverError (generic)
+
+    func test_http502_noStatusBody_returnsServerError() throws {
+        let fetcher = try makeFetcher()
+        let body = "Bad Gateway".data(using: .utf8)
+        stubResponse(statusCode: 502, body: body)
+
+        let expectation = expectation(description: "completion")
+        fetcher.request(route: FetchInAppGeoRoute()) { result in
+            switch result {
+            case .success:
+                XCTFail("Expected serverError")
+            case .failure(let error):
+                guard case .serverError(let pe) = error else {
+                    XCTFail("Expected serverError, got \(error)")
+                    expectation.fulfill()
+                    return
+                }
+                XCTAssertEqual(pe.httpStatusCode, 502)
+            }
+            expectation.fulfill()
+        }
+        waitForExpectations(timeout: 1)
+    }
+
+    // MARK: - 2xx + decode failure + emptyData → success
+
+    func test_http200_decodeFail_emptyDataTrue_returnsSuccess() throws {
+        let fetcher = try makeFetcher()
+        let body = "not json".data(using: .utf8)
+        stubResponse(statusCode: 200, body: body)
+
+        let expectation = expectation(description: "completion")
+        // Void request uses emptyData=true internally
+        fetcher.request(route: FetchInAppGeoRoute()) { result in
+            switch result {
+            case .success:
+                break // expected — emptyData=true swallows decode errors at 2xx
+            case .failure(let error):
+                XCTFail("Expected success with emptyData=true at 2xx, got \(error)")
+            }
+            expectation.fulfill()
+        }
+        waitForExpectations(timeout: 1)
+    }
+
+    // MARK: - needBaseResponse=false + HTTP 4xx → protocolError (NOT success)
+
+    func test_needBaseResponseFalse_http403_returnsProtocolError() throws {
+        let fetcher = try makeFetcher()
+        let body = "Forbidden".data(using: .utf8)
+        stubResponse(statusCode: 403, body: body)
+
+        let expectation = expectation(description: "completion")
+        fetcher.request(type: InAppGeoResponse.self, route: FetchInAppGeoRoute(), needBaseResponse: false) { result in
+            switch result {
+            case .success:
+                XCTFail("needBaseResponse=false + HTTP 403 should NOT be success")
+            case .failure(let error):
+                guard case .protocolError(let pe) = error else {
+                    XCTFail("Expected protocolError, got \(error)")
+                    expectation.fulfill()
+                    return
+                }
+                XCTAssertEqual(pe.httpStatusCode, 403)
+            }
+            expectation.fulfill()
+        }
+        waitForExpectations(timeout: 1)
+    }
+
+    // MARK: - needBaseResponse=false + HTTP 2xx → success
+
+    func test_needBaseResponseFalse_http200_returnsSuccess() throws {
+        let fetcher = try makeFetcher()
+        let model = InAppGeoResponse(city: 1, region: 2, country: 3)
+        let body = try JSONEncoder().encode(model)
+        stubResponse(statusCode: 200, body: body)
+
+        let expectation = expectation(description: "completion")
+        fetcher.request(type: InAppGeoResponse.self, route: FetchInAppGeoRoute(), needBaseResponse: false) { result in
+            switch result {
+            case .success(let response):
+                XCTAssertEqual(response.city, 1)
+            case .failure(let error):
+                XCTFail("Expected success, got \(error)")
+            }
+            expectation.fulfill()
+        }
+        waitForExpectations(timeout: 1)
+    }
+
+    // MARK: - 3xx → invalidResponse
+
+    func test_http301_returnsInvalidResponse() throws {
+        let fetcher = try makeFetcher()
+        let body = Data()
+        stubResponse(statusCode: 301, body: body)
+
+        let expectation = expectation(description: "completion")
+        fetcher.request(route: FetchInAppGeoRoute()) { result in
+            switch result {
+            case .success:
+                XCTFail("Expected invalidResponse for 3xx")
+            case .failure(let error):
+                guard case .invalidResponse = error else {
+                    XCTFail("Expected invalidResponse, got \(error)")
+                    expectation.fulfill()
+                    return
+                }
+            }
+            expectation.fulfill()
+        }
+        waitForExpectations(timeout: 1)
+    }
+}
+
+// MARK: - Stub URL Protocol
+
+private final class StubURLProtocol: URLProtocol {
+    static var requestHandler: ((URLRequest) throws -> (HTTPURLResponse, Data?))?
+
+    override class func canInit(with request: URLRequest) -> Bool { true }
+
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+        guard let handler = Self.requestHandler else {
+            client?.urlProtocol(self, didFailWithError: URLError(.badServerResponse))
+            return
+        }
+        do {
+            let (response, data) = try handler(request)
+            client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+            if let data = data {
+                client?.urlProtocol(self, didLoad: data)
+            }
+            client?.urlProtocolDidFinishLoading(self)
+        } catch {
+            client?.urlProtocol(self, didFailWithError: error)
+        }
+    }
+
+    override func stopLoading() {}
+}

--- a/MindboxTests/Network/MBNetworkFetcherResponseHandlingTests.swift
+++ b/MindboxTests/Network/MBNetworkFetcherResponseHandlingTests.swift
@@ -368,6 +368,302 @@ final class MBNetworkFetcherResponseHandlingTests: XCTestCase {
         }
         waitForExpectations(timeout: 1)
     }
+
+    // MARK: - 2xx + ProtocolError status in body → invalidResponse
+
+    func test_http200_statusProtocolError_returnsInvalidResponse() throws {
+        let fetcher = try makeFetcher()
+        let body = baseResponseData(status: "ProtocolError")
+        stubResponse(statusCode: 200, body: body)
+
+        let expectation = expectation(description: "completion")
+        fetcher.request(route: FetchInAppGeoRoute()) { result in
+            switch result {
+            case .success:
+                XCTFail("Expected invalidResponse for 2xx + ProtocolError status")
+            case .failure(let error):
+                guard case .invalidResponse = error else {
+                    XCTFail("Expected invalidResponse, got \(error)")
+                    expectation.fulfill()
+                    return
+                }
+            }
+            expectation.fulfill()
+        }
+        waitForExpectations(timeout: 1)
+    }
+
+    // MARK: - 2xx + InternalServerError status in body → invalidResponse
+
+    func test_http200_statusInternalServerError_returnsInvalidResponse() throws {
+        let fetcher = try makeFetcher()
+        let body = baseResponseData(status: "InternalServerError")
+        stubResponse(statusCode: 200, body: body)
+
+        let expectation = expectation(description: "completion")
+        fetcher.request(route: FetchInAppGeoRoute()) { result in
+            switch result {
+            case .success:
+                XCTFail("Expected invalidResponse for 2xx + InternalServerError status")
+            case .failure(let error):
+                guard case .invalidResponse = error else {
+                    XCTFail("Expected invalidResponse, got \(error)")
+                    expectation.fulfill()
+                    return
+                }
+            }
+            expectation.fulfill()
+        }
+        waitForExpectations(timeout: 1)
+    }
+
+    // MARK: - 2xx + unknown status in body → invalidResponse
+
+    func test_http200_statusUnknown_returnsInvalidResponse() throws {
+        let fetcher = try makeFetcher()
+        let body = baseResponseData(status: "SomethingUnexpected")
+        stubResponse(statusCode: 200, body: body)
+
+        let expectation = expectation(description: "completion")
+        fetcher.request(route: FetchInAppGeoRoute()) { result in
+            switch result {
+            case .success:
+                XCTFail("Expected invalidResponse for 2xx + unknown status")
+            case .failure(let error):
+                guard case .invalidResponse = error else {
+                    XCTFail("Expected invalidResponse, got \(error)")
+                    expectation.fulfill()
+                    return
+                }
+            }
+            expectation.fulfill()
+        }
+        waitForExpectations(timeout: 1)
+    }
+
+    // MARK: - 4xx + ValidationError status → .validationError
+
+    func test_http400_statusValidationError_returnsValidationError() throws {
+        let fetcher = try makeFetcher()
+        let body = validationErrorData()
+        stubResponse(statusCode: 400, body: body)
+
+        let expectation = expectation(description: "completion")
+        fetcher.request(route: FetchInAppGeoRoute()) { result in
+            switch result {
+            case .success:
+                XCTFail("Expected validationError")
+            case .failure(let error):
+                guard case .validationError = error else {
+                    XCTFail("Expected validationError, got \(error)")
+                    expectation.fulfill()
+                    return
+                }
+            }
+            expectation.fulfill()
+        }
+        waitForExpectations(timeout: 1)
+    }
+
+    // MARK: - 4xx (non-404) + unparseable body → protocolError "Client error"
+
+    func test_http400_unparseableBody_returnsProtocolErrorClientError() throws {
+        let fetcher = try makeFetcher()
+        let body = "not json".data(using: .utf8)
+        stubResponse(statusCode: 400, body: body)
+
+        let expectation = expectation(description: "completion")
+        fetcher.request(route: FetchInAppGeoRoute()) { result in
+            switch result {
+            case .success:
+                XCTFail("Expected protocolError for 400 + unparseable body")
+            case .failure(let error):
+                guard case .protocolError(let pe) = error else {
+                    XCTFail("Expected protocolError, got \(error)")
+                    expectation.fulfill()
+                    return
+                }
+                XCTAssertEqual(pe.httpStatusCode, 400)
+                XCTAssertEqual(pe.errorMessage, "Client error")
+            }
+            expectation.fulfill()
+        }
+        waitForExpectations(timeout: 1)
+    }
+
+    // MARK: - 403 + unparseable body → protocolError "Client error"
+
+    func test_http403_unparseableBody_returnsProtocolErrorClientError() throws {
+        let fetcher = try makeFetcher()
+        let body = "Forbidden".data(using: .utf8)
+        stubResponse(statusCode: 403, body: body)
+
+        let expectation = expectation(description: "completion")
+        fetcher.request(route: FetchInAppGeoRoute()) { result in
+            switch result {
+            case .success:
+                XCTFail("Expected protocolError for 403 + unparseable body")
+            case .failure(let error):
+                guard case .protocolError(let pe) = error else {
+                    XCTFail("Expected protocolError, got \(error)")
+                    expectation.fulfill()
+                    return
+                }
+                XCTAssertEqual(pe.httpStatusCode, 403)
+                XCTAssertEqual(pe.errorMessage, "Client error")
+            }
+            expectation.fulfill()
+        }
+        waitForExpectations(timeout: 1)
+    }
+
+    // MARK: - 5xx + empty body → .serverError
+
+    func test_http500_emptyBody_returnsServerError() throws {
+        let fetcher = try makeFetcher()
+        stubResponse(statusCode: 500, body: nil)
+
+        let expectation = expectation(description: "completion")
+        fetcher.request(route: FetchInAppGeoRoute()) { result in
+            switch result {
+            case .success:
+                XCTFail("Expected serverError for 500 + nil data")
+            case .failure(let error):
+                guard case .serverError(let pe) = error else {
+                    XCTFail("Expected serverError, got \(error)")
+                    expectation.fulfill()
+                    return
+                }
+                XCTAssertEqual(pe.httpStatusCode, 500)
+            }
+            expectation.fulfill()
+        }
+        waitForExpectations(timeout: 1)
+    }
+
+    // MARK: - 2xx + empty body + Void request (emptyData=true) → success
+
+    func test_http200_emptyBody_voidRequest_returnsSuccess() throws {
+        let fetcher = try makeFetcher()
+        stubResponse(statusCode: 200, body: nil)
+
+        let expectation = expectation(description: "completion")
+        fetcher.request(route: FetchInAppGeoRoute()) { result in
+            switch result {
+            case .success:
+                break // expected — emptyData=true at 2xx tolerates unparseable body
+            case .failure(let error):
+                XCTFail("Expected success for 200 + empty body + Void request, got \(error)")
+            }
+            expectation.fulfill()
+        }
+        waitForExpectations(timeout: 1)
+    }
+
+    // MARK: - 2xx + empty body + typed request (emptyData=false) → parsing error
+
+    func test_http200_emptyBody_typedRequest_returnsParsingError() throws {
+        let fetcher = try makeFetcher()
+        stubResponse(statusCode: 200, body: nil)
+
+        let expectation = expectation(description: "completion")
+        fetcher.request(type: InAppGeoResponse.self, route: FetchInAppGeoRoute()) { result in
+            switch result {
+            case .success:
+                XCTFail("Expected parsing error for 200 + empty body + typed request")
+            case .failure(let error):
+                guard case .internalError(let ie) = error else {
+                    XCTFail("Expected internalError(.parsing), got \(error)")
+                    expectation.fulfill()
+                    return
+                }
+                XCTAssertEqual(ie.errorKey, ErrorKey.parsing.rawValue)
+            }
+            expectation.fulfill()
+        }
+        waitForExpectations(timeout: 1)
+    }
+
+    // MARK: - 503 + parseable body → .serverError with decoded message
+
+    func test_http503_parseableBody_returnsServerErrorWithMessage() throws {
+        let fetcher = try makeFetcher()
+        let body = protocolErrorData(status: "InternalServerError", message: "Service Unavailable", httpCode: 503)
+        stubResponse(statusCode: 503, body: body)
+
+        let expectation = expectation(description: "completion")
+        fetcher.request(route: FetchInAppGeoRoute()) { result in
+            switch result {
+            case .success:
+                XCTFail("Expected serverError")
+            case .failure(let error):
+                guard case .serverError(let pe) = error else {
+                    XCTFail("Expected serverError, got \(error)")
+                    expectation.fulfill()
+                    return
+                }
+                XCTAssertEqual(pe.httpStatusCode, 503)
+                XCTAssertEqual(pe.errorMessage, "Service Unavailable")
+            }
+            expectation.fulfill()
+        }
+        waitForExpectations(timeout: 1)
+    }
+
+    // MARK: - Typed request + 200 + needBaseResponse=true + success body → decoded object
+
+    func test_typedRequest_http200_statusSuccess_returnsDecodedObject() throws {
+        let fetcher = try makeFetcher()
+        let responseBody: [String: Any] = [
+            "status": "Success",
+            "city_id": 10,
+            "region_id": 20,
+            "country_id": 30
+        ]
+        // swiftlint:disable:next force_try
+        let body = try! JSONSerialization.data(withJSONObject: responseBody)
+        stubResponse(statusCode: 200, body: body)
+
+        let expectation = expectation(description: "completion")
+        fetcher.request(type: InAppGeoResponse.self, route: FetchInAppGeoRoute()) { result in
+            switch result {
+            case .success(let response):
+                XCTAssertEqual(response.city, 10)
+                XCTAssertEqual(response.region, 20)
+                XCTAssertEqual(response.country, 30)
+            case .failure(let error):
+                XCTFail("Expected success, got \(error)")
+            }
+            expectation.fulfill()
+        }
+        waitForExpectations(timeout: 1)
+    }
+
+    // MARK: - Typed request + 200 + valid base response but invalid target type → parsing error
+
+    func test_typedRequest_http200_invalidTargetType_returnsParsingError() throws {
+        let fetcher = try makeFetcher()
+        // Valid base response but missing fields for InAppGeoResponse
+        let body = baseResponseData(status: "Success")
+        stubResponse(statusCode: 200, body: body)
+
+        let expectation = expectation(description: "completion")
+        fetcher.request(type: InAppGeoResponse.self, route: FetchInAppGeoRoute()) { result in
+            switch result {
+            case .success:
+                XCTFail("Expected parsing error for invalid target type")
+            case .failure(let error):
+                guard case .internalError(let ie) = error else {
+                    XCTFail("Expected internalError(.parsing), got \(error)")
+                    expectation.fulfill()
+                    return
+                }
+                XCTAssertEqual(ie.errorKey, ErrorKey.parsing.rawValue)
+            }
+            expectation.fulfill()
+        }
+        waitForExpectations(timeout: 1)
+    }
 }
 
 // MARK: - Stub URL Protocol


### PR DESCRIPTION
Ticket: https://tracker.yandex.ru/MOBILE-72

## Summary

Refactor network response handling to prioritize HTTP status code over body status field, preventing cases where 4xx/5xx responses with "Success" in body were incorrectly treated as successful.

## Type of Change

- [x] Refactor
- [x] Tests

## Changes

- Restructured `handleResponse` in `MBNetworkFetcher` into smaller focused methods: `makeResponseContext`, `handleResponseData`, and per-status-code-group handlers
- HTTP status code now determines the response handling path (2xx/3xx/4xx/5xx) before body parsing
- Added default parameter `needBaseResponse=true` via `NetworkFetcher` protocol extension to simplify call sites
- Simplified `MBEventRepository` call by using the new default parameter

## Testing

- [x] Unit tests added/updated
- 25 tests covering all HTTP status code groups (2xx, 3xx, 4xx, 5xx) combined with various body status values (Success, ProtocolError, ValidationError, InternalServerError, unknown, empty body, unparseable body)
- Key scenario tested: HTTP 4xx + "Success" body status → correctly returns protocolError (not success)