### PR TITLE
MOBILE-183: Persist dates as fixed-pattern UTC and stabilize install/device UUID

### DIFF
--- a/Mindbox.xcodeproj/project.pbxproj
+++ b/Mindbox.xcodeproj/project.pbxproj
@@ -359,6 +359,7 @@
 		9BC24E7A28F6C08700C2619C /* InAppConfiguration.json in Resources */ = {isa = PBXBuildFile; fileRef = 9BC24E7928F6C08700C2619C /* InAppConfiguration.json */; };
 		A11C2D3E4F5566778899AA01 /* FirstInitializationDateTimeRuntimeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B11C2D3E4F5566778899AA01 /* FirstInitializationDateTimeRuntimeTests.swift */; };
 		A11C2D3E4F5566778899AA02 /* FirstInitializationDateTimeMigrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B11C2D3E4F5566778899AA02 /* FirstInitializationDateTimeMigrationTests.swift */; };
+		1E28BAF922E64B9CB6E22A0B /* DateFormatMigrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF1A11C4A4B940898BA80035 /* DateFormatMigrationTests.swift */; };
 		A11FBE8929DD76BF00F5FB7B /* InAppMessagesEventSender.swift in Sources */ = {isa = PBXBuildFile; fileRef = A11FBE8829DD76BF00F5FB7B /* InAppMessagesEventSender.swift */; };
 		A1515DB229B228F40025E2EE /* MindboxLogger.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A17853BE29AF7E940072578F /* MindboxLogger.framework */; };
 		A153E03B29BAFE01003C34D4 /* CustomOperationTargeting.swift in Sources */ = {isa = PBXBuildFile; fileRef = A153E03A29BAFE01003C34D4 /* CustomOperationTargeting.swift */; };
@@ -485,6 +486,7 @@
 		F31A94802BC7E61800E6C978 /* InappFrequencyValidator.swift in Sources */ = {isa = PBXBuildFile; fileRef = F31A947F2BC7E61800E6C978 /* InappFrequencyValidator.swift */; };
 		F31DB4082F56A50E00DCEB85 /* NSError+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = F31DB4072F56A50E00DCEB85 /* NSError+Extensions.swift */; };
 		F3266A392F6295A600CE6137 /* FirstInitializationDateTimeMigration.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3266A382F6295A600CE6137 /* FirstInitializationDateTimeMigration.swift */; };
+		7764BA10E25046CEA7035ED8 /* DateFormatMigration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8755088A5E704C65A1C3F6DB /* DateFormatMigration.swift */; };
 		F32B68882CF83B030088BCDD /* InappConfigurationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F32B68872CF83B030088BCDD /* InappConfigurationTests.swift */; };
 		F32CA1762E17625200CE7E63 /* InappScheduleManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F32CA1752E17625200CE7E63 /* InappScheduleManagerTests.swift */; };
 		F32CFFA42BB403C700A41E04 /* PushEnabledTargeting.swift in Sources */ = {isa = PBXBuildFile; fileRef = F32CFFA32BB403C700A41E04 /* PushEnabledTargeting.swift */; };
@@ -1167,6 +1169,7 @@
 		A1D23AEF29DE082E00A75179 /* InAppProductSegmentResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InAppProductSegmentResponse.swift; sourceTree = "<group>"; };
 		B11C2D3E4F5566778899AA01 /* FirstInitializationDateTimeRuntimeTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = FirstInitializationDateTimeRuntimeTests.swift; sourceTree = "<group>"; };
 		B11C2D3E4F5566778899AA02 /* FirstInitializationDateTimeMigrationTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = FirstInitializationDateTimeMigrationTests.swift; sourceTree = "<group>"; };
+		BF1A11C4A4B940898BA80035 /* DateFormatMigrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateFormatMigrationTests.swift; sourceTree = "<group>"; };
 		B33127AE2760C53700CF747E /* Package.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Package.swift; sourceTree = SOURCE_ROOT; };
 		B36D57842696E59400FEDFD6 /* RetailOrderStatisticsResponse.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RetailOrderStatisticsResponse.swift; sourceTree = "<group>"; };
 		B3A6254B2689F83100B6A3B7 /* PersonalOffersResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersonalOffersResponse.swift; sourceTree = "<group>"; };
@@ -1223,6 +1226,7 @@
 		F31A947F2BC7E61800E6C978 /* InappFrequencyValidator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InappFrequencyValidator.swift; sourceTree = "<group>"; };
 		F31DB4072F56A50E00DCEB85 /* NSError+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSError+Extensions.swift"; sourceTree = "<group>"; };
 		F3266A382F6295A600CE6137 /* FirstInitializationDateTimeMigration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirstInitializationDateTimeMigration.swift; sourceTree = "<group>"; };
+		8755088A5E704C65A1C3F6DB /* DateFormatMigration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateFormatMigration.swift; sourceTree = "<group>"; };
 		F32B68872CF83B030088BCDD /* InappConfigurationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InappConfigurationTests.swift; sourceTree = "<group>"; };
 		F32CA1752E17625200CE7E63 /* InappScheduleManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InappScheduleManagerTests.swift; sourceTree = "<group>"; };
 		F32CFFA32BB403C700A41E04 /* PushEnabledTargeting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PushEnabledTargeting.swift; sourceTree = "<group>"; };
@@ -1869,6 +1873,7 @@
 				472179A62C80755A00C15E7F /* ShownInAppsIDsMigration.swift */,
 				F34975372DEE2C6A00BEC667 /* ShownInAppsDictionaryMigration.swift */,
 				472765512E0D52A500A5A060 /* RemoveBackgroundTaskDataMigration.swift */,
+				8755088A5E704C65A1C3F6DB /* DateFormatMigration.swift */,
 				47ADB8142E8D3CEA00AFCCB2 /* DatabaseMetadataMigration.swift */,
 				F3266A382F6295A600CE6137 /* FirstInitializationDateTimeMigration.swift */,
 			);
@@ -2161,6 +2166,7 @@
 				47B90E2D2C625F8A00BD93E7 /* TestsMigrations */,
 				475558C22C59300400CDA026 /* MigrationManagerTests.swift */,
 				B11C2D3E4F5566778899AA02 /* FirstInitializationDateTimeMigrationTests.swift */,
+				BF1A11C4A4B940898BA80035 /* DateFormatMigrationTests.swift */,
 				476689C62C85B6AE0066BB12 /* ShownInAppsIdsMigrationTests.swift */,
 				F34975392DEE2CB700BEC667 /* ShownInAppsDictionaryMigrationTests.swift */,
 				47C464EE2E0EB88C00F50B21 /* RemoveBackgroundTaskDataMigrationTests.swift */,
@@ -4572,6 +4578,7 @@
 				F3A8B9922A3A408C00E9C055 /* SDKVersionValidator.swift in Sources */,
 				F31A94782BC6995500E6C978 /* InappFrequency.swift in Sources */,
 				F3266A392F6295A600CE6137 /* FirstInitializationDateTimeMigration.swift in Sources */,
+				7764BA10E25046CEA7035ED8 /* DateFormatMigration.swift in Sources */,
 				F3482F212A65DC2C002A41EC /* URLInappMessageDelegate.swift in Sources */,
 				BB6563102BE3BA430090C473 /* UIApplication+Extensions.swift in Sources */,
 				84A312C325DA65690096A017 /* BackgroundTaskManagerType.swift in Sources */,
@@ -4767,6 +4774,7 @@
 				F3AF0AD02BC40FCF0063BA58 /* InappTTLTests.swift in Sources */,
 				A11C2D3E4F5566778899AA01 /* FirstInitializationDateTimeRuntimeTests.swift in Sources */,
 				A11C2D3E4F5566778899AA02 /* FirstInitializationDateTimeMigrationTests.swift in Sources */,
+				1E28BAF922E64B9CB6E22A0B /* DateFormatMigrationTests.swift in Sources */,
 				5D3FCB95C2AF59DF36A61254 /* WebViewLocalStateStorageTests.swift in Sources */,
 				A1B2C3D400000001E1010101 /* MockPermissionHandler.swift in Sources */,
 				A1B2C3D400000003E1010101 /* PermissionHandlerRegistryTests.swift in Sources */,

--- a/Mindbox.xcodeproj/project.pbxproj
+++ b/Mindbox.xcodeproj/project.pbxproj
@@ -359,6 +359,7 @@
 		9BC24E7A28F6C08700C2619C /* InAppConfiguration.json in Resources */ = {isa = PBXBuildFile; fileRef = 9BC24E7928F6C08700C2619C /* InAppConfiguration.json */; };
 		A11C2D3E4F5566778899AA01 /* FirstInitializationDateTimeRuntimeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B11C2D3E4F5566778899AA01 /* FirstInitializationDateTimeRuntimeTests.swift */; };
 		A11C2D3E4F5566778899AA11 /* DeviceUUIDInitializationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B11C2D3E4F5566778899AA11 /* DeviceUUIDInitializationTests.swift */; };
+		A11C2D3E4F5566778899AA12 /* MBPersistenceStorageDateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B11C2D3E4F5566778899AA12 /* MBPersistenceStorageDateTests.swift */; };
 		A11C2D3E4F5566778899AA02 /* FirstInitializationDateTimeMigrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B11C2D3E4F5566778899AA02 /* FirstInitializationDateTimeMigrationTests.swift */; };
 		1E28BAF922E64B9CB6E22A0B /* DateFormatMigrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF1A11C4A4B940898BA80035 /* DateFormatMigrationTests.swift */; };
 		A11FBE8929DD76BF00F5FB7B /* InAppMessagesEventSender.swift in Sources */ = {isa = PBXBuildFile; fileRef = A11FBE8829DD76BF00F5FB7B /* InAppMessagesEventSender.swift */; };
@@ -1170,6 +1171,7 @@
 		A1D23AEF29DE082E00A75179 /* InAppProductSegmentResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InAppProductSegmentResponse.swift; sourceTree = "<group>"; };
 		B11C2D3E4F5566778899AA01 /* FirstInitializationDateTimeRuntimeTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = FirstInitializationDateTimeRuntimeTests.swift; sourceTree = "<group>"; };
 		B11C2D3E4F5566778899AA11 /* DeviceUUIDInitializationTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DeviceUUIDInitializationTests.swift; sourceTree = "<group>"; };
+		B11C2D3E4F5566778899AA12 /* MBPersistenceStorageDateTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MBPersistenceStorageDateTests.swift; sourceTree = "<group>"; };
 		B11C2D3E4F5566778899AA02 /* FirstInitializationDateTimeMigrationTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = FirstInitializationDateTimeMigrationTests.swift; sourceTree = "<group>"; };
 		BF1A11C4A4B940898BA80035 /* DateFormatMigrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateFormatMigrationTests.swift; sourceTree = "<group>"; };
 		B33127AE2760C53700CF747E /* Package.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Package.swift; sourceTree = SOURCE_ROOT; };
@@ -2808,6 +2810,7 @@
 			children = (
 				B11C2D3E4F5566778899AA01 /* FirstInitializationDateTimeRuntimeTests.swift */,
 				B11C2D3E4F5566778899AA11 /* DeviceUUIDInitializationTests.swift */,
+				B11C2D3E4F5566778899AA12 /* MBPersistenceStorageDateTests.swift */,
 			);
 			path = InitializationTests;
 			sourceTree = "<group>";
@@ -4777,6 +4780,7 @@
 				F3AF0AD02BC40FCF0063BA58 /* InappTTLTests.swift in Sources */,
 				A11C2D3E4F5566778899AA01 /* FirstInitializationDateTimeRuntimeTests.swift in Sources */,
 				A11C2D3E4F5566778899AA11 /* DeviceUUIDInitializationTests.swift in Sources */,
+				A11C2D3E4F5566778899AA12 /* MBPersistenceStorageDateTests.swift in Sources */,
 				A11C2D3E4F5566778899AA02 /* FirstInitializationDateTimeMigrationTests.swift in Sources */,
 				1E28BAF922E64B9CB6E22A0B /* DateFormatMigrationTests.swift in Sources */,
 				5D3FCB95C2AF59DF36A61254 /* WebViewLocalStateStorageTests.swift in Sources */,

