### PR TITLE
MOBILE-0000: Treat trunk 409 Conflict as success in pod push wrapper

### DIFF
--- a/.github/pod-trunk-push.sh
+++ b/.github/pod-trunk-push.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Wrapper around `pod trunk push` that treats a 409 Conflict
+# ("Unable to accept duplicate entry") from trunk as success.
+#
+# Why: trunk sometimes returns 504 Gateway Timeout while the spec
+# still lands in CocoaPods/Specs (Heroku 30s router cap on the
+# GitHub Commits API call). Without this wrapper, re-running the
+# failed publish job fails again with 409 "duplicate entry",
+# keeping the workflow red even though the release is actually done.
+
+set -uo pipefail
+
+if [ $# -lt 1 ]; then
+  echo "usage: $0 <Pod.podspec> [pod trunk push args...]" >&2
+  exit 64
+fi
+
+PODSPEC="$1"; shift
+
+set +e
+OUT="$(pod trunk push "$PODSPEC" "$@" 2>&1)"
+RC=$?
+set -e
+printf '%s\n' "$OUT"
+
+if [ "$RC" -eq 0 ]; then
+  exit 0
+fi
+
+if grep -qE 'HTTP/1\.[01] 409 Conflict|Unable to accept duplicate entry' <<<"$OUT"; then
+  echo "[pod-trunk-push] trunk returned 409 — version already published, treating as success"
+  exit 0
+fi
+
+exit "$RC"

--- a/.github/workflows/publish-reusable.yml
+++ b/.github/workflows/publish-reusable.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Deploy to Cocoapods MindboxLogger
         run: |
           pod lib lint MindboxLogger.podspec --allow-warnings
-          pod trunk push MindboxLogger.podspec --allow-warnings --verbose
+          ./.github/pod-trunk-push.sh MindboxLogger.podspec --allow-warnings --verbose
         env:
           COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TOKEN }}
           
@@ -103,7 +103,7 @@ jobs:
             pod repo update
             set -eo pipefail
             pod lib lint MindboxNotifications.podspec --allow-warnings
-            pod trunk push MindboxNotifications.podspec --allow-warnings --verbose
+            ./.github/pod-trunk-push.sh MindboxNotifications.podspec --allow-warnings --verbose
         env:
           COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TOKEN }}
           
@@ -130,7 +130,7 @@ jobs:
             pod repo update
             set -eo pipefail
             pod lib lint Mindbox.podspec --allow-warnings
-            pod trunk push Mindbox.podspec --allow-warnings --verbose
+            ./.github/pod-trunk-push.sh Mindbox.podspec --allow-warnings --verbose
         env:
           COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TOKEN }}
 


### PR DESCRIPTION
CocoaPods trunk sometimes returns 504 Gateway Timeout while the spec still lands in CocoaPods/Specs. Re-running the failed publish job then fails again with 409 "Unable to accept duplicate entry", keeping the release red even though it is actually done.

Wrap pod trunk push in .github/pod-trunk-push.sh and treat 409 as a successful no-op so a single re-run closes the release cleanly.