### PR TITLE
MOBILE-0000: Fix flaky InappScheduleManager delay-0 tests

### DIFF
--- a/MindboxTests/InApp/Tests/InappScheduleManagerTests.swift
+++ b/MindboxTests/InApp/Tests/InappScheduleManagerTests.swift
@@ -39,30 +39,30 @@ struct InappScheduleManagerTests {
 
     // MARK: - No delay
 
-    @Test("In-app without delay is scheduled and presented immediately", .tags(.inAppSchedule))
+    @Test("In-app without delay is presented exactly once and the queue is cleaned up", .tags(.inAppSchedule))
     func scheduleInapp_noDelay_schedulesCorrectly() {
         #expect(scheduleManager.inappsByPresentationTime.isEmpty)
+        #expect(scheduleManager.getDelay(nil) == 0)
 
         let inapp = createInAppFormData(id: "1", isPriority: false, delayTime: nil)
         scheduleManager.scheduleInApp(inapp, processingDuration: 0)
 
+        // delayTime == nil ⇒ delay 0, so the production DispatchSourceTimer is armed
+        // for `.now()` and can fire and present on its own the instant the host app is
+        // foregrounded, racing any "scheduled but not yet shown" inspection. That
+        // intermediate state is not observable here and contradicts the no-delay
+        // contract, so we assert only the deterministic end state. If the timer has not
+        // already presented (e.g. host app backgrounded), drive it manually — this is
+        // idempotent because showEligibleInapp removes the entry under `queue`, so the
+        // in-app is presented at most once whichever path wins.
         var presentationTime: TimeInterval?
-
         scheduleManager.queue.sync {
-            #expect(self.scheduleManager.inappsByPresentationTime.count == 1)
             presentationTime = self.scheduleManager.inappsByPresentationTime.keys.first
-
-            let storedInapp = self.scheduleManager.inappsByPresentationTime.values.first?.first?.inapp
-            #expect(storedInapp?.inAppId == inapp.inAppId)
-            #expect(self.presentationManagerMock.presentCallsCount == 0)
         }
 
-        guard let time = presentationTime else {
-            Issue.record("Expected presentationTime to be set")
-            return
+        if let presentationTime {
+            scheduleManager.showEligibleInapp(presentationTime)
         }
-
-        scheduleManager.showEligibleInapp(time)
 
         scheduleManager.queue.sync {
             #expect(self.presentationManagerMock.presentCallsCount == 1)
@@ -212,23 +212,22 @@ struct InappScheduleManagerTests {
         let inapp = createInAppFormData(id: "1", isPriority: false, delayTime: "invalid_time")
         scheduleManager.scheduleInApp(inapp, processingDuration: 0)
 
+        // An invalid delay string falls back to 0, so the timer can auto-fire and
+        // present immediately, racing inspection — see scheduleInapp_noDelay_schedulesCorrectly.
+        // Drive presentation only if the timer has not already done so.
         var presentationTime: TimeInterval?
-
         scheduleManager.queue.sync {
-            #expect(self.scheduleManager.inappsByPresentationTime.count == 1)
             presentationTime = self.scheduleManager.inappsByPresentationTime.keys.first
         }
 
-        guard let time = presentationTime else {
-            Issue.record("Expected presentationTime to be set")
-            return
+        if let presentationTime {
+            scheduleManager.showEligibleInapp(presentationTime)
         }
-
-        scheduleManager.showEligibleInapp(time)
 
         scheduleManager.queue.sync {
             #expect(self.presentationManagerMock.presentCallsCount == 1)
             #expect(self.presentationManagerMock.receivedInAppUIModel?.inAppId == inapp.inAppId)
+            #expect(self.scheduleManager.inappsByPresentationTime.isEmpty)
         }
     }
 
@@ -239,23 +238,22 @@ struct InappScheduleManagerTests {
         let inapp = createInAppFormData(id: "1", isPriority: false, delayTime: "00:00:00")
         scheduleManager.scheduleInApp(inapp, processingDuration: 0)
 
+        // Zero delay ⇒ the timer can auto-fire and present immediately, racing
+        // inspection — see scheduleInapp_noDelay_schedulesCorrectly. Drive presentation
+        // only if the timer has not already done so.
         var presentationTime: TimeInterval?
-
         scheduleManager.queue.sync {
-            #expect(self.scheduleManager.inappsByPresentationTime.count == 1)
             presentationTime = self.scheduleManager.inappsByPresentationTime.keys.first
         }
 
-        guard let time = presentationTime else {
-            Issue.record("Expected presentationTime to be set")
-            return
+        if let presentationTime {
+            scheduleManager.showEligibleInapp(presentationTime)
         }
-
-        scheduleManager.showEligibleInapp(time)
 
         scheduleManager.queue.sync {
             #expect(self.presentationManagerMock.presentCallsCount == 1)
             #expect(self.presentationManagerMock.receivedInAppUIModel?.inAppId == inapp.inAppId)
+            #expect(self.scheduleManager.inappsByPresentationTime.isEmpty)
         }
     }
 


### PR DESCRIPTION
A delay of 0 (nil / "00:00:00" / invalid string all fall back to 0) arms the production timer for .now(), so it can present the in-app and clean up on its own before the test inspects state. The tests asserted a "scheduled but not yet presented" intermediate window that does not deterministically exist on that path, so they raced the timer — CI saw count==0, a nil presentationTime, and presentCallsCount==1.

Assert only the deterministic end state and trigger showEligibleInapp only when the timer hasn't already; removal happens under `queue`, so presentation stays idempotent and fires exactly once on either path. Also add the missing isEmpty cleanup assertion to the zero/invalid-delay tests and an explicit getDelay(nil)==0 check, for parity with the no-delay case.

Issue - https://github.com/mindbox-cloud/ios-sdk/actions/runs/26737038292/job/78792295227

### Что хотел проверять тест
1. Запланировать in-app без задержки.
2. Промежуточно: убедиться, что он «лежит в очереди (count == 1), но ещё не показан (presentCallsCount == 0)».
3. Вручную вызвать showEligibleInapp.
4. Финально: показан 1 раз, очередь очищена.

### Почему ломалось

При `delay == 0` продакшн-код взводит таймер на .now() `InappScheduleManager.swift:59-60` и сам, без участия теста, почти мгновенно делает `showEligibleInapp → present → removeValue`.

Тест выполняется на фоновом потоке (Swift Testing, struct-suite, не @MainActor). Между строкой `scheduleInApp(...)` и `queue.sync {…}` есть микро-окно. Если в этот момент планировщик ОС «отнял» тестовый поток (а на нагруженном CI это обычное дело), таймер успевает прогнать весь конвейер раньше, чем тест посмотрит на состояние. Тогда `queue.sync` видит:

- `count == 0` (запись уже удалена) → падает строка с `count == 1`;
- `keys.first == nil` → `presentationTime` не задан → срабатывает `Issue.record`;
- `storedInapp == nil`;
- `presentCallsCount == 1` (уже показан) → падает `== 0`.

Это ровно 4 ошибки из CI. Корень: тест пытался «подсмотреть» состояние «запланировано, но ещё не показано», которого при `delay == 0` детерминированно не существует — оно прямо противоречит контракту «без задержки = показать сразу».

### Почему теперь работает детерминированно
Опираемся на два инварианта самого продакшн-кода — и тогда неважно, кто выиграл гонку (таймер или ручной вызов):

1. Показ не более одного раза. И таймер, и ручной `showEligibleInapp` работают на одной серийной `queue`. Кто выполнится первым — пройдёт `guard`, покажет (`present`) и удалит запись (`removeValue`), всё в одном критическом участке. Второй увидит, что записи уже нет → выйдет по `guard`, ничего не показав. → `presentCallsCount` не может стать 2.

2. `keys.first == nil` ⇔ показ уже состоялся. `removeValue` идёт строго после `present`, в том же блоке на `queue`. Значит пустая очередь = `present` уже отработал. Поэтому условие корректно: запись на месте → покажем сами; записи нет → таймер уже показал.

Суть: перестали проверять **недетерминированное «промежуточное»** и проверяем только **гарантированно истинное в конце**.

### Покрытие не потеряли

- Правильность id теперь проверяется по `receivedInAppUIModel?.inAppId` (то, что реально показано) — это транзитивно покрывает «сохранён правильный in-app».
- «Показан ровно 1 раз + очередь очищена» — сохранено.
- Вернули недостающий i`sEmpty` в два соседних теста и добавили `getDelay(nil) == 0`.
- Выкинули только то утверждение, которое для `delay == 0` и не было настоящим инвариантом.

И это именно тест-фикс, а не маскировка: в проде нет ни «наблюдателя промежуточного состояния», ни второго ручного драйвера показа — таймер срабатывает один раз и показывает один раз. Гонка жила только в тестовой обвязке.