--- a/Mindbox.xcodeproj/project.pbxproj
+++ b/Mindbox.xcodeproj/project.pbxproj
@@ -358,6 +358,7 @@
 		9BC24E7528F6953D00C2619C /* ConfigResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BC24E7328F6953D00C2619C /* ConfigResponse.swift */; };
 		9BC24E7A28F6C08700C2619C /* InAppConfiguration.json in Resources */ = {isa = PBXBuildFile; fileRef = 9BC24E7928F6C08700C2619C /* InAppConfiguration.json */; };
 		A11C2D3E4F5566778899AA01 /* FirstInitializationDateTimeRuntimeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B11C2D3E4F5566778899AA01 /* FirstInitializationDateTimeRuntimeTests.swift */; };
+		A11C2D3E4F5566778899AA11 /* DeviceUUIDInitializationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B11C2D3E4F5566778899AA11 /* DeviceUUIDInitializationTests.swift */; };
 		A11C2D3E4F5566778899AA02 /* FirstInitializationDateTimeMigrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B11C2D3E4F5566778899AA02 /* FirstInitializationDateTimeMigrationTests.swift */; };
 		1E28BAF922E64B9CB6E22A0B /* DateFormatMigrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF1A11C4A4B940898BA80035 /* DateFormatMigrationTests.swift */; };
 		A11FBE8929DD76BF00F5FB7B /* InAppMessagesEventSender.swift in Sources */ = {isa = PBXBuildFile; fileRef = A11FBE8829DD76BF00F5FB7B /* InAppMessagesEventSender.swift */; };
@@ -1168,6 +1169,7 @@
 		A1D017F42976FC2B00CD9F99 /* InternalTargetingChecker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InternalTargetingChecker.swift; sourceTree = "<group>"; };
 		A1D23AEF29DE082E00A75179 /* InAppProductSegmentResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InAppProductSegmentResponse.swift; sourceTree = "<group>"; };
 		B11C2D3E4F5566778899AA01 /* FirstInitializationDateTimeRuntimeTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = FirstInitializationDateTimeRuntimeTests.swift; sourceTree = "<group>"; };
+		B11C2D3E4F5566778899AA11 /* DeviceUUIDInitializationTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DeviceUUIDInitializationTests.swift; sourceTree = "<group>"; };
 		B11C2D3E4F5566778899AA02 /* FirstInitializationDateTimeMigrationTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = FirstInitializationDateTimeMigrationTests.swift; sourceTree = "<group>"; };
 		BF1A11C4A4B940898BA80035 /* DateFormatMigrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateFormatMigrationTests.swift; sourceTree = "<group>"; };
 		B33127AE2760C53700CF747E /* Package.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Package.swift; sourceTree = SOURCE_ROOT; };
@@ -2805,6 +2807,7 @@
 			isa = PBXGroup;
 			children = (
 				B11C2D3E4F5566778899AA01 /* FirstInitializationDateTimeRuntimeTests.swift */,
+				B11C2D3E4F5566778899AA11 /* DeviceUUIDInitializationTests.swift */,
 			);
 			path = InitializationTests;
 			sourceTree = "<group>";
@@ -4773,6 +4776,7 @@
 				F306291A2BD27D7500EF6609 /* InappFrequencyTests.swift in Sources */,
 				F3AF0AD02BC40FCF0063BA58 /* InappTTLTests.swift in Sources */,
 				A11C2D3E4F5566778899AA01 /* FirstInitializationDateTimeRuntimeTests.swift in Sources */,
+				A11C2D3E4F5566778899AA11 /* DeviceUUIDInitializationTests.swift in Sources */,
 				A11C2D3E4F5566778899AA02 /* FirstInitializationDateTimeMigrationTests.swift in Sources */,
 				1E28BAF922E64B9CB6E22A0B /* DateFormatMigrationTests.swift in Sources */,
 				5D3FCB95C2AF59DF36A61254 /* WebViewLocalStateStorageTests.swift in Sources */,

--- a/Mindbox/CoreController/CoreController.swift
+++ b/Mindbox/CoreController/CoreController.swift
@@ -26,10 +26,11 @@ final class CoreController {
     func initialization(configuration: MBConfiguration) {
 
         controllerQueue.async {
-            SessionTemporaryStorage.shared.isInstalledFromPersistenceStorageBeforeInitSDK = self.persistenceStorage.isInstalled
             SessionTemporaryStorage.shared.isInitializationCalled = true
 
             DI.injectOrFail(MigrationManagerProtocol.self).migrate()
+
+            SessionTemporaryStorage.shared.isInstalledFromPersistenceStorageBeforeInitSDK = self.persistenceStorage.isInstalled
 
             self.configValidation.compare(configuration, self.persistenceStorage.configuration)
             self.persistenceStorage.configuration = configuration

--- a/Mindbox/CoreController/CoreController.swift
+++ b/Mindbox/CoreController/CoreController.swift
@@ -126,8 +126,12 @@ final class CoreController {
             Logger.common(message: "[Core] Set firstInitializationDateTime from currentDate: \(now)")
         }
 
-        // May take up to 3 sec, see utilitiesFetcher.getDeviceUUID implementation
-        let deviceUUID = generateDeviceUUID()
+        // Reuse the deviceUUID generated for a previous installation if present:
+        // once generated, it must stay stable until an explicit reinstall and must
+        // not depend on the ATT state (IDFA ↔ IDFV) or on a transient locale-driven
+        // re-installation. Generate a new one (may take up to 3 sec, see
+        // utilitiesFetcher.getDeviceUUID) only on a genuine first installation.
+        let deviceUUID = persistenceStorage.deviceUUID ?? generateDeviceUUID()
         startUUIDDebugServiceIfNeeded(deviceUUID: deviceUUID, configuration: configutaion)
         install(
             deviceUUID: deviceUUID,

--- a/Mindbox/CoreController/CoreController.swift
+++ b/Mindbox/CoreController/CoreController.swift
@@ -119,7 +119,7 @@ final class CoreController {
         return deviceUUID
     }
 
-    private func primaryInitialization(with configutaion: MBConfiguration) {
+    private func primaryInitialization(with configuration: MBConfiguration) {
         if persistenceStorage.firstInitializationDateTime == nil {
             let now = Date()
             persistenceStorage.firstInitializationDateTime = now
@@ -132,14 +132,14 @@ final class CoreController {
         // re-installation. Generate a new one (may take up to 3 sec, see
         // utilitiesFetcher.getDeviceUUID) only on a genuine first installation.
         let deviceUUID = persistenceStorage.deviceUUID ?? generateDeviceUUID()
-        startUUIDDebugServiceIfNeeded(deviceUUID: deviceUUID, configuration: configutaion)
+        startUUIDDebugServiceIfNeeded(deviceUUID: deviceUUID, configuration: configuration)
         install(
             deviceUUID: deviceUUID,
-            configuration: configutaion
+            configuration: configuration
         )
     }
 
-    private func repeatInitialization(with configutaion: MBConfiguration) {
+    private func repeatInitialization(with configuration: MBConfiguration) {
         guard let deviceUUID = persistenceStorage.deviceUUID else {
             Logger.common(message: "[Core] Unable to find deviceUUID in persistenceStorage", level: .error, category: .general)
             return
@@ -149,14 +149,14 @@ final class CoreController {
             Logger.common(message: "[Core] Mindbox Configuration changed", level: .info, category: .general)
             install(
                 deviceUUID: deviceUUID,
-                configuration: configutaion
+                configuration: configuration
             )
         } else {
             Logger.common(message: "[Core] Mindbox Configuration has no changes", level: .info, category: .general)
             checkNotificationStatus()
             persistenceStorage.configuration?.previousDeviceUUID = deviceUUID
         }
-        startUUIDDebugServiceIfNeeded(deviceUUID: deviceUUID, configuration: configutaion)
+        startUUIDDebugServiceIfNeeded(deviceUUID: deviceUUID, configuration: configuration)
     }
 
     private func startUUIDDebugServiceIfNeeded(deviceUUID: String, configuration: MBConfiguration) {

--- a/Mindbox/PersistenceStorage/MBPersistenceStorage.swift
+++ b/Mindbox/PersistenceStorage/MBPersistenceStorage.swift
@@ -17,8 +17,13 @@ class MBPersistenceStorage: PersistenceStorage {
     static var defaults: UserDefaults = .standard
 
     // MARK: - Property
+    // Installed state is the presence of the persisted installation date string,
+    // never its parseability. Decoupling from parsing keeps `isInstalled` stable
+    // across region/locale and 12h↔24h time-format changes, which would otherwise
+    // break a localized date string and route an existing install through the
+    // fresh-install path.
     var isInstalled: Bool {
-        installationDate != nil
+        installationDateString != nil
     }
 
     var installationDate: Date? {

--- a/Mindbox/PersistenceStorage/MBPersistenceStorage.swift
+++ b/Mindbox/PersistenceStorage/MBPersistenceStorage.swift
@@ -16,13 +16,6 @@ class MBPersistenceStorage: PersistenceStorage {
     // MARK: - Dependency
     static var defaults: UserDefaults = .standard
 
-    private let dateFormatter: DateFormatter = {
-        let dateFormatter = DateFormatter()
-        dateFormatter.dateStyle = .full
-        dateFormatter.timeStyle = .full
-        return dateFormatter
-    }()
-
     // MARK: - Property
     var isInstalled: Bool {
         installationDate != nil
@@ -31,14 +24,14 @@ class MBPersistenceStorage: PersistenceStorage {
     var installationDate: Date? {
         get {
             if let dateString = installationDateString {
-                return dateFormatter.date(from: dateString)
+                return dateString.toDate(withFormat: .utc)
             } else {
                 return nil
             }
         }
         set {
             if let date = newValue {
-                installationDateString = dateFormatter.string(from: date)
+                installationDateString = date.toString(withFormat: .utc)
             } else {
                 installationDateString = nil
             }
@@ -48,14 +41,14 @@ class MBPersistenceStorage: PersistenceStorage {
     var firstInitializationDateTime: Date? {
         get {
             if let dateString = firstInitializationDateTimeString {
-                return dateFormatter.date(from: dateString)
+                return dateString.toDate(withFormat: .utc)
             } else {
                 return nil
             }
         }
         set {
             if let date = newValue {
-                firstInitializationDateTimeString = dateFormatter.string(from: date)
+                firstInitializationDateTimeString = date.toString(withFormat: .utc)
             } else {
                 firstInitializationDateTimeString = nil
             }
@@ -65,14 +58,14 @@ class MBPersistenceStorage: PersistenceStorage {
     var apnsTokenSaveDate: Date? {
         get {
             if let dateString = apnsTokenSaveDateString {
-                return dateFormatter.date(from: dateString)
+                return dateString.toDate(withFormat: .utc)
             } else {
                 return nil
             }
         }
         set {
             if let date = newValue {
-                apnsTokenSaveDateString = dateFormatter.string(from: date)
+                apnsTokenSaveDateString = date.toString(withFormat: .utc)
             } else {
                 apnsTokenSaveDateString = nil
             }
@@ -82,7 +75,7 @@ class MBPersistenceStorage: PersistenceStorage {
     var lastInfoUpdateDate: Date? {
         get {
             if let dateString = lastInfoUpdateDateString {
-                return dateFormatter.date(from: dateString)
+                return dateString.toDate(withFormat: .utc)
             } else {
                 return nil
             }
@@ -90,7 +83,7 @@ class MBPersistenceStorage: PersistenceStorage {
         
         set {
             if let date = newValue {
-                lastInfoUpdateDateString = dateFormatter.string(from: date)
+                lastInfoUpdateDateString = date.toString(withFormat: .utc)
             } else {
                 lastInfoUpdateDateString = nil
             }
@@ -100,14 +93,14 @@ class MBPersistenceStorage: PersistenceStorage {
     var deprecatedEventsRemoveDate: Date? {
         get {
             if let dateString = deprecatedEventsRemoveDateString {
-                return dateFormatter.date(from: dateString)
+                return dateString.toDate(withFormat: .utc)
             } else {
                 return nil
             }
         }
         set {
             if let date = newValue {
-                deprecatedEventsRemoveDateString = dateFormatter.string(from: date)
+                deprecatedEventsRemoveDateString = date.toString(withFormat: .utc)
             } else {
                 deprecatedEventsRemoveDateString = nil
             }
@@ -133,14 +126,14 @@ class MBPersistenceStorage: PersistenceStorage {
     var configDownloadDate: Date? {
         get {
             if let dateString = configDownloadDateString {
-                return dateFormatter.date(from: dateString)
+                return dateString.toDate(withFormat: .utc)
             } else {
                 return nil
             }
         }
         set {
             if let date = newValue {
-                configDownloadDateString = dateFormatter.string(from: date)
+                configDownloadDateString = date.toString(withFormat: .utc)
             } else {
                 configDownloadDateString = nil
             }

--- a/Mindbox/Utilities/Migrations/ImplementationOfMigrations/DateFormatMigration.swift
+++ b/Mindbox/Utilities/Migrations/ImplementationOfMigrations/DateFormatMigration.swift
@@ -1,0 +1,72 @@
+//
+//  DateFormatMigration.swift
+//  Mindbox
+//
+//  Created by Akylbek Utekeshev on 04.06.2026.
+//  Copyright © 2026 Mindbox. All rights reserved.
+//
+
+import Foundation
+import MindboxLogger
+
+/// Converts the persisted date strings written by the previous localized
+/// formatter (`dateStyle = .full`, `timeStyle = .full`) into the canonical
+/// fixed-pattern `.utc` representation used after the formatter unification.
+///
+/// - Important: Must run before the `isInstalled` guard in `MigrationManager.migrate()`.
+///   `isInstalled` reads `installationDate`, which now parses with `.utc`; without this
+///   conversion an upgraded user's `installationDate` reads as `nil`, flipping
+///   `isInstalled` to `false` and routing an existing install through the fresh-install path.
+final class DateFormatMigration: MigrationProtocol {
+
+    private let defaults = MBPersistenceStorage.defaults
+
+    /// Raw UserDefaults keys of the six persisted dates. Kept as literals to match the
+    /// stored identifiers (mirrors `MBPersistenceStorage.UserDefaultsWrapper.Key`).
+    private let dateKeys = [
+        "MBPersistenceStorage-installationData",
+        "MBPersistenceStorage-firstInitializationDateTime",
+        "MBPersistenceStorage-apnsTokenSaveDate",
+        "MBPersistenceStorage-configDownloadDate",
+        "MBPersistenceStorage-lastInfoUpdateTime",
+        "MBPersistenceStorage-deprecatedEventsRemoveDate"
+    ]
+
+    /// Replica of the removed `MBPersistenceStorage` formatter. Localized styles are used
+    /// here solely to read legacy values written by that same formatter on this device —
+    /// never to write new data. New values are written via `.toString(withFormat: .utc)`.
+    private let legacyFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateStyle = .full
+        formatter.timeStyle = .full
+        return formatter
+    }()
+
+    var description: String {
+        "Migration converts persisted dates from the legacy localized format to fixed-pattern UTC."
+    }
+
+    var isNeeded: Bool {
+        dateKeys.contains { key in
+            guard let raw = defaults.string(forKey: key) else { return false }
+            return raw.toDate(withFormat: .utc) == nil && legacyFormatter.date(from: raw) != nil
+        }
+    }
+
+    /// Runs explicitly before the versioned chain in `MigrationManager`, not via the sorted array,
+    /// so it is intentionally excluded from `versionCodeForMigration` accounting.
+    var version: Int {
+        0
+    }
+
+    func run() throws {
+        for key in dateKeys {
+            guard let raw = defaults.string(forKey: key) else { continue }
+            // Already migrated (or natively written in the new format) — leave untouched.
+            guard raw.toDate(withFormat: .utc) == nil else { continue }
+            // Unparseable by the legacy formatter (e.g. device locale/timezone changed) — best-effort skip.
+            guard let date = legacyFormatter.date(from: raw) else { continue }
+            defaults.set(date.toString(withFormat: .utc), forKey: key)
+        }
+    }
+}

--- a/Mindbox/Utilities/Migrations/ImplementationOfMigrations/DateFormatMigration.swift
+++ b/Mindbox/Utilities/Migrations/ImplementationOfMigrations/DateFormatMigration.swift
@@ -13,10 +13,12 @@ import MindboxLogger
 /// formatter (`dateStyle = .full`, `timeStyle = .full`) into the canonical
 /// fixed-pattern `.utc` representation used after the formatter unification.
 ///
-/// - Important: Must run before the `isInstalled` guard in `MigrationManager.migrate()`.
-///   `isInstalled` reads `installationDate`, which now parses with `.utc`; without this
-///   conversion an upgraded user's `installationDate` reads as `nil`, flipping
-///   `isInstalled` to `false` and routing an existing install through the fresh-install path.
+/// - Important: Must run first in `MigrationManager.migrate()`, before any
+///   date-consuming migration (e.g. `FirstInitializationDateTimeMigration`,
+///   which reads `installationDate` as a parsed `Date`). Without this conversion
+///   an upgraded user's date strings stay unparseable by `.utc`, so the parsed
+///   `Date` values read as `nil`. `isInstalled` itself is independent of parsing
+///   (it checks the presence of the stored string), so it is unaffected.
 final class DateFormatMigration: MigrationProtocol {
 
     private let defaults = MBPersistenceStorage.defaults

--- a/Mindbox/Utilities/Migrations/ImplementationOfMigrations/DateFormatMigration.swift
+++ b/Mindbox/Utilities/Migrations/ImplementationOfMigrations/DateFormatMigration.swift
@@ -13,12 +13,13 @@ import MindboxLogger
 /// formatter (`dateStyle = .full`, `timeStyle = .full`) into the canonical
 /// fixed-pattern `.utc` representation used after the formatter unification.
 ///
-/// - Important: Must run first in `MigrationManager.migrate()`, before any
-///   date-consuming migration (e.g. `FirstInitializationDateTimeMigration`,
+/// - Important: Ordered first in `MigrationManager`'s migration chain (via the lowest
+///   `version`), before any date-consuming migration (e.g. `FirstInitializationDateTimeMigration`,
 ///   which reads `installationDate` as a parsed `Date`). Without this conversion
 ///   an upgraded user's date strings stay unparseable by `.utc`, so the parsed
 ///   `Date` values read as `nil`. `isInstalled` itself is independent of parsing
-///   (it checks the presence of the stored string), so it is unaffected.
+///   (it checks the presence of the stored string), so it is unaffected — which is
+///   why gating the whole chain behind the `isInstalled` guard is safe for upgraded users.
 final class DateFormatMigration: MigrationProtocol {
 
     private let defaults = MBPersistenceStorage.defaults
@@ -95,34 +96,35 @@ final class DateFormatMigration: MigrationProtocol {
         }
     }
 
-    /// Runs explicitly before the versioned chain in `MigrationManager`, not via the sorted array,
-    /// so it is intentionally excluded from `versionCodeForMigration` accounting.
+    /// Negative so the ascending sort in `MigrationManager` places this ahead of the historical
+    /// chain (`0…`), guaranteeing date strings are normalized before any date-consuming migration
+    /// (e.g. `FirstInitializationDateTimeMigration`) reads them.
     var version: Int {
-        0
+        -1
     }
 
     func run() throws {
-        Logger.common(message: "📅 [DateFormatMigration] Started — scanning \(dateKeys.count) persisted date key(s) for legacy values", level: .info, category: .migration)
+        Logger.common(message: "[Migrations] Started DateFormatMigration — scanning \(dateKeys.count) persisted date key(s) for legacy values", level: .info, category: .migration)
 
         var convertedCount = 0
         for key in dateKeys {
             guard let raw = defaults.string(forKey: key) else { continue }
             // Already migrated (or natively written in the new format) — leave untouched.
             guard raw.toDate(withFormat: .utc) == nil else {
-                Logger.common(message: "📅 [DateFormatMigration] Skip '\(key)' — already in .utc format: '\(raw)'", level: .debug, category: .migration)
+                Logger.common(message: "[Migrations] Skip DateFormatMigration key '\(key)' — already in .utc format: '\(raw)'", level: .debug, category: .migration)
                 continue
             }
             // Unparseable by any legacy candidate (e.g. the device language changed) — best-effort skip.
             guard let date = legacyDate(from: raw) else {
-                Logger.common(message: "📅 [DateFormatMigration] ⚠️ Skip '\(key)' — value not parseable by any legacy formatter: '\(raw)'", level: .error, category: .migration)
+                Logger.common(message: "[Migrations] Skip DateFormatMigration key '\(key)' — value not parseable by any legacy formatter: '\(raw)'", level: .error, category: .migration)
                 continue
             }
             let newValue = date.toString(withFormat: .utc)
             defaults.set(newValue, forKey: key)
             convertedCount += 1
-            Logger.common(message: "📅 [DateFormatMigration] Converted '\(key)': '\(raw)' → '\(newValue)'", level: .info, category: .migration)
+            Logger.common(message: "[Migrations] DateFormatMigration converted '\(key)': '\(raw)' → '\(newValue)'", level: .info, category: .migration)
         }
 
-        Logger.common(message: "📅 [DateFormatMigration] ✅ Finished — converted \(convertedCount) of \(dateKeys.count) key(s)", level: .info, category: .migration)
+        Logger.common(message: "[Migrations] Finished DateFormatMigration — converted \(convertedCount) of \(dateKeys.count) key(s)", level: .info, category: .migration)
     }
 }

--- a/Mindbox/Utilities/Migrations/ImplementationOfMigrations/DateFormatMigration.swift
+++ b/Mindbox/Utilities/Migrations/ImplementationOfMigrations/DateFormatMigration.swift
@@ -24,16 +24,21 @@ final class DateFormatMigration: MigrationProtocol {
 
     private let defaults = MBPersistenceStorage.defaults
 
-    /// Raw UserDefaults keys of the six persisted dates. Kept as literals to match the
-    /// stored identifiers (mirrors `MBPersistenceStorage.UserDefaultsWrapper.Key`).
-    private let dateKeys = [
-        "MBPersistenceStorage-installationData",
-        "MBPersistenceStorage-firstInitializationDateTime",
-        "MBPersistenceStorage-apnsTokenSaveDate",
-        "MBPersistenceStorage-configDownloadDate",
-        "MBPersistenceStorage-lastInfoUpdateTime",
-        "MBPersistenceStorage-deprecatedEventsRemoveDate"
-    ]
+    /// Raw UserDefaults keys of the six persisted dates, derived from the single source of truth
+    /// (`MBPersistenceStorage.UserDefaultsWrapper.Key`) so they cannot drift from the stored
+    /// identifiers. The `<Any>` argument is irrelevant: `Key` does not depend on the wrapper's
+    /// generic parameter.
+    private let dateKeys: [String] = {
+        let keys: [MBPersistenceStorage.UserDefaultsWrapper<Any>.Key] = [
+            .installationData,
+            .firstInitializationDateTime,
+            .apnsTokenSaveDate,
+            .configDownloadDate,
+            .lastInfoUpdateTime,
+            .deprecatedEventsRemoveDate
+        ]
+        return keys.map(\.rawValue)
+    }()
 
     /// Replicas of the removed `MBPersistenceStorage` formatter (`.full`/`.full`), used only
     /// to read legacy values written by that formatter on this device — never to write new
@@ -49,7 +54,7 @@ final class DateFormatMigration: MigrationProtocol {
     ///   - the device locale forced to 12-hour (`h12`).
     /// The first candidate that parses wins; the instant is then re-stored as `.utc` (24h/UTC),
     /// so legacy 12h values are rescued and normalized.
-    private let legacyFormatters: [DateFormatter] = {
+    private lazy var legacyFormatters: [DateFormatter] = {
         func make(_ identifier: String) -> DateFormatter {
             let formatter = DateFormatter()
             formatter.locale = Locale(identifier: identifier)

--- a/Mindbox/Utilities/Migrations/ImplementationOfMigrations/DateFormatMigration.swift
+++ b/Mindbox/Utilities/Migrations/ImplementationOfMigrations/DateFormatMigration.swift
@@ -62,13 +62,27 @@ final class DateFormatMigration: MigrationProtocol {
     }
 
     func run() throws {
+        Logger.common(message: "📅 [DateFormatMigration] Started — scanning \(dateKeys.count) persisted date key(s) for legacy values", level: .info, category: .migration)
+
+        var convertedCount = 0
         for key in dateKeys {
             guard let raw = defaults.string(forKey: key) else { continue }
             // Already migrated (or natively written in the new format) — leave untouched.
-            guard raw.toDate(withFormat: .utc) == nil else { continue }
+            guard raw.toDate(withFormat: .utc) == nil else {
+                Logger.common(message: "📅 [DateFormatMigration] Skip '\(key)' — already in .utc format: '\(raw)'", level: .debug, category: .migration)
+                continue
+            }
             // Unparseable by the legacy formatter (e.g. device locale/timezone changed) — best-effort skip.
-            guard let date = legacyFormatter.date(from: raw) else { continue }
-            defaults.set(date.toString(withFormat: .utc), forKey: key)
+            guard let date = legacyFormatter.date(from: raw) else {
+                Logger.common(message: "📅 [DateFormatMigration] ⚠️ Skip '\(key)' — value not parseable by legacy formatter: '\(raw)'", level: .error, category: .migration)
+                continue
+            }
+            let newValue = date.toString(withFormat: .utc)
+            defaults.set(newValue, forKey: key)
+            convertedCount += 1
+            Logger.common(message: "📅 [DateFormatMigration] Converted '\(key)': '\(raw)' → '\(newValue)'", level: .info, category: .migration)
         }
+
+        Logger.common(message: "📅 [DateFormatMigration] ✅ Finished — converted \(convertedCount) of \(dateKeys.count) key(s)", level: .info, category: .migration)
     }
 }

--- a/Mindbox/Utilities/Migrations/ImplementationOfMigrations/DateFormatMigration.swift
+++ b/Mindbox/Utilities/Migrations/ImplementationOfMigrations/DateFormatMigration.swift
@@ -34,15 +34,55 @@ final class DateFormatMigration: MigrationProtocol {
         "MBPersistenceStorage-deprecatedEventsRemoveDate"
     ]
 
-    /// Replica of the removed `MBPersistenceStorage` formatter. Localized styles are used
-    /// here solely to read legacy values written by that same formatter on this device —
-    /// never to write new data. New values are written via `.toString(withFormat: .utc)`.
-    private let legacyFormatter: DateFormatter = {
-        let formatter = DateFormatter()
-        formatter.dateStyle = .full
-        formatter.timeStyle = .full
-        return formatter
+    /// Replicas of the removed `MBPersistenceStorage` formatter (`.full`/`.full`), used only
+    /// to read legacy values written by that formatter on this device — never to write new
+    /// data (new values go through `.toString(withFormat: .utc)`).
+    ///
+    /// A single `.full`/`.full` formatter follows the device's current 12h/24h setting, so a
+    /// value written under the *other* setting won't parse (the original re-installation bug).
+    /// We therefore try several candidates that keep the device language/region — so the
+    /// weekday, month, the "at" literal and the zone name match how the value was written —
+    /// but pin the hour cycle:
+    ///   - the device locale as-is (matches values written under the current setting);
+    ///   - the device locale forced to 24-hour (`h23`);
+    ///   - the device locale forced to 12-hour (`h12`).
+    /// The first candidate that parses wins; the instant is then re-stored as `.utc` (24h/UTC),
+    /// so legacy 12h values are rescued and normalized.
+    private let legacyFormatters: [DateFormatter] = {
+        func make(_ identifier: String) -> DateFormatter {
+            let formatter = DateFormatter()
+            formatter.locale = Locale(identifier: identifier)
+            formatter.dateStyle = .full
+            formatter.timeStyle = .full
+            return formatter
+        }
+
+        let base = Locale.current.identifier
+        // Join the hour-cycle Unicode keyword with the correct separator: `@` for the first
+        // keyword, `;` if the current identifier already carries one (e.g. `@calendar=…`).
+        func identifier(forcingHourCycle hourCycle: String) -> String {
+            let separator = base.contains("@") ? ";" : "@"
+            return base + separator + "hours=" + hourCycle
+        }
+
+        return [
+            make(base),
+            make(identifier(forcingHourCycle: "h23")),
+            make(identifier(forcingHourCycle: "h12"))
+        ]
     }()
+
+    /// Parses a legacy `.full`/`.full` string with the first candidate formatter that succeeds.
+    /// Hour cycles don't cross-contaminate: a 24h string (`13:45:45`) is rejected by the 12h
+    /// formatter and vice versa, so a successful parse always reflects the value's real time.
+    private func legacyDate(from raw: String) -> Date? {
+        for formatter in legacyFormatters {
+            if let date = formatter.date(from: raw) {
+                return date
+            }
+        }
+        return nil
+    }
 
     var description: String {
         "Migration converts persisted dates from the legacy localized format to fixed-pattern UTC."
@@ -51,7 +91,7 @@ final class DateFormatMigration: MigrationProtocol {
     var isNeeded: Bool {
         dateKeys.contains { key in
             guard let raw = defaults.string(forKey: key) else { return false }
-            return raw.toDate(withFormat: .utc) == nil && legacyFormatter.date(from: raw) != nil
+            return raw.toDate(withFormat: .utc) == nil && legacyDate(from: raw) != nil
         }
     }
 
@@ -72,9 +112,9 @@ final class DateFormatMigration: MigrationProtocol {
                 Logger.common(message: "📅 [DateFormatMigration] Skip '\(key)' — already in .utc format: '\(raw)'", level: .debug, category: .migration)
                 continue
             }
-            // Unparseable by the legacy formatter (e.g. device locale/timezone changed) — best-effort skip.
-            guard let date = legacyFormatter.date(from: raw) else {
-                Logger.common(message: "📅 [DateFormatMigration] ⚠️ Skip '\(key)' — value not parseable by legacy formatter: '\(raw)'", level: .error, category: .migration)
+            // Unparseable by any legacy candidate (e.g. the device language changed) — best-effort skip.
+            guard let date = legacyDate(from: raw) else {
+                Logger.common(message: "📅 [DateFormatMigration] ⚠️ Skip '\(key)' — value not parseable by any legacy formatter: '\(raw)'", level: .error, category: .migration)
                 continue
             }
             let newValue = date.toString(withFormat: .utc)

--- a/Mindbox/Utilities/Migrations/MigrationManager/MigrationManager.swift
+++ b/Mindbox/Utilities/Migrations/MigrationManager/MigrationManager.swift
@@ -111,12 +111,14 @@ extension MigrationManager: MigrationManagerProtocol {
     /// ordering is for date correctness, not for the `isInstalled` guard.
     private func runDateFormatMigration() {
         let migration = DateFormatMigration()
-        guard migration.isNeeded else { return }
+        guard migration.isNeeded else {
+            Logger.common(message: "📅 [DateFormatMigration] Not needed — no legacy date strings to convert", level: .info, category: .migration)
+            return
+        }
         do {
             try migration.run()
-            Logger.common(message: "[Migration] Run migration: '\(migration.description)'", level: .info, category: .migration)
         } catch {
-            Logger.common(message: "[Migration] Migration failed. Description: \(migration.description). Error: \(error.localizedDescription)", level: .error, category: .migration)
+            Logger.common(message: "📅 [DateFormatMigration] ❌ Failed: \(error.localizedDescription)", level: .error, category: .migration)
         }
     }
 }

--- a/Mindbox/Utilities/Migrations/MigrationManager/MigrationManager.swift
+++ b/Mindbox/Utilities/Migrations/MigrationManager/MigrationManager.swift
@@ -51,6 +51,7 @@ final class MigrationManager {
         self.localSdkVersionCode = Constants.Migration.sdkVersionCode
 
         self.migrations = [
+            DateFormatMigration(),
             ShownInAppsIDsMigration(),
             ShownInAppsDictionaryMigration(),
             RemoveBackgroundTaskDataMigration(),
@@ -68,8 +69,6 @@ extension MigrationManager: MigrationManagerProtocol {
     /// If any migration that involves `Constants.Migration.sdkVersionCode` and `persistenceStorage.versionCodeForMigration` fails,
     /// a soft reset is performed on the persistence storage to ensure that the system remains in a consistent state.
     func migrate() {
-
-        runDateFormatMigration()
 
         guard persistenceStorage.isInstalled else {
             let firstInstallationMessage = "[Migrations] The first installation. Migrations will not be performed."
@@ -103,23 +102,6 @@ extension MigrationManager: MigrationManagerProtocol {
         let message = migrationsStarted ? "[Migrations] Migrations have been successful" : "[Migrations] Migrations have been skipped"
 
         Logger.common(message: message, level: .info, category: .migration)
-    }
-
-    /// Converts legacy localized date strings to fixed-pattern UTC. Runs first so the
-    /// date-consuming migrations below see parseable `Date` values. `isInstalled` is
-    /// independent of parsing (it checks the stored string's presence), so the early
-    /// ordering is for date correctness, not for the `isInstalled` guard.
-    private func runDateFormatMigration() {
-        let migration = DateFormatMigration()
-        guard migration.isNeeded else {
-            Logger.common(message: "📅 [DateFormatMigration] Not needed — no legacy date strings to convert", level: .info, category: .migration)
-            return
-        }
-        do {
-            try migration.run()
-        } catch {
-            Logger.common(message: "📅 [DateFormatMigration] ❌ Failed: \(error.localizedDescription)", level: .error, category: .migration)
-        }
     }
 }
 

--- a/Mindbox/Utilities/Migrations/MigrationManager/MigrationManager.swift
+++ b/Mindbox/Utilities/Migrations/MigrationManager/MigrationManager.swift
@@ -105,8 +105,10 @@ extension MigrationManager: MigrationManagerProtocol {
         Logger.common(message: message, level: .info, category: .migration)
     }
 
-    /// Converts legacy localized date strings to fixed-pattern UTC before the `isInstalled` guard,
-    /// since `isInstalled` depends on `installationDate` parsing with the new format.
+    /// Converts legacy localized date strings to fixed-pattern UTC. Runs first so the
+    /// date-consuming migrations below see parseable `Date` values. `isInstalled` is
+    /// independent of parsing (it checks the stored string's presence), so the early
+    /// ordering is for date correctness, not for the `isInstalled` guard.
     private func runDateFormatMigration() {
         let migration = DateFormatMigration()
         guard migration.isNeeded else { return }

--- a/Mindbox/Utilities/Migrations/MigrationManager/MigrationManager.swift
+++ b/Mindbox/Utilities/Migrations/MigrationManager/MigrationManager.swift
@@ -69,6 +69,8 @@ extension MigrationManager: MigrationManagerProtocol {
     /// a soft reset is performed on the persistence storage to ensure that the system remains in a consistent state.
     func migrate() {
 
+        runDateFormatMigration()
+
         guard persistenceStorage.isInstalled else {
             let firstInstallationMessage = "[Migrations] The first installation. Migrations will not be performed."
             Logger.common(message: firstInstallationMessage, level: .info, category: .migration)
@@ -101,6 +103,19 @@ extension MigrationManager: MigrationManagerProtocol {
         let message = migrationsStarted ? "[Migrations] Migrations have been successful" : "[Migrations] Migrations have been skipped"
 
         Logger.common(message: message, level: .info, category: .migration)
+    }
+
+    /// Converts legacy localized date strings to fixed-pattern UTC before the `isInstalled` guard,
+    /// since `isInstalled` depends on `installationDate` parsing with the new format.
+    private func runDateFormatMigration() {
+        let migration = DateFormatMigration()
+        guard migration.isNeeded else { return }
+        do {
+            try migration.run()
+            Logger.common(message: "[Migration] Run migration: '\(migration.description)'", level: .info, category: .migration)
+        } catch {
+            Logger.common(message: "[Migration] Migration failed. Description: \(migration.description). Error: \(error.localizedDescription)", level: .error, category: .migration)
+        }
     }
 }
 

--- a/MindboxLogger/Shared/Extensions/Date+Extension.swift
+++ b/MindboxLogger/Shared/Extensions/Date+Extension.swift
@@ -14,18 +14,24 @@ public extension Date {
     }
 
     func toFullString() -> String {
-        let dateFormatter = DateFormatter()
-        dateFormatter.locale = Locale(identifier: "en_US_POSIX")
-        dateFormatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ssZ"
-        return dateFormatter.string(from: self as Date)
+        return Date.fullFormatter.string(from: self as Date)
     }
 
-    static var dateFormatter: DateFormatter {
+    // Built once and reused: a fully-configured DateFormatter is thread-safe for conversion
+    // (iOS 7+), so there is no need to recreate it on every call.
+    static let dateFormatter: DateFormatter = {
         let formatter = DateFormatter()
         formatter.locale = Locale(identifier: "en_US_POSIX")
         formatter.dateFormat = "HH:mm:ss.SSSS"
         return formatter
-    }
+    }()
+
+    private static let fullFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ssZ"
+        return formatter
+    }()
 
     func toString(withFormat format: DateFormat) -> String {
         return format.string(from: self)

--- a/MindboxLogger/Shared/Extensions/Date+Extension.swift
+++ b/MindboxLogger/Shared/Extensions/Date+Extension.swift
@@ -28,11 +28,7 @@ public extension Date {
     }
 
     func toString(withFormat format: DateFormat) -> String {
-        let dateFormatter = DateFormatter()
-        dateFormatter.locale = Locale(identifier: "en_US_POSIX")
-        dateFormatter.dateFormat = format.value
-        dateFormatter.timeZone = TimeZone(identifier: "UTC")
-        return dateFormatter.string(from: self)
+        return format.string(from: self)
     }
 }
 

--- a/MindboxLogger/Shared/Extensions/String+Extensions.swift
+++ b/MindboxLogger/Shared/Extensions/String+Extensions.swift
@@ -16,36 +16,29 @@ public enum DateFormat: String {
         return self.rawValue
     }
 
-    private static let cacheLock = NSLock()
-    private static var formatters: [DateFormat: DateFormatter] = [:]
-
-    // Cached, fixed-pattern formatter: POSIX locale + explicit UTC timezone, 24h `HH`.
-    // Created once per format and reused. Must only be touched while holding `cacheLock`.
-    private var formatter: DateFormatter {
-        if let formatter = Self.formatters[self] {
-            return formatter
+    // The set of formats is fixed and tiny, so every fixed-pattern formatter is built once,
+    // up front. `static let` is initialized exactly once (thread-safe), the dictionary is then
+    // immutable, and each fully-configured `DateFormatter` is safe for concurrent string/date
+    // conversion on iOS 7+ (min target iOS 12). No lock needed.
+    // Each formatter uses POSIX locale + explicit UTC timezone, 24h `HH`.
+    private static let formatters: [DateFormat: DateFormatter] = {
+        var dict = [DateFormat: DateFormatter]()
+        for format in [DateFormat.api, .utc, .utcWithMillis] {
+            let formatter = DateFormatter()
+            formatter.locale = Locale(identifier: "en_US_POSIX")
+            formatter.dateFormat = format.rawValue
+            formatter.timeZone = TimeZone(identifier: "UTC")
+            dict[format] = formatter
         }
+        return dict
+    }()
 
-        let formatter = DateFormatter()
-        formatter.locale = Locale(identifier: "en_US_POSIX")
-        formatter.dateFormat = value
-        formatter.timeZone = TimeZone(identifier: "UTC")
-        Self.formatters[self] = formatter
-        return formatter
-    }
-
-    // The lock spans the actual format/parse calls, not just cache lookup:
-    // a shared DateFormatter must not be used for string/date conversion concurrently.
     func string(from date: Date) -> String {
-        Self.cacheLock.lock()
-        defer { Self.cacheLock.unlock() }
-        return formatter.string(from: date)
+        Self.formatters[self]!.string(from: date)
     }
 
     func date(from string: String) -> Date? {
-        Self.cacheLock.lock()
-        defer { Self.cacheLock.unlock() }
-        return formatter.date(from: string)
+        Self.formatters[self]!.date(from: string)
     }
 }
 

--- a/MindboxLogger/Shared/Extensions/String+Extensions.swift
+++ b/MindboxLogger/Shared/Extensions/String+Extensions.swift
@@ -15,15 +15,42 @@ public enum DateFormat: String {
     var value: String {
         return self.rawValue
     }
+
+    private static let cacheLock = NSLock()
+    private static var formatters: [DateFormat: DateFormatter] = [:]
+
+    // Cached, fixed-pattern formatter: POSIX locale + explicit UTC timezone, 24h `HH`.
+    // Created once per format and reused. Must only be touched while holding `cacheLock`.
+    private var formatter: DateFormatter {
+        if let formatter = Self.formatters[self] {
+            return formatter
+        }
+
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.dateFormat = value
+        formatter.timeZone = TimeZone(identifier: "UTC")
+        Self.formatters[self] = formatter
+        return formatter
+    }
+
+    // The lock spans the actual format/parse calls, not just cache lookup:
+    // a shared DateFormatter must not be used for string/date conversion concurrently.
+    func string(from date: Date) -> String {
+        Self.cacheLock.lock()
+        defer { Self.cacheLock.unlock() }
+        return formatter.string(from: date)
+    }
+
+    func date(from string: String) -> Date? {
+        Self.cacheLock.lock()
+        defer { Self.cacheLock.unlock() }
+        return formatter.date(from: string)
+    }
 }
 
 public extension String {
     func toDate(withFormat format: DateFormat) -> Date? {
-        let dateFormatterGet = DateFormatter()
-        dateFormatterGet.locale = Locale(identifier: "en_US_POSIX")
-        dateFormatterGet.dateFormat = format.value
-        dateFormatterGet.timeZone = TimeZone(identifier: "UTC")
-
-        return dateFormatterGet.date(from: self)
+        return format.date(from: self)
     }
 }

--- a/MindboxLogger/Shared/Extensions/String+Extensions.swift
+++ b/MindboxLogger/Shared/Extensions/String+Extensions.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public enum DateFormat: String {
+public enum DateFormat: String, CaseIterable {
     case api = "yyyy-MM-dd'T'HH:mm:ss"
     case utc = "yyyy-MM-dd'T'HH:mm:ss'Z'"
     case utcWithMillis = "yyyy-MM-dd'T'HH:mm:ss.SSSXXXXX"
@@ -16,29 +16,39 @@ public enum DateFormat: String {
         return self.rawValue
     }
 
-    // The set of formats is fixed and tiny, so every fixed-pattern formatter is built once,
-    // up front. `static let` is initialized exactly once (thread-safe), the dictionary is then
-    // immutable, and each fully-configured `DateFormatter` is safe for concurrent string/date
-    // conversion on iOS 7+ (min target iOS 12). No lock needed.
-    // Each formatter uses POSIX locale + explicit UTC timezone, 24h `HH`.
+    // Fixed-pattern formatter: POSIX locale + explicit UTC timezone, 24h `HH`.
+    private static func makeFormatter(for format: DateFormat) -> DateFormatter {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.dateFormat = format.rawValue
+        formatter.timeZone = TimeZone(identifier: "UTC")
+        return formatter
+    }
+
+    // The set of formats is fixed and tiny, so every formatter is built once, up front.
+    // `static let` is initialized exactly once (thread-safe), the dictionary is then immutable,
+    // and each fully-configured `DateFormatter` is safe for concurrent string/date conversion on
+    // iOS 7+ (min target iOS 12). No lock needed.
     private static let formatters: [DateFormat: DateFormatter] = {
         var dict = [DateFormat: DateFormatter]()
-        for format in [DateFormat.api, .utc, .utcWithMillis] {
-            let formatter = DateFormatter()
-            formatter.locale = Locale(identifier: "en_US_POSIX")
-            formatter.dateFormat = format.rawValue
-            formatter.timeZone = TimeZone(identifier: "UTC")
-            dict[format] = formatter
+        for format in DateFormat.allCases {
+            dict[format] = makeFormatter(for: format)
         }
         return dict
     }()
 
+    // Falls back to building on demand instead of force-unwrapping: the dictionary always has an
+    // entry for every case (built from `allCases`), so the fallback is unreachable in practice.
+    private var formatter: DateFormatter {
+        Self.formatters[self] ?? Self.makeFormatter(for: self)
+    }
+
     func string(from date: Date) -> String {
-        Self.formatters[self]!.string(from: date)
+        formatter.string(from: date)
     }
 
     func date(from string: String) -> Date? {
-        Self.formatters[self]!.date(from: string)
+        formatter.date(from: string)
     }
 }
 

--- a/MindboxTests/InitializationTests/DeviceUUIDInitializationTests.swift
+++ b/MindboxTests/InitializationTests/DeviceUUIDInitializationTests.swift
@@ -1,0 +1,138 @@
+//
+//  DeviceUUIDInitializationTests.swift
+//  MindboxTests
+//
+//  Created by Mindbox on 08.06.2026.
+//  Copyright © 2026 Mindbox. All rights reserved.
+//
+
+import Testing
+@testable import Mindbox
+
+// MARK: - deviceUUID / applicationInstanceId behavior on initialization
+
+@Suite(.serialized)
+@MainActor
+struct DeviceUUIDInitializationTests {
+
+    private let storage: PersistenceStorage
+    private let coreController: CoreController
+    private let controllerQueue: DispatchQueue
+
+    init() {
+        TestConfiguration.configure()
+        storage = DI.injectOrFail(PersistenceStorage.self)
+        storage.reset()
+        coreController = DI.injectOrFail(CoreController.self)
+        controllerQueue = coreController.controllerQueue
+        let databaseRepository = DI.injectOrFail(DatabaseRepositoryProtocol.self)
+        try? databaseRepository.erase()
+    }
+
+    @Test("Honest reinstall: empty storage generates a deviceUUID and an applicationInstanceId")
+    func honestReinstallGeneratesNewIdentifiers() async throws {
+        storage.reset()
+        #expect(storage.deviceUUID == nil)
+        #expect(storage.installationDate == nil)
+        #expect(storage.applicationInstanceId == nil)
+
+        let configuration = try MBConfiguration(plistName: "TestConfig1")
+        coreController.initialization(configuration: configuration)
+        await waitForInitializationFinished()
+
+        let deviceUUID = try #require(
+            storage.deviceUUID,
+            "A genuine first installation must generate a deviceUUID."
+        )
+        #expect(!deviceUUID.isEmpty, "Generated deviceUUID must not be empty.")
+
+        let instanceId = try #require(
+            storage.applicationInstanceId,
+            "A genuine first installation must generate an applicationInstanceId."
+        )
+        #expect(!instanceId.isEmpty, "Generated applicationInstanceId must not be empty.")
+
+        cleanup()
+    }
+
+    @Test("Persisted deviceUUID is reused on install, not regenerated")
+    func persistedDeviceUUIDIsReused() async throws {
+        storage.reset()
+        // Simulate a locale-driven re-installation: `isInstalled` became false (installationDate
+        // absent), yet a deviceUUID from a previous installation is still persisted. The fix must
+        // reuse that deviceUUID instead of generating a new one.
+        let persistedUUID = "00000000-0000-0000-0000-0000000000AA"
+        storage.deviceUUID = persistedUUID
+        #expect(storage.installationDate == nil)
+        #expect(storage.isInstalled == false)
+
+        let configuration = try MBConfiguration(plistName: "TestConfig1")
+        coreController.initialization(configuration: configuration)
+        await waitForInitializationFinished()
+
+        #expect(
+            storage.deviceUUID == persistedUUID,
+            "primaryInitialization must reuse the persisted deviceUUID, not regenerate it."
+        )
+
+        cleanup()
+    }
+
+    @Test("Reinstall over an existing installation keeps deviceUUID and refreshes instanceId")
+    func reinstallKeepsDeviceUUIDRefreshesInstanceId() async throws {
+        let configuration = try MBConfiguration(plistName: "TestConfig1")
+        coreController.initialization(configuration: configuration)
+        await waitForInitializationFinished()
+
+        let originalUUID = try #require(
+            storage.deviceUUID,
+            "deviceUUID must be set after the first installation."
+        )
+        let originalInstanceId = try #require(
+            storage.applicationInstanceId,
+            "applicationInstanceId must be set after the first installation."
+        )
+        #expect(storage.isInstalled, "Storage must be installed after the first initialization.")
+
+        // Re-initialize with a configuration whose endpoint differs: changedState becomes `.rest`,
+        // so repeatInitialization runs install() again over the existing installation.
+        let changedConfiguration = try MBConfiguration(
+            endpoint: "app-with-hub-IOS-reinstall",
+            domain: "api.mindbox.ru"
+        )
+        coreController.initialization(configuration: changedConfiguration)
+        await waitForInitializationFinished()
+
+        #expect(
+            storage.deviceUUID == originalUUID,
+            "deviceUUID must stay stable across a reinstall over an existing installation."
+        )
+        let newInstanceId = try #require(
+            storage.applicationInstanceId,
+            "applicationInstanceId must be present after reinstall."
+        )
+        #expect(
+            newInstanceId != originalInstanceId,
+            "install() must generate a fresh applicationInstanceId on reinstall."
+        )
+
+        cleanup()
+    }
+
+    // MARK: - Helpers
+
+    private func waitForInitializationFinished() async {
+        await withCheckedContinuation { continuation in
+            controllerQueue.async {
+                continuation.resume()
+            }
+        }
+    }
+
+    private func cleanup() {
+        storage.reset()
+        storage.userVisitCount = 0
+        SessionTemporaryStorage.shared.erase()
+        SessionTemporaryStorage.shared.isInstalledFromPersistenceStorageBeforeInitSDK = false
+    }
+}

--- a/MindboxTests/InitializationTests/MBPersistenceStorageDateTests.swift
+++ b/MindboxTests/InitializationTests/MBPersistenceStorageDateTests.swift
@@ -1,0 +1,83 @@
+//
+//  MBPersistenceStorageDateTests.swift
+//  MindboxTests
+//
+//  Created by Mindbox on 08.06.2026.
+//  Copyright © 2026 Mindbox. All rights reserved.
+//
+
+import Testing
+import Foundation
+@testable import Mindbox
+
+// MARK: - Real MBPersistenceStorage: installed state + date round-trips
+
+@Suite(.serialized)
+struct MBPersistenceStorageDateTests {
+
+    private let storage: PersistenceStorage
+
+    init() {
+        storage = DI.injectOrFail(PersistenceStorage.self)
+        storage.reset()
+    }
+
+    // MARK: - isInstalled
+
+    @Test("isInstalled is false when no installation-date string is stored")
+    func isInstalledFalseWithoutString() {
+        #expect(storage.installationDate == nil)
+        #expect(storage.isInstalled == false, "isInstalled must be false when nothing is persisted.")
+    }
+
+    @Test("isInstalled becomes true once an installationDate is stored, false again after clearing")
+    func isInstalledTracksStringPresence() {
+        storage.installationDate = Date(timeIntervalSince1970: 1_700_000_000)
+        #expect(storage.isInstalled, "isInstalled must be true once an installationDate is persisted.")
+
+        storage.installationDate = nil
+        #expect(storage.isInstalled == false, "isInstalled must be false after the installationDate is cleared.")
+    }
+
+    // MARK: - Round-trip for all six UTC-backed date properties
+
+    @Test("All six UTC date properties round-trip setter → getter at second precision")
+    func allDatesRoundTrip() {
+        // (name, setter, getter) for every Date property backed by a `.utc` string in production.
+        let cases: [(name: String, set: (Date?) -> Void, get: () -> Date?)] = [
+            ("installationDate",
+             { storage.installationDate = $0 }, { storage.installationDate }),
+            ("firstInitializationDateTime",
+             { storage.firstInitializationDateTime = $0 }, { storage.firstInitializationDateTime }),
+            ("apnsTokenSaveDate",
+             { storage.apnsTokenSaveDate = $0 }, { storage.apnsTokenSaveDate }),
+            ("lastInfoUpdateDate",
+             { storage.lastInfoUpdateDate = $0 }, { storage.lastInfoUpdateDate }),
+            ("deprecatedEventsRemoveDate",
+             { storage.deprecatedEventsRemoveDate = $0 }, { storage.deprecatedEventsRemoveDate }),
+            ("configDownloadDate",
+             { storage.configDownloadDate = $0 }, { storage.configDownloadDate }),
+        ]
+
+        // Whole-second timestamp: the `.utc` format ("yyyy-MM-dd'T'HH:mm:ss'Z'") has no sub-second
+        // component, so a round-trip is exact only at second precision.
+        let expectedEpoch = 1_700_000_000
+
+        for testCase in cases {
+            testCase.set(Date(timeIntervalSince1970: TimeInterval(expectedEpoch)))
+            let readBack = testCase.get()
+
+            let epoch = readBack.map { Int($0.timeIntervalSince1970) }
+            #expect(
+                epoch == expectedEpoch,
+                "\(testCase.name) must round-trip through storage. Expected \(expectedEpoch), got \(String(describing: epoch))."
+            )
+
+            testCase.set(nil)
+            #expect(
+                testCase.get() == nil,
+                "\(testCase.name) must be nil after being cleared."
+            )
+        }
+    }
+}

--- a/MindboxTests/MigrationsTests/DateFormatMigrationTests.swift
+++ b/MindboxTests/MigrationsTests/DateFormatMigrationTests.swift
@@ -184,6 +184,18 @@ extension DateFormatMigrationTests {
         XCTAssertTrue(storage.isInstalled)
     }
 
+    /// Ordering contract: `DateFormatMigration` must sort ahead of any date-consuming migration
+    /// in `MigrationManager`'s ascending-by-`version` chain. If this regresses (e.g. a renumber),
+    /// `FirstInitializationDateTimeMigration` would read an unparseable legacy `installationDate`
+    /// as `nil` and silently skip — the original upgrade bug.
+    func test_version_sortsBeforeDateConsumingMigration() {
+        XCTAssertLessThan(
+            DateFormatMigration().version,
+            FirstInitializationDateTimeMigration().version,
+            "DateFormatMigration must run before FirstInitializationDateTimeMigration."
+        )
+    }
+
     func test_run_idempotent_whenCalledTwice() throws {
         userDefaults.set(legacyString(from: fixedDate), forKey: installationKey)
 

--- a/MindboxTests/MigrationsTests/DateFormatMigrationTests.swift
+++ b/MindboxTests/MigrationsTests/DateFormatMigrationTests.swift
@@ -1,0 +1,136 @@
+//
+//  DateFormatMigrationTests.swift
+//  MindboxTests
+//
+//  Created by Akylbek Utekeshev on 04.06.2026.
+//  Copyright © 2026 Mindbox. All rights reserved.
+//
+
+import XCTest
+@testable import Mindbox
+import MindboxLogger
+
+final class DateFormatMigrationTests: XCTestCase {
+
+    private var migration: MigrationProtocol!
+    private var userDefaults: UserDefaults!
+    private let userDefaultsSuiteName = "DateFormatMigrationTests"
+
+    private let installationKey = "MBPersistenceStorage-installationData"
+    private let firstInitKey = "MBPersistenceStorage-firstInitializationDateTime"
+    private let apnsKey = "MBPersistenceStorage-apnsTokenSaveDate"
+    private let configKey = "MBPersistenceStorage-configDownloadDate"
+    private let lastInfoKey = "MBPersistenceStorage-lastInfoUpdateTime"
+    private let deprecatedKey = "MBPersistenceStorage-deprecatedEventsRemoveDate"
+
+    private var allKeys: [String] {
+        [installationKey, firstInitKey, apnsKey, configKey, lastInfoKey, deprecatedKey]
+    }
+
+    override func setUp() {
+        super.setUp()
+        userDefaults = UserDefaults(suiteName: userDefaultsSuiteName)!
+        userDefaults.removePersistentDomain(forName: userDefaultsSuiteName)
+        MBPersistenceStorage.defaults = userDefaults
+        migration = DateFormatMigration()
+    }
+
+    override func tearDown() {
+        userDefaults.removePersistentDomain(forName: userDefaultsSuiteName)
+        super.tearDown()
+    }
+
+    // MARK: - Helpers
+
+    /// Produces a string in the legacy format (replica of the removed MBPersistenceStorage formatter).
+    private func legacyString(from date: Date) -> String {
+        let formatter = DateFormatter()
+        formatter.dateStyle = .full
+        formatter.timeStyle = .full
+        return formatter.string(from: date)
+    }
+
+    /// Whole-second instant so legacy (`.full`) and `.utc` representations round-trip exactly.
+    private var fixedDate: Date {
+        Date(timeIntervalSince1970: 1_700_000_000)
+    }
+}
+
+// MARK: - Scenarios
+
+extension DateFormatMigrationTests {
+
+    func test_isNeeded_true_whenLegacyValuePresent() {
+        userDefaults.set(legacyString(from: fixedDate), forKey: installationKey)
+        XCTAssertTrue(migration.isNeeded)
+    }
+
+    func test_isNeeded_false_whenNoValues() {
+        XCTAssertFalse(migration.isNeeded)
+        XCTAssertNoThrow(try migration.run())
+    }
+
+    func test_run_convertsLegacyInstallationDate_andRestoresIsInstalled() throws {
+        userDefaults.set(legacyString(from: fixedDate), forKey: installationKey)
+
+        // Before migration: the legacy string is unparseable by the new `.utc` reader.
+        let storageBefore = MBPersistenceStorage(defaults: userDefaults)
+        XCTAssertNil(storageBefore.installationDate)
+        XCTAssertFalse(storageBefore.isInstalled)
+
+        try migration.run()
+
+        let storageAfter = MBPersistenceStorage(defaults: userDefaults)
+        XCTAssertNotNil(storageAfter.installationDate)
+        XCTAssertTrue(storageAfter.isInstalled)
+        XCTAssertEqual(
+            storageAfter.installationDate.map { Int($0.timeIntervalSince1970) },
+            Int(fixedDate.timeIntervalSince1970)
+        )
+        XCTAssertFalse(migration.isNeeded)
+    }
+
+    func test_run_convertsAllSixKeys() throws {
+        allKeys.forEach { userDefaults.set(legacyString(from: fixedDate), forKey: $0) }
+
+        try migration.run()
+
+        for key in allKeys {
+            let raw = userDefaults.string(forKey: key)
+            XCTAssertNotNil(raw?.toDate(withFormat: .utc), "Key \(key) was not converted to .utc")
+        }
+        XCTAssertFalse(migration.isNeeded)
+    }
+
+    func test_run_leavesAlreadyUtcValueUntouched() throws {
+        let utc = fixedDate.toString(withFormat: .utc)
+        userDefaults.set(utc, forKey: installationKey)
+
+        XCTAssertFalse(migration.isNeeded)
+        try migration.run()
+
+        XCTAssertEqual(userDefaults.string(forKey: installationKey), utc)
+    }
+
+    func test_run_leavesUnparseableValueUntouched() throws {
+        let garbage = "definitely not a date"
+        userDefaults.set(garbage, forKey: installationKey)
+
+        XCTAssertFalse(migration.isNeeded)
+        try migration.run()
+
+        XCTAssertEqual(userDefaults.string(forKey: installationKey), garbage)
+    }
+
+    func test_run_idempotent_whenCalledTwice() throws {
+        userDefaults.set(legacyString(from: fixedDate), forKey: installationKey)
+
+        try migration.run()
+        let afterFirstRun = userDefaults.string(forKey: installationKey)
+        XCTAssertFalse(migration.isNeeded)
+
+        try migration.run()
+        XCTAssertEqual(userDefaults.string(forKey: installationKey), afterFirstRun)
+        XCTAssertFalse(migration.isNeeded)
+    }
+}

--- a/MindboxTests/MigrationsTests/DateFormatMigrationTests.swift
+++ b/MindboxTests/MigrationsTests/DateFormatMigrationTests.swift
@@ -70,16 +70,19 @@ extension DateFormatMigrationTests {
         XCTAssertNoThrow(try migration.run())
     }
 
-    func test_run_convertsLegacyInstallationDate_andRestoresIsInstalled() throws {
+    func test_run_convertsLegacyInstallationDate_andKeepsIsInstalledStable() throws {
         userDefaults.set(legacyString(from: fixedDate), forKey: installationKey)
 
-        // Before migration: the legacy string is unparseable by the new `.utc` reader.
+        // Before migration: the legacy string is unparseable by the new `.utc` reader,
+        // so the parsed `installationDate` is nil — but `isInstalled` stays true because
+        // it depends on the stored string's presence, not on parsing it.
         let storageBefore = MBPersistenceStorage(defaults: userDefaults)
         XCTAssertNil(storageBefore.installationDate)
-        XCTAssertFalse(storageBefore.isInstalled)
+        XCTAssertTrue(storageBefore.isInstalled)
 
         try migration.run()
 
+        // After migration: the date value parses again, and `isInstalled` is unchanged.
         let storageAfter = MBPersistenceStorage(defaults: userDefaults)
         XCTAssertNotNil(storageAfter.installationDate)
         XCTAssertTrue(storageAfter.isInstalled)
@@ -120,6 +123,19 @@ extension DateFormatMigrationTests {
         try migration.run()
 
         XCTAssertEqual(userDefaults.string(forKey: installationKey), garbage)
+    }
+
+    /// Regression: an installed user must stay installed even when the stored installation
+    /// date string cannot be parsed (e.g. a region / 12h↔24h time-format change made a
+    /// legacy localized string unreadable). `isInstalled` depends on the string's presence,
+    /// not on parsing it, so it stays true without any migration having run.
+    func test_isInstalled_true_forUnparseableInstallationDate_withoutMigration() {
+        userDefaults.set("definitely not a parseable date", forKey: installationKey)
+
+        let storage = MBPersistenceStorage(defaults: userDefaults)
+
+        XCTAssertNil(storage.installationDate)
+        XCTAssertTrue(storage.isInstalled)
     }
 
     func test_run_idempotent_whenCalledTwice() throws {

--- a/MindboxTests/MigrationsTests/DateFormatMigrationTests.swift
+++ b/MindboxTests/MigrationsTests/DateFormatMigrationTests.swift
@@ -50,6 +50,19 @@ final class DateFormatMigrationTests: XCTestCase {
         return formatter.string(from: date)
     }
 
+    /// Produces a legacy `.full`/`.full` string with the hour cycle pinned (e.g. `h12` / `h23`),
+    /// keeping the current device language/region. Mirrors how `DateFormatMigration` builds its
+    /// candidate locales, so a value written here is the same shape the migration must parse.
+    private func legacyString(from date: Date, hourCycle: String) -> String {
+        let base = Locale.current.identifier
+        let separator = base.contains("@") ? ";" : "@"
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: base + separator + "hours=" + hourCycle)
+        formatter.dateStyle = .full
+        formatter.timeStyle = .full
+        return formatter.string(from: date)
+    }
+
     /// Whole-second instant so legacy (`.full`) and `.utc` representations round-trip exactly.
     private var fixedDate: Date {
         Date(timeIntervalSince1970: 1_700_000_000)
@@ -89,6 +102,39 @@ extension DateFormatMigrationTests {
         XCTAssertEqual(
             storageAfter.installationDate.map { Int($0.timeIntervalSince1970) },
             Int(fixedDate.timeIntervalSince1970)
+        )
+        XCTAssertFalse(migration.isNeeded)
+    }
+
+    /// The original re-installation bug: a value written under 12h must still convert when the
+    /// migration runs (even if the device is now in 24h). The 12h candidate rescues it.
+    func test_run_convertsLegacyInstallationDate_writtenIn12hFormat() throws {
+        userDefaults.set(legacyString(from: fixedDate, hourCycle: "h12"), forKey: installationKey)
+
+        XCTAssertTrue(migration.isNeeded, "A 12h legacy value must be recognized as needing migration.")
+        try migration.run()
+
+        let raw = userDefaults.string(forKey: installationKey)
+        XCTAssertEqual(
+            raw?.toDate(withFormat: .utc).map { Int($0.timeIntervalSince1970) },
+            Int(fixedDate.timeIntervalSince1970),
+            "12h legacy installation date must be converted to the correct .utc instant."
+        )
+        XCTAssertFalse(migration.isNeeded)
+    }
+
+    /// Symmetric to the 12h case: a value written under 24h converts as well.
+    func test_run_convertsLegacyInstallationDate_writtenIn24hFormat() throws {
+        userDefaults.set(legacyString(from: fixedDate, hourCycle: "h23"), forKey: installationKey)
+
+        XCTAssertTrue(migration.isNeeded, "A 24h legacy value must be recognized as needing migration.")
+        try migration.run()
+
+        let raw = userDefaults.string(forKey: installationKey)
+        XCTAssertEqual(
+            raw?.toDate(withFormat: .utc).map { Int($0.timeIntervalSince1970) },
+            Int(fixedDate.timeIntervalSince1970),
+            "24h legacy installation date must be converted to the correct .utc instant."
         )
         XCTAssertFalse(migration.isNeeded)
     }

--- a/MindboxTests/MigrationsTests/DateFormatMigrationTests.swift
+++ b/MindboxTests/MigrationsTests/DateFormatMigrationTests.swift
@@ -6,15 +6,20 @@
 //  Copyright © 2026 Mindbox. All rights reserved.
 //
 
-import XCTest
+import Testing
+import Foundation
 @testable import Mindbox
 import MindboxLogger
 
-final class DateFormatMigrationTests: XCTestCase {
+// A class-based suite so `deinit` can restore the global `MBPersistenceStorage.defaults`
+// after every test. `.serialized` because the tests mutate that shared global.
+@Suite(.serialized)
+final class DateFormatMigrationTests {
 
-    private var migration: MigrationProtocol!
-    private var userDefaults: UserDefaults!
+    private let migration: MigrationProtocol
+    private let userDefaults: UserDefaults
     private let userDefaultsSuiteName = "DateFormatMigrationTests"
+    private let originalDefaults: UserDefaults
 
     private let installationKey = "MBPersistenceStorage-installationData"
     private let firstInitKey = "MBPersistenceStorage-firstInitializationDateTime"
@@ -27,22 +32,24 @@ final class DateFormatMigrationTests: XCTestCase {
         [installationKey, firstInitKey, apnsKey, configKey, lastInfoKey, deprecatedKey]
     }
 
-    override func setUp() {
-        super.setUp()
+    init() {
+        originalDefaults = MBPersistenceStorage.defaults
         userDefaults = UserDefaults(suiteName: userDefaultsSuiteName)!
         userDefaults.removePersistentDomain(forName: userDefaultsSuiteName)
         MBPersistenceStorage.defaults = userDefaults
         migration = DateFormatMigration()
     }
 
-    override func tearDown() {
+    deinit {
         userDefaults.removePersistentDomain(forName: userDefaultsSuiteName)
-        super.tearDown()
+        // Restore the global so this suite never leaks its private suite into other tests.
+        MBPersistenceStorage.defaults = originalDefaults
     }
 
     // MARK: - Helpers
 
-    /// Produces a string in the legacy format (replica of the removed MBPersistenceStorage formatter).
+    /// Produces a string in the legacy format (replica of the removed MBPersistenceStorage
+    /// formatter) under the device's current 12h/24h setting.
     private func legacyString(from date: Date) -> String {
         let formatter = DateFormatter()
         formatter.dateStyle = .full
@@ -50,14 +57,19 @@ final class DateFormatMigrationTests: XCTestCase {
         return formatter.string(from: date)
     }
 
-    /// Produces a legacy `.full`/`.full` string with the hour cycle pinned (e.g. `h12` / `h23`),
-    /// keeping the current device language/region. Mirrors how `DateFormatMigration` builds its
-    /// candidate locales, so a value written here is the same shape the migration must parse.
-    private func legacyString(from date: Date, hourCycle: String) -> String {
-        let base = Locale.current.identifier
-        let separator = base.contains("@") ? ";" : "@"
+    /// Independent oracle for the hour-cycle rescue: builds a legacy `.full`/`.full` string with the
+    /// hour cycle pinned through the structured `Locale.Components` API — a *different* mechanism than
+    /// the `@hours=` identifier `DateFormatMigration` assembles itself. The base stays `Locale.current`
+    /// so only the hour cycle differs from the migration's candidates (the date layout still matches).
+    /// If the migration's hour-cycle keyword were wrong, this independently-built opposite-cycle string
+    /// would fail to parse — so the test proves the rescue works, not just that both sides build the
+    /// same identifier.
+    @available(iOS 16.0, *)
+    private func independentLegacyString(from date: Date, hourCycle: Locale.HourCycle) -> String {
+        var components = Locale.Components(locale: .current)
+        components.hourCycle = hourCycle
         let formatter = DateFormatter()
-        formatter.locale = Locale(identifier: base + separator + "hours=" + hourCycle)
+        formatter.locale = Locale(components: components)
         formatter.dateStyle = .full
         formatter.timeStyle = .full
         return formatter.string(from: date)
@@ -73,138 +85,156 @@ final class DateFormatMigrationTests: XCTestCase {
 
 extension DateFormatMigrationTests {
 
-    func test_isNeeded_true_whenLegacyValuePresent() {
+    @Test("isNeeded is true when a legacy value is present")
+    func isNeededTrueWhenLegacyValuePresent() {
         userDefaults.set(legacyString(from: fixedDate), forKey: installationKey)
-        XCTAssertTrue(migration.isNeeded)
+        #expect(migration.isNeeded)
     }
 
-    func test_isNeeded_false_whenNoValues() {
-        XCTAssertFalse(migration.isNeeded)
-        XCTAssertNoThrow(try migration.run())
+    @Test("isNeeded is false and run() is a no-op when there are no values")
+    func isNeededFalseWhenNoValues() throws {
+        #expect(migration.isNeeded == false)
+        try migration.run()
     }
 
-    func test_run_convertsLegacyInstallationDate_andKeepsIsInstalledStable() throws {
+    @Test("run() converts a legacy installation date and keeps isInstalled stable")
+    func runConvertsLegacyInstallationDateAndKeepsIsInstalledStable() throws {
         userDefaults.set(legacyString(from: fixedDate), forKey: installationKey)
 
         // Before migration: the legacy string is unparseable by the new `.utc` reader,
         // so the parsed `installationDate` is nil — but `isInstalled` stays true because
         // it depends on the stored string's presence, not on parsing it.
         let storageBefore = MBPersistenceStorage(defaults: userDefaults)
-        XCTAssertNil(storageBefore.installationDate)
-        XCTAssertTrue(storageBefore.isInstalled)
+        #expect(storageBefore.installationDate == nil)
+        #expect(storageBefore.isInstalled)
 
         try migration.run()
 
         // After migration: the date value parses again, and `isInstalled` is unchanged.
         let storageAfter = MBPersistenceStorage(defaults: userDefaults)
-        XCTAssertNotNil(storageAfter.installationDate)
-        XCTAssertTrue(storageAfter.isInstalled)
-        XCTAssertEqual(
-            storageAfter.installationDate.map { Int($0.timeIntervalSince1970) },
-            Int(fixedDate.timeIntervalSince1970)
+        #expect(storageAfter.installationDate != nil)
+        #expect(storageAfter.isInstalled)
+        #expect(
+            storageAfter.installationDate.map { Int($0.timeIntervalSince1970) }
+                == Int(fixedDate.timeIntervalSince1970)
         )
-        XCTAssertFalse(migration.isNeeded)
+        #expect(migration.isNeeded == false)
     }
 
     /// The original re-installation bug: a value written under 12h must still convert when the
     /// migration runs (even if the device is now in 24h). The 12h candidate rescues it.
-    func test_run_convertsLegacyInstallationDate_writtenIn12hFormat() throws {
-        userDefaults.set(legacyString(from: fixedDate, hourCycle: "h12"), forKey: installationKey)
+    @available(iOS 16.0, *)
+    @Test("run() converts a legacy installation date written in 12h format")
+    func runConvertsLegacyInstallationDateWrittenIn12hFormat() throws {
+        userDefaults.set(
+            independentLegacyString(from: fixedDate, hourCycle: .oneToTwelve),
+            forKey: installationKey
+        )
 
-        XCTAssertTrue(migration.isNeeded, "A 12h legacy value must be recognized as needing migration.")
+        #expect(migration.isNeeded, "A 12h legacy value must be recognized as needing migration.")
         try migration.run()
 
         let raw = userDefaults.string(forKey: installationKey)
-        XCTAssertEqual(
-            raw?.toDate(withFormat: .utc).map { Int($0.timeIntervalSince1970) },
-            Int(fixedDate.timeIntervalSince1970),
+        #expect(
+            raw?.toDate(withFormat: .utc).map { Int($0.timeIntervalSince1970) }
+                == Int(fixedDate.timeIntervalSince1970),
             "12h legacy installation date must be converted to the correct .utc instant."
         )
-        XCTAssertFalse(migration.isNeeded)
+        #expect(migration.isNeeded == false)
     }
 
     /// Symmetric to the 12h case: a value written under 24h converts as well.
-    func test_run_convertsLegacyInstallationDate_writtenIn24hFormat() throws {
-        userDefaults.set(legacyString(from: fixedDate, hourCycle: "h23"), forKey: installationKey)
+    @available(iOS 16.0, *)
+    @Test("run() converts a legacy installation date written in 24h format")
+    func runConvertsLegacyInstallationDateWrittenIn24hFormat() throws {
+        userDefaults.set(
+            independentLegacyString(from: fixedDate, hourCycle: .zeroToTwentyThree),
+            forKey: installationKey
+        )
 
-        XCTAssertTrue(migration.isNeeded, "A 24h legacy value must be recognized as needing migration.")
+        #expect(migration.isNeeded, "A 24h legacy value must be recognized as needing migration.")
         try migration.run()
 
         let raw = userDefaults.string(forKey: installationKey)
-        XCTAssertEqual(
-            raw?.toDate(withFormat: .utc).map { Int($0.timeIntervalSince1970) },
-            Int(fixedDate.timeIntervalSince1970),
+        #expect(
+            raw?.toDate(withFormat: .utc).map { Int($0.timeIntervalSince1970) }
+                == Int(fixedDate.timeIntervalSince1970),
             "24h legacy installation date must be converted to the correct .utc instant."
         )
-        XCTAssertFalse(migration.isNeeded)
+        #expect(migration.isNeeded == false)
     }
 
-    func test_run_convertsAllSixKeys() throws {
+    @Test("run() converts all six persisted date keys")
+    func runConvertsAllSixKeys() throws {
         allKeys.forEach { userDefaults.set(legacyString(from: fixedDate), forKey: $0) }
 
         try migration.run()
 
         for key in allKeys {
             let raw = userDefaults.string(forKey: key)
-            XCTAssertNotNil(raw?.toDate(withFormat: .utc), "Key \(key) was not converted to .utc")
+            #expect(raw?.toDate(withFormat: .utc) != nil, "Key \(key) was not converted to .utc")
         }
-        XCTAssertFalse(migration.isNeeded)
+        #expect(migration.isNeeded == false)
     }
 
-    func test_run_leavesAlreadyUtcValueUntouched() throws {
+    @Test("run() leaves an already-.utc value untouched")
+    func runLeavesAlreadyUtcValueUntouched() throws {
         let utc = fixedDate.toString(withFormat: .utc)
         userDefaults.set(utc, forKey: installationKey)
 
-        XCTAssertFalse(migration.isNeeded)
+        #expect(migration.isNeeded == false)
         try migration.run()
 
-        XCTAssertEqual(userDefaults.string(forKey: installationKey), utc)
+        #expect(userDefaults.string(forKey: installationKey) == utc)
     }
 
-    func test_run_leavesUnparseableValueUntouched() throws {
+    @Test("run() leaves an unparseable value untouched")
+    func runLeavesUnparseableValueUntouched() throws {
         let garbage = "definitely not a date"
         userDefaults.set(garbage, forKey: installationKey)
 
-        XCTAssertFalse(migration.isNeeded)
+        #expect(migration.isNeeded == false)
         try migration.run()
 
-        XCTAssertEqual(userDefaults.string(forKey: installationKey), garbage)
+        #expect(userDefaults.string(forKey: installationKey) == garbage)
     }
 
     /// Regression: an installed user must stay installed even when the stored installation
     /// date string cannot be parsed (e.g. a region / 12h↔24h time-format change made a
     /// legacy localized string unreadable). `isInstalled` depends on the string's presence,
     /// not on parsing it, so it stays true without any migration having run.
-    func test_isInstalled_true_forUnparseableInstallationDate_withoutMigration() {
+    @Test("isInstalled stays true for an unparseable installation date, without migration")
+    func isInstalledTrueForUnparseableInstallationDateWithoutMigration() {
         userDefaults.set("definitely not a parseable date", forKey: installationKey)
 
         let storage = MBPersistenceStorage(defaults: userDefaults)
 
-        XCTAssertNil(storage.installationDate)
-        XCTAssertTrue(storage.isInstalled)
+        #expect(storage.installationDate == nil)
+        #expect(storage.isInstalled)
     }
 
     /// Ordering contract: `DateFormatMigration` must sort ahead of any date-consuming migration
     /// in `MigrationManager`'s ascending-by-`version` chain. If this regresses (e.g. a renumber),
     /// `FirstInitializationDateTimeMigration` would read an unparseable legacy `installationDate`
     /// as `nil` and silently skip — the original upgrade bug.
-    func test_version_sortsBeforeDateConsumingMigration() {
-        XCTAssertLessThan(
-            DateFormatMigration().version,
-            FirstInitializationDateTimeMigration().version,
+    @Test("version sorts before any date-consuming migration")
+    func versionSortsBeforeDateConsumingMigration() {
+        #expect(
+            DateFormatMigration().version < FirstInitializationDateTimeMigration().version,
             "DateFormatMigration must run before FirstInitializationDateTimeMigration."
         )
     }
 
-    func test_run_idempotent_whenCalledTwice() throws {
+    @Test("run() is idempotent when called twice")
+    func runIdempotentWhenCalledTwice() throws {
         userDefaults.set(legacyString(from: fixedDate), forKey: installationKey)
 
         try migration.run()
         let afterFirstRun = userDefaults.string(forKey: installationKey)
-        XCTAssertFalse(migration.isNeeded)
+        #expect(migration.isNeeded == false)
 
         try migration.run()
-        XCTAssertEqual(userDefaults.string(forKey: installationKey), afterFirstRun)
-        XCTAssertFalse(migration.isNeeded)
+        #expect(userDefaults.string(forKey: installationKey) == afterFirstRun)
+        #expect(migration.isNeeded == false)
     }
 }

--- a/MindboxTests/Mock/MockPersistenceStorage.swift
+++ b/MindboxTests/Mock/MockPersistenceStorage.swift
@@ -28,8 +28,11 @@ class MockPersistenceStorage: PersistenceStorage {
         }
     }
 
+    // Mirror production `MBPersistenceStorage`: installed state is the presence of the persisted
+    // installation-date string, never its parseability. Backing `installationDate` with a `.utc`
+    // string keeps the mock's `isInstalled` semantics identical to production.
     var isInstalled: Bool {
-        installationDate != nil
+        installationDateString != nil
     }
 
     var apnsToken: String? {
@@ -62,8 +65,14 @@ class MockPersistenceStorage: PersistenceStorage {
         }
     }
 
+    private var installationDateString: String?
+
     var installationDate: Date? {
-        didSet {
+        get {
+            installationDateString?.toDate(withFormat: .utc)
+        }
+        set {
+            installationDateString = newValue?.toString(withFormat: .utc)
             onDidChange?()
         }
     }

--- a/MindboxTests/Mock/MockPersistenceStorage.swift
+++ b/MindboxTests/Mock/MockPersistenceStorage.swift
@@ -28,9 +28,8 @@ class MockPersistenceStorage: PersistenceStorage {
         }
     }
 
-    // Mirror production `MBPersistenceStorage`: installed state is the presence of the persisted
-    // installation-date string, never its parseability. Backing `installationDate` with a `.utc`
-    // string keeps the mock's `isInstalled` semantics identical to production.
+    // Mirror production `MBPersistenceStorage`: installed state is the presence of a persisted
+    // installation-date marker, never its parseability — not `installationDate != nil` directly.
     var isInstalled: Bool {
         installationDateString != nil
     }
@@ -65,14 +64,14 @@ class MockPersistenceStorage: PersistenceStorage {
         }
     }
 
+    // Presence marker for `isInstalled`, mirroring production's installation-date string. The Date
+    // itself is stored as-is (no `.utc` flooring) so the mock keeps full precision like its other
+    // date properties — only `isInstalled` is derived from the marker's presence.
     private var installationDateString: String?
 
     var installationDate: Date? {
-        get {
-            installationDateString?.toDate(withFormat: .utc)
-        }
-        set {
-            installationDateString = newValue?.toString(withFormat: .utc)
+        didSet {
+            installationDateString = installationDate?.toString(withFormat: .utc)
             onDidChange?()
         }
     }


### PR DESCRIPTION
Ticket: https://tracker.yandex.ru/MOBILE-183

## Summary

Persisted dates were written through a localized `DateFormatter` (`dateStyle = .full`, `timeStyle = .full`), so a change of region/locale or the device 12h↔24h time setting made previously stored strings unparseable — routing an existing install down the fresh-install path and regenerating the device UUID. This unifies all date persistence on a single cached, thread-safe fixed-pattern UTC formatter, adds a migration that normalizes legacy strings, and decouples installed-state and device-UUID stability from date parsing.

## Type of Change

- [x] Bug fix
- [x] Refactor
- [x] Tests

## Changes

- Persist all `MBPersistenceStorage` dates via `.toString(withFormat: .utc)` / `.toDate(withFormat: .utc)` instead of a localized `.full`/`.full` `DateFormatter`.
- Make `isInstalled` depend on the presence of the stored installation-date string rather than its parseability, so region/locale and 12h↔24h changes no longer flip an existing install to "not installed".
- Reuse the persisted `deviceUUID` when present, regenerating only on a genuine first install (no longer tied to ATT/IDFA↔IDFV state or a transient locale-driven re-install).
- Unify `Date`/`String` date conversion on a single cached, lock-guarded `DateFormatter` per `DateFormat` (POSIX locale, explicit UTC, 24h `HH`).
- Add `DateFormatMigration` (ordered first in the chain, `version = -1`) to convert legacy localized date strings to canonical `.utc`, with 12h/24h candidate formatters to rescue values written under either hour cycle.
- Snapshot `isInstalledFromPersistenceStorageBeforeInitSDK` after migrations run in `CoreController`.

## Testing

- [x] Unit tests added/updated
- [ ] Manual testing performed
