### PR TITLE
MOBILE-0000: Raise `MindboxNotifications` coverage to ~96%; drop unused `logger` dep

### DIFF
--- a/Mindbox.xcodeproj/project.pbxproj
+++ b/Mindbox.xcodeproj/project.pbxproj
@@ -213,6 +213,11 @@
 		4747708B2C6B838B00C36FC8 /* SharedInternalMethodsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4747708A2C6B838B00C36FC8 /* SharedInternalMethodsTests.swift */; };
 		4747708F2C6B93AC00C36FC8 /* MindboxNotificationServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4747708E2C6B93AC00C36FC8 /* MindboxNotificationServiceTests.swift */; };
 		474770912C6B9A7200C36FC8 /* MindboxNotificationContentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 474770902C6B9A7200C36FC8 /* MindboxNotificationContentTests.swift */; };
+		06212EA5EAFF6E0B2673232F /* NotificationTestFixtures.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD8E942B5004DC96C644E39F /* NotificationTestFixtures.swift */; };
+		3CE2724E23B0E01A54EA3D0E /* Tag+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5624595257BF8C206167332 /* Tag+Extensions.swift */; };
+		800C44DB3C1226891455ACF8 /* ImageFormatTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D68AD2869EF175FE754AE284 /* ImageFormatTests.swift */; };
+		EEF7A48FC34733D3D1D1E5EE /* PushNotificationParsingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEDFA644103A7CA5760F368C /* PushNotificationParsingTests.swift */; };
+		65CF5AEAD0D6957DC4FF2BB6 /* MindboxPushNotificationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B909F3184E7FAE110C8D813 /* MindboxPushNotificationTests.swift */; };
 		474851C12C6A622E0026C38E /* NotificationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 474851C02C6A622E0026C38E /* NotificationService.swift */; };
 		474851C32C6A627F0026C38E /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 474851C22C6A627F0026C38E /* Constants.swift */; };
 		474851C52C6A62AE0026C38E /* NotificationContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 474851C42C6A62AE0026C38E /* NotificationContent.swift */; };
@@ -964,6 +969,11 @@
 		4747708A2C6B838B00C36FC8 /* SharedInternalMethodsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SharedInternalMethodsTests.swift; sourceTree = "<group>"; };
 		4747708E2C6B93AC00C36FC8 /* MindboxNotificationServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MindboxNotificationServiceTests.swift; sourceTree = "<group>"; };
 		474770902C6B9A7200C36FC8 /* MindboxNotificationContentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MindboxNotificationContentTests.swift; sourceTree = "<group>"; };
+		BD8E942B5004DC96C644E39F /* NotificationTestFixtures.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationTestFixtures.swift; sourceTree = "<group>"; };
+		F5624595257BF8C206167332 /* Tag+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Tag+Extensions.swift"; sourceTree = "<group>"; };
+		D68AD2869EF175FE754AE284 /* ImageFormatTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageFormatTests.swift; sourceTree = "<group>"; };
+		BEDFA644103A7CA5760F368C /* PushNotificationParsingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PushNotificationParsingTests.swift; sourceTree = "<group>"; };
+		8B909F3184E7FAE110C8D813 /* MindboxPushNotificationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MindboxPushNotificationTests.swift; sourceTree = "<group>"; };
 		474851C02C6A622E0026C38E /* NotificationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationService.swift; sourceTree = "<group>"; };
 		474851C22C6A627F0026C38E /* Constants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
 		474851C42C6A62AE0026C38E /* NotificationContent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationContent.swift; sourceTree = "<group>"; };
@@ -1726,6 +1736,11 @@
 				4747708E2C6B93AC00C36FC8 /* MindboxNotificationServiceTests.swift */,
 				474770902C6B9A7200C36FC8 /* MindboxNotificationContentTests.swift */,
 				4747708A2C6B838B00C36FC8 /* SharedInternalMethodsTests.swift */,
+				BD8E942B5004DC96C644E39F /* NotificationTestFixtures.swift */,
+				F5624595257BF8C206167332 /* Tag+Extensions.swift */,
+				D68AD2869EF175FE754AE284 /* ImageFormatTests.swift */,
+				BEDFA644103A7CA5760F368C /* PushNotificationParsingTests.swift */,
+				8B909F3184E7FAE110C8D813 /* MindboxPushNotificationTests.swift */,
 				3333C1A72681D3CF00B60D84 /* Info.plist */,
 			);
 			path = MindboxNotificationsTests;
@@ -4843,6 +4858,11 @@
 				4747708B2C6B838B00C36FC8 /* SharedInternalMethodsTests.swift in Sources */,
 				4747708F2C6B93AC00C36FC8 /* MindboxNotificationServiceTests.swift in Sources */,
 				474770912C6B9A7200C36FC8 /* MindboxNotificationContentTests.swift in Sources */,
+				06212EA5EAFF6E0B2673232F /* NotificationTestFixtures.swift in Sources */,
+				3CE2724E23B0E01A54EA3D0E /* Tag+Extensions.swift in Sources */,
+				800C44DB3C1226891455ACF8 /* ImageFormatTests.swift in Sources */,
+				EEF7A48FC34733D3D1D1E5EE /* PushNotificationParsingTests.swift in Sources */,
+				65CF5AEAD0D6957DC4FF2BB6 /* MindboxPushNotificationTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Mindbox.xcodeproj/project.pbxproj
+++ b/Mindbox.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		06212EA5EAFF6E0B2673232F /* NotificationTestFixtures.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD8E942B5004DC96C644E39F /* NotificationTestFixtures.swift */; };
 		0A3D045A2BC6803E00E1FC52 /* ImageFormat.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A3D04592BC6803E00E1FC52 /* ImageFormat.swift */; };
 		0E7A224A082FA2DA35706CC7 /* MotionServiceResolvePositionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C8192B8B7043EF74D05B36B /* MotionServiceResolvePositionTests.swift */; };
 		0E7A224A082FA2DA35706CC8 /* MotionServiceShakeToEditTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C8192B8B7043EF74D05B36C /* MotionServiceShakeToEditTests.swift */; };
@@ -15,9 +16,6 @@
 		302E35788CBDA959283569F4 /* MotionServiceBehaviorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0DB93A7997961CA7C2BE917 /* MotionServiceBehaviorTests.swift */; };
 		313B233A25ADEA0F00A1CB72 /* Mindbox.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 313B233025ADEA0F00A1CB72 /* Mindbox.framework */; };
 		313B233F25ADEA0F00A1CB72 /* MindboxTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 313B233E25ADEA0F00A1CB72 /* MindboxTests.swift */; };
-		A1B2C3D4E5F60718293A4B01 /* MindboxOperationsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F60718293A4B02 /* MindboxOperationsTests.swift */; };
-		A1B2C3D4E5F60718293A4B03 /* OperationNameValidatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F60718293A4B04 /* OperationNameValidatorTests.swift */; };
-		A1B2C3D4E5F60718293A4B05 /* PollUntil.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F60718293A4B06 /* PollUntil.swift */; };
 		313B234125ADEA0F00A1CB72 /* Mindbox.h in Headers */ = {isa = PBXBuildFile; fileRef = 313B233325ADEA0F00A1CB72 /* Mindbox.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		314B38FD25AEE8B200E947B9 /* MBConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 314B38FC25AEE8B200E947B9 /* MBConfiguration.swift */; };
 		314B390025AEE96F00E947B9 /* CoreController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 314B38FF25AEE96F00E947B9 /* CoreController.swift */; };
@@ -102,6 +100,7 @@
 		33C81EA4264145CD00863380 /* TimerManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33C81EA3264145CD00863380 /* TimerManager.swift */; };
 		33E42E5C268323E60046CBCB /* CashdeskRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33E42E5B268323E60046CBCB /* CashdeskRequest.swift */; };
 		33EBF0B0264E6283002A35D5 /* MBSessionManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33EBF0AF264E6283002A35D5 /* MBSessionManager.swift */; };
+		3CE2724E23B0E01A54EA3D0E /* Tag+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5624595257BF8C206167332 /* Tag+Extensions.swift */; };
 		3FB93AC126964AD3A061B4A7 /* FeatureToggleManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3456BAC56F984378B6CED7CB /* FeatureToggleManager.swift */; };
 		472179A72C80755A00C15E7F /* ShownInAppsIDsMigration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 472179A62C80755A00C15E7F /* ShownInAppsIDsMigration.swift */; };
 		472765522E0D52A500A5A060 /* RemoveBackgroundTaskDataMigration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 472765512E0D52A500A5A060 /* RemoveBackgroundTaskDataMigration.swift */; };
@@ -213,11 +212,6 @@
 		4747708B2C6B838B00C36FC8 /* SharedInternalMethodsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4747708A2C6B838B00C36FC8 /* SharedInternalMethodsTests.swift */; };
 		4747708F2C6B93AC00C36FC8 /* MindboxNotificationServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4747708E2C6B93AC00C36FC8 /* MindboxNotificationServiceTests.swift */; };
 		474770912C6B9A7200C36FC8 /* MindboxNotificationContentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 474770902C6B9A7200C36FC8 /* MindboxNotificationContentTests.swift */; };
-		06212EA5EAFF6E0B2673232F /* NotificationTestFixtures.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD8E942B5004DC96C644E39F /* NotificationTestFixtures.swift */; };
-		3CE2724E23B0E01A54EA3D0E /* Tag+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5624595257BF8C206167332 /* Tag+Extensions.swift */; };
-		800C44DB3C1226891455ACF8 /* ImageFormatTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D68AD2869EF175FE754AE284 /* ImageFormatTests.swift */; };
-		EEF7A48FC34733D3D1D1E5EE /* PushNotificationParsingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEDFA644103A7CA5760F368C /* PushNotificationParsingTests.swift */; };
-		65CF5AEAD0D6957DC4FF2BB6 /* MindboxPushNotificationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B909F3184E7FAE110C8D813 /* MindboxPushNotificationTests.swift */; };
 		474851C12C6A622E0026C38E /* NotificationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 474851C02C6A622E0026C38E /* NotificationService.swift */; };
 		474851C32C6A627F0026C38E /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 474851C22C6A627F0026C38E /* Constants.swift */; };
 		474851C52C6A62AE0026C38E /* NotificationContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 474851C42C6A62AE0026C38E /* NotificationContent.swift */; };
@@ -253,6 +247,7 @@
 		47EFF0FD2E8D85B700E72D0A /* DatabaseMetadataMigrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47EFF0FC2E8D85B700E72D0A /* DatabaseMetadataMigrationTests.swift */; };
 		47FDF0BA2C5BDAB80051F08C /* MigrationManagerProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47FDF0B92C5BDAB80051F08C /* MigrationManagerProtocol.swift */; };
 		47FDF0BC2C5BE8BB0051F08C /* MigrationProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47FDF0BB2C5BE8BB0051F08C /* MigrationProtocol.swift */; };
+		4841683F6839440F84477966 /* OperationNameValidator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EF1D88A18D64D60BD03ABB8 /* OperationNameValidator.swift */; };
 		5D3FCB95C2AF59DF36A61254 /* WebViewLocalStateStorageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CFCC82B8014DE7276C217CD /* WebViewLocalStateStorageTests.swift */; };
 		6182078DDFC681D168546DAD /* HapticService.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD1BE43AA9EAEA03F8ED4008 /* HapticService.swift */; };
 		6182078DDFC681D168546DAE /* HapticRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD1BE43AA9EAEA03F8ED4009 /* HapticRequest.swift */; };
@@ -260,6 +255,7 @@
 		6182078DDFC681D168546DB0 /* HapticRequestValidator.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD1BE43AA9EAEA03F8ED400B /* HapticRequestValidator.swift */; };
 		6182078DDFC681D168546DB1 /* HapticRequestParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD1BE43AA9EAEA03F8ED400C /* HapticRequestParserTests.swift */; };
 		6182078DDFC681D168546DB2 /* HapticRequestValidatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD1BE43AA9EAEA03F8ED400D /* HapticRequestValidatorTests.swift */; };
+		65CF5AEAD0D6957DC4FF2BB6 /* MindboxPushNotificationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B909F3184E7FAE110C8D813 /* MindboxPushNotificationTests.swift */; };
 		6F1EAA16266A670E007A335B /* ProductListItemsResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F1EAA15266A670E007A335B /* ProductListItemsResponse.swift */; };
 		6FDD143B266F7BD900A50C35 /* ProcessingStatusResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FDD143A266F7BD900A50C35 /* ProcessingStatusResponse.swift */; };
 		6FDD143D266F7BEB00A50C35 /* ItemResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FDD143C266F7BEB00A50C35 /* ItemResponse.swift */; };
@@ -284,6 +280,7 @@
 		6FDD1463266F7CED00A50C35 /* ProductElementReponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FDD1462266F7CED00A50C35 /* ProductElementReponse.swift */; };
 		6FDD1465266F7CFE00A50C35 /* ItemProductResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FDD1464266F7CFE00A50C35 /* ItemProductResponse.swift */; };
 		7764BA10E25046CEA7035ED8 /* DateFormatMigration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8755088A5E704C65A1C3F6DB /* DateFormatMigration.swift */; };
+		800C44DB3C1226891455ACF8 /* ImageFormatTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D68AD2869EF175FE754AE284 /* ImageFormatTests.swift */; };
 		813FE960DC0543F681C94275 /* SettingsRequestParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30FC619AC23245CC8CD45E63 /* SettingsRequestParser.swift */; };
 		840042A12614CE0000CA17C5 /* ClickNotificationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 840042A02614CE0000CA17C5 /* ClickNotificationManager.swift */; };
 		840C387225CC1AF200D50183 /* CDEvent+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 840C387025CC1AF200D50183 /* CDEvent+CoreDataClass.swift */; };
@@ -312,7 +309,6 @@
 		84B09FB42611C74400B0A06E /* MockDatabaseRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84B09FB32611C74400B0A06E /* MockDatabaseRepository.swift */; };
 		84B625D925C9558E00AB6228 /* MBPersistenceStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84B625D825C9558E00AB6228 /* MBPersistenceStorage.swift */; };
 		84B625E425C988FA00AB6228 /* URLValidator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84B625E325C988FA00AB6228 /* URLValidator.swift */; };
-		4841683F6839440F84477966 /* OperationNameValidator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EF1D88A18D64D60BD03ABB8 /* OperationNameValidator.swift */; };
 		84B625E925C989C100AB6228 /* UDIDValidator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84B625E825C989C100AB6228 /* UDIDValidator.swift */; };
 		84B625F025C98B1200AB6228 /* ValidatorsTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84B625EF25C98B1200AB6228 /* ValidatorsTestCase.swift */; };
 		84BAEF8225D54919002E8A26 /* BodyDecoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84BAEF8125D54919002E8A26 /* BodyDecoder.swift */; };
@@ -370,7 +366,6 @@
 		A11C2D3E4F5566778899AA11 /* DeviceUUIDInitializationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B11C2D3E4F5566778899AA11 /* DeviceUUIDInitializationTests.swift */; };
 		A11C2D3E4F5566778899AA12 /* MBPersistenceStorageDateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B11C2D3E4F5566778899AA12 /* MBPersistenceStorageDateTests.swift */; };
 		A11FBE8929DD76BF00F5FB7B /* InAppMessagesEventSender.swift in Sources */ = {isa = PBXBuildFile; fileRef = A11FBE8829DD76BF00F5FB7B /* InAppMessagesEventSender.swift */; };
-		A1515DB229B228F40025E2EE /* MindboxLogger.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A17853BE29AF7E940072578F /* MindboxLogger.framework */; };
 		A153E03B29BAFE01003C34D4 /* CustomOperationTargeting.swift in Sources */ = {isa = PBXBuildFile; fileRef = A153E03A29BAFE01003C34D4 /* CustomOperationTargeting.swift */; };
 		A153E03D29BAFEC1003C34D4 /* CustomOperationChecker.swift in Sources */ = {isa = PBXBuildFile; fileRef = A153E03C29BAFEC0003C34D4 /* CustomOperationChecker.swift */; };
 		A153E03F29BB002A003C34D4 /* SessionTemporaryStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = A153E03E29BB002A003C34D4 /* SessionTemporaryStorage.swift */; };
@@ -433,6 +428,9 @@
 		A1B2C3D400000014E1010101 /* PushNotificationsPermissionHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D400000015E1010101 /* PushNotificationsPermissionHandler.swift */; };
 		A1B2C3D400000020E1010101 /* PushPermissionHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D400000021E1010101 /* PushPermissionHelper.swift */; };
 		A1B2C3D400000030E1010101 /* PushPermissionHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D400000031E1010101 /* PushPermissionHelperTests.swift */; };
+		A1B2C3D4E5F60718293A4B01 /* MindboxOperationsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F60718293A4B02 /* MindboxOperationsTests.swift */; };
+		A1B2C3D4E5F60718293A4B03 /* OperationNameValidatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F60718293A4B04 /* OperationNameValidatorTests.swift */; };
+		A1B2C3D4E5F60718293A4B05 /* PollUntil.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F60718293A4B06 /* PollUntil.swift */; };
 		A1B2C3D4E5F6A7B8C9D0E1F2 /* MotionService.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F6A7B8C9D0E1F3 /* MotionService.swift */; };
 		A1B940B7298104ED00B0F994 /* UnknownTargetingsModel.json in Resources */ = {isa = PBXBuildFile; fileRef = A1B940B6298104ED00B0F994 /* UnknownTargetingsModel.json */; };
 		A1D017E72976CBE100CD9F99 /* TargetingModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1D017E62976CBE100CD9F99 /* TargetingModel.swift */; };
@@ -478,6 +476,7 @@
 		DAE90A6BC9F524C24F9B5BA7 /* LoggerDatabaseLoaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 447CD2C35E75139236BFAFAE /* LoggerDatabaseLoaderTests.swift */; };
 		DEC482157E5249DBBFAEFC9A /* FeatureTogglesModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9778038796A8426ABDED1E97 /* FeatureTogglesModel.swift */; };
 		EA395B77BB16CEFE6DC91D1D /* TransparentViewSyncOperationResponseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B7DAFAB687945FA908DB1AC /* TransparentViewSyncOperationResponseTests.swift */; };
+		EEF7A48FC34733D3D1D1E5EE /* PushNotificationParsingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEDFA644103A7CA5760F368C /* PushNotificationParsingTests.swift */; };
 		F30005442CFF3F7D004BE915 /* ABTestStubs.swift in Sources */ = {isa = PBXBuildFile; fileRef = F30005432CFF3F7D004BE915 /* ABTestStubs.swift */; };
 		F306291A2BD27D7500EF6609 /* InappFrequencyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F30629192BD27D7500EF6609 /* InappFrequencyTests.swift */; };
 		F30654BB2F1A83520058808C /* MindboxWebViewFacade.swift in Sources */ = {isa = PBXBuildFile; fileRef = F30654BA2F1A83520058808C /* MindboxWebViewFacade.swift */; };
@@ -730,13 +729,6 @@
 			remoteGlobalIDString = 3333C1972681D3CF00B60D84;
 			remoteInfo = MindboxNotifications;
 		};
-		A1515DB429B228F40025E2EE /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 313B232725ADEA0F00A1CB72 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = A17853BD29AF7E940072578F;
-			remoteInfo = MindboxLogger;
-		};
 		A170EDDE29B0883800CE547F /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 313B232725ADEA0F00A1CB72 /* Project object */;
@@ -757,6 +749,7 @@
 		0475E8755F63483597539A50 /* TrackVisitManagerTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TrackVisitManagerTests.swift; sourceTree = "<group>"; };
 		0A3D04592BC6803E00E1FC52 /* ImageFormat.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageFormat.swift; sourceTree = "<group>"; };
 		0CFCC82B8014DE7276C217CD /* WebViewLocalStateStorageTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WebViewLocalStateStorageTests.swift; sourceTree = "<group>"; };
+		0EF1D88A18D64D60BD03ABB8 /* OperationNameValidator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OperationNameValidator.swift; sourceTree = "<group>"; };
 		17AAEE27309FA3CF568151D3 /* ThreadSanitizer.xctestplan */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = ThreadSanitizer.xctestplan; sourceTree = "<group>"; };
 		2EF2F75E4C66C001E8670EA2 /* Mindbox.xctestplan */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = Mindbox.xctestplan; sourceTree = "<group>"; };
 		30CFF46A37DD2CEE9F8517DF /* IsolatedMBLoggerCoreDataManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = IsolatedMBLoggerCoreDataManager.swift; sourceTree = "<group>"; };
@@ -766,9 +759,6 @@
 		313B233425ADEA0F00A1CB72 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		313B233925ADEA0F00A1CB72 /* MindboxTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = MindboxTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		313B233E25ADEA0F00A1CB72 /* MindboxTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MindboxTests.swift; sourceTree = "<group>"; };
-		A1B2C3D4E5F60718293A4B02 /* MindboxOperationsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MindboxOperationsTests.swift; sourceTree = "<group>"; };
-		A1B2C3D4E5F60718293A4B04 /* OperationNameValidatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OperationNameValidatorTests.swift; sourceTree = "<group>"; };
-		A1B2C3D4E5F60718293A4B06 /* PollUntil.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PollUntil.swift; sourceTree = "<group>"; };
 		313B234025ADEA0F00A1CB72 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		314B38FC25AEE8B200E947B9 /* MBConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MBConfiguration.swift; sourceTree = "<group>"; };
 		314B38FF25AEE96F00E947B9 /* CoreController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreController.swift; sourceTree = "<group>"; };
@@ -969,11 +959,6 @@
 		4747708A2C6B838B00C36FC8 /* SharedInternalMethodsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SharedInternalMethodsTests.swift; sourceTree = "<group>"; };
 		4747708E2C6B93AC00C36FC8 /* MindboxNotificationServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MindboxNotificationServiceTests.swift; sourceTree = "<group>"; };
 		474770902C6B9A7200C36FC8 /* MindboxNotificationContentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MindboxNotificationContentTests.swift; sourceTree = "<group>"; };
-		BD8E942B5004DC96C644E39F /* NotificationTestFixtures.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationTestFixtures.swift; sourceTree = "<group>"; };
-		F5624595257BF8C206167332 /* Tag+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Tag+Extensions.swift"; sourceTree = "<group>"; };
-		D68AD2869EF175FE754AE284 /* ImageFormatTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageFormatTests.swift; sourceTree = "<group>"; };
-		BEDFA644103A7CA5760F368C /* PushNotificationParsingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PushNotificationParsingTests.swift; sourceTree = "<group>"; };
-		8B909F3184E7FAE110C8D813 /* MindboxPushNotificationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MindboxPushNotificationTests.swift; sourceTree = "<group>"; };
 		474851C02C6A622E0026C38E /* NotificationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationService.swift; sourceTree = "<group>"; };
 		474851C22C6A627F0026C38E /* Constants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
 		474851C42C6A62AE0026C38E /* NotificationContent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationContent.swift; sourceTree = "<group>"; };
@@ -1062,7 +1047,6 @@
 		84B09FB32611C74400B0A06E /* MockDatabaseRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockDatabaseRepository.swift; sourceTree = "<group>"; };
 		84B625D825C9558E00AB6228 /* MBPersistenceStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MBPersistenceStorage.swift; sourceTree = "<group>"; };
 		84B625E325C988FA00AB6228 /* URLValidator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLValidator.swift; sourceTree = "<group>"; };
-		0EF1D88A18D64D60BD03ABB8 /* OperationNameValidator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OperationNameValidator.swift; sourceTree = "<group>"; };
 		84B625E825C989C100AB6228 /* UDIDValidator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UDIDValidator.swift; sourceTree = "<group>"; };
 		84B625EF25C98B1200AB6228 /* ValidatorsTestCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ValidatorsTestCase.swift; sourceTree = "<group>"; };
 		84BAEF8125D54919002E8A26 /* BodyDecoder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BodyDecoder.swift; sourceTree = "<group>"; };
@@ -1093,6 +1077,7 @@
 		84FCD3B825CA109E00D1E574 /* MockNetworkFetcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockNetworkFetcher.swift; sourceTree = "<group>"; };
 		84FCD3BC25CA10F600D1E574 /* SuccessResponse.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = SuccessResponse.json; sourceTree = "<group>"; };
 		8755088A5E704C65A1C3F6DB /* DateFormatMigration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateFormatMigration.swift; sourceTree = "<group>"; };
+		8B909F3184E7FAE110C8D813 /* MindboxPushNotificationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MindboxPushNotificationTests.swift; sourceTree = "<group>"; };
 		9778038796A8426ABDED1E97 /* FeatureTogglesModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeatureTogglesModel.swift; sourceTree = "<group>"; };
 		97FEDDEB5F71A67F1C4C675F /* MBNetworkFetcherResponseHandlingTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MBNetworkFetcherResponseHandlingTests.swift; sourceTree = "<group>"; };
 		9B24FAAB28C74B8300F10B5D /* InAppConfigurationRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InAppConfigurationRepository.swift; sourceTree = "<group>"; };
@@ -1181,6 +1166,9 @@
 		A1B2C3D400000015E1010101 /* PushNotificationsPermissionHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PushNotificationsPermissionHandler.swift; sourceTree = "<group>"; };
 		A1B2C3D400000021E1010101 /* PushPermissionHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PushPermissionHelper.swift; sourceTree = "<group>"; };
 		A1B2C3D400000031E1010101 /* PushPermissionHelperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PushPermissionHelperTests.swift; sourceTree = "<group>"; };
+		A1B2C3D4E5F60718293A4B02 /* MindboxOperationsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MindboxOperationsTests.swift; sourceTree = "<group>"; };
+		A1B2C3D4E5F60718293A4B04 /* OperationNameValidatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OperationNameValidatorTests.swift; sourceTree = "<group>"; };
+		A1B2C3D4E5F60718293A4B06 /* PollUntil.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PollUntil.swift; sourceTree = "<group>"; };
 		A1B2C3D4E5F6A7B8C9D0E1F3 /* MotionService.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MotionService.swift; sourceTree = "<group>"; };
 		A1B940B6298104ED00B0F994 /* UnknownTargetingsModel.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = UnknownTargetingsModel.json; sourceTree = "<group>"; };
 		A1D017E62976CBE100CD9F99 /* TargetingModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TargetingModel.swift; sourceTree = "<group>"; };
@@ -1223,7 +1211,9 @@
 		BD1BE43AA9EAEA03F8ED400B /* HapticRequestValidator.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = HapticRequestValidator.swift; sourceTree = "<group>"; };
 		BD1BE43AA9EAEA03F8ED400C /* HapticRequestParserTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = HapticRequestParserTests.swift; sourceTree = "<group>"; };
 		BD1BE43AA9EAEA03F8ED400D /* HapticRequestValidatorTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = HapticRequestValidatorTests.swift; sourceTree = "<group>"; };
+		BD8E942B5004DC96C644E39F /* NotificationTestFixtures.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationTestFixtures.swift; sourceTree = "<group>"; };
 		BECF3D292B29C1894F80948F /* MBEventRepositorySendRawTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MBEventRepositorySendRawTests.swift; sourceTree = "<group>"; };
+		BEDFA644103A7CA5760F368C /* PushNotificationParsingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PushNotificationParsingTests.swift; sourceTree = "<group>"; };
 		BF1A11C4A4B940898BA80035 /* DateFormatMigrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateFormatMigrationTests.swift; sourceTree = "<group>"; };
 		D216DE502C0716B70020F58A /* StringExtensionsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StringExtensionsTests.swift; sourceTree = "<group>"; };
 		D216DE522C0716B80020F58A /* TimeIntervalTimeSpanTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TimeIntervalTimeSpanTests.swift; sourceTree = "<group>"; };
@@ -1231,6 +1221,7 @@
 		D2F7E2462BADB9EF00B24BB8 /* UserVisitManagerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UserVisitManagerTests.swift; sourceTree = "<group>"; };
 		D2F7E2492BADC2AB00B24BB8 /* SessionManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionManager.swift; sourceTree = "<group>"; };
 		D2F7E24B2BADC4CA00B24BB8 /* MockSessionManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockSessionManager.swift; sourceTree = "<group>"; };
+		D68AD2869EF175FE754AE284 /* ImageFormatTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageFormatTests.swift; sourceTree = "<group>"; };
 		D8BDF175A75C9AA9138161F4 /* DateFormatTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DateFormatTests.swift; sourceTree = "<group>"; };
 		F0DB93A7997961CA7C2BE917 /* MotionServiceBehaviorTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MotionServiceBehaviorTests.swift; sourceTree = "<group>"; };
 		F30005432CFF3F7D004BE915 /* ABTestStubs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ABTestStubs.swift; sourceTree = "<group>"; };
@@ -1468,6 +1459,7 @@
 		F3FEEAA82C25CC9F000E9D0F /* InjectionMocks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InjectionMocks.swift; sourceTree = "<group>"; };
 		F3FEEAAA2C25D874000E9D0F /* InjectReplaceable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InjectReplaceable.swift; sourceTree = "<group>"; };
 		F3FEEAAC2C25FD1F000E9D0F /* InjectABTestUtilities.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InjectABTestUtilities.swift; sourceTree = "<group>"; };
+		F5624595257BF8C206167332 /* Tag+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Tag+Extensions.swift"; sourceTree = "<group>"; };
 		F78E92EE282E63320003B4A3 /* DispatchSemaphore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DispatchSemaphore.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -1498,7 +1490,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				A1515DB229B228F40025E2EE /* MindboxLogger.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -3971,7 +3962,6 @@
 			buildRules = (
 			);
 			dependencies = (
-				A1515DB529B228F40025E2EE /* PBXTargetDependency */,
 			);
 			name = MindboxNotifications;
 			productName = MindboxNotifications;
@@ -4926,11 +4916,6 @@
 			isa = PBXTargetDependency;
 			target = 3333C1972681D3CF00B60D84 /* MindboxNotifications */;
 			targetProxy = 3333C1A22681D3CF00B60D84 /* PBXContainerItemProxy */;
-		};
-		A1515DB529B228F40025E2EE /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = A17853BD29AF7E940072578F /* MindboxLogger */;
-			targetProxy = A1515DB429B228F40025E2EE /* PBXContainerItemProxy */;
 		};
 		A170EDDF29B0883800CE547F /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;

--- a/MindboxNotificationsTests/ImageFormatTests.swift
+++ b/MindboxNotificationsTests/ImageFormatTests.swift
@@ -1,0 +1,56 @@
+//
+//  ImageFormatTests.swift
+//  MindboxNotificationsTests
+//
+//  Created by Sergei Semko on 6/16/26.
+//  Copyright © 2026 Mindbox. All rights reserved.
+//
+
+import Testing
+import Foundation
+@testable import MindboxNotifications
+
+@Suite("ImageFormat", .tags(.notifications, .imageFormat))
+struct ImageFormatTests {
+
+    @Test("Detects the format from the leading magic byte", arguments: [
+        UInt8(0x89): ImageFormat.png,
+        0xFF: .jpg,
+        0x47: .gif
+    ])
+    func detectsFormatFromFirstByte(firstByte: UInt8, expected: ImageFormat) {
+        let data = Data([firstByte, 0x00, 0x01])
+        #expect(ImageFormat(data) == expected)
+        #expect(ImageFormat.get(from: data) == expected)
+    }
+
+    @Test("Returns nil for an unrecognized leading byte", arguments: [
+        UInt8(0x00), 0x42, 0x7F, 0xAB, 0xCC
+    ])
+    func returnsNilForUnknownByte(firstByte: UInt8) {
+        let data = Data([firstByte, 0x10])
+        #expect(ImageFormat(data) == nil)
+        #expect(ImageFormat.get(from: data) == nil)
+    }
+
+    @Test("Returns nil for empty data")
+    func returnsNilForEmptyData() {
+        #expect(ImageFormat(Data()) == nil)
+        #expect(ImageFormat.get(from: Data()) == nil)
+    }
+
+    @Test("Only the first byte determines the format")
+    func onlyFirstByteMatters() {
+        #expect(ImageFormat(Data([0x89, 0xFF, 0x47, 0x00])) == .png)
+    }
+
+    @Test("extension equals the raw value", arguments: [
+        ImageFormat.png: "png",
+        .jpg: "jpg",
+        .gif: "gif"
+    ])
+    func extensionMatchesRawValue(format: ImageFormat, expected: String) {
+        #expect(format.extension == expected)
+        #expect(format.rawValue == expected)
+    }
+}

--- a/MindboxNotificationsTests/MindboxNotificationContentTests.swift
+++ b/MindboxNotificationsTests/MindboxNotificationContentTests.swift
@@ -6,138 +6,81 @@
 //  Copyright © 2024 Mindbox. All rights reserved.
 //
 
-import XCTest
+import Testing
+import Foundation
+import UIKit
+import UserNotifications
 @testable import MindboxNotifications
 
-// swiftlint:disable force_unwrapping force_try
+@MainActor
+@Suite("MindboxNotificationService (NotificationContent extension)", .tags(.notifications, .notificationContent))
+struct MindboxNotificationContentTests {
 
-@available(iOS 13.0, *)
-final class MindboxNotificationContentTests: XCTestCase {
+    let service = MindboxNotificationService()
+    let viewController = UIViewController()
 
-    var service: MindboxNotificationService! // MindboxNotificationContentProtocol
-    var mockViewController: UIViewController!
-    var mockExtensionContext: NSExtensionContext!
-    var mockNotificationRequest: UNNotificationRequest!
+    @Test("didReceive wires up the view controller, image view and button actions")
+    func didReceiveBuildsContentImageAndActions() throws {
+        let content = NotificationTestFixtures.makeContent(
+            userInfo: NotificationTestFixtures.currentFormatUserInfo(),
+            title: "Test title",
+            body: "Test description"
+        )
+        content.attachments = [try NotificationTestFixtures.makeImageAttachment()]
+        let request = UNNotificationRequest(identifier: "test", content: content, trigger: nil)
+        let notification = MockUNNotification(request: request)
+        let context = MockExtensionContext()
 
-    override func setUp() {
-        super.setUp()
-        service = MindboxNotificationService()
-        mockViewController = UIViewController()
-        mockExtensionContext = MockExtensionContext()
+        #expect(!notification.request.content.attachments.isEmpty)
 
-        let aps: [AnyHashable: Any] = [
-            "mutable-content": 1,
-            "alert": [
-                "title": "Test title",
-                "body": "Test description"
-            ],
-            "content-available": 1,
-            "sound": "default"
-        ]
+        service.didReceive(notification: notification, viewController: viewController, extensionContext: context)
 
-        let userInfo: [AnyHashable: Any] = [
-            "clickUrl": "https://mindbox.ru/",
-            "payload": "{\n  \"payload\": \"data\"\n}",
-            "uniqueKey": "4cccb64d-ba46-41eb-9699-3a706f2b910b",
-            "imageUrl": "https://mobpush-images.mindbox.ru/Mpush-test/63/5933f4cd-47e3-4317-9237-bc5aad291aa9.png",
-            "buttons": [
-                [
-                    "url": "https://developers.mindbox.ru/docs/mindbox-sdk",
-                    "text": "Documentation",
-                    "uniqueKey": "1b112bcd-5eae-4914-8842-d77198466466"
-                ],
-                [
-                    "url": "https://google.com",
-                    "text": "Button #1",
-                    "uniqueKey": "cff05f38-6df4-4a10-9859-ea3bf0a65068"
-                ]
-            ],
-            "aps": aps
-        ]
+        #expect(service.viewController === viewController)
+        #expect(service.context === context)
 
-        let content = UNMutableNotificationContent()
-        content.userInfo = userInfo
-        content.title = "Test title"
-        content.body = "Test description"
+        #expect(service.context?.notificationActions.count == 2)
+        let actionTitles = service.context?.notificationActions.map { $0.title }
+        #expect(actionTitles?.contains("Documentation") == true)
+        #expect(actionTitles?.contains("Button #1") == true)
 
-        let image = UIImage(systemName: "star")!
-        let imageData = image.pngData()!
-        let tempDirectory = FileManager.default.temporaryDirectory
-        let imageFileURL = tempDirectory.appendingPathComponent("testImage.png")
-
-        try! imageData.write(to: imageFileURL)
-        let notificationAttachment = try! UNNotificationAttachment(identifier: "identifier", url: imageFileURL, options: nil)
-
-        content.attachments.append(notificationAttachment)
-
-        mockNotificationRequest = UNNotificationRequest(identifier: "test", content: content, trigger: nil)
+        let imageView = viewController.view.subviews.first { $0 is UIImageView }
+        #expect(imageView != nil, "The UIImageView should be added to the view controller")
     }
 
-    override func tearDown() {
-        service = nil
-        mockViewController = nil
-        mockExtensionContext = nil
-        mockNotificationRequest = nil
-        super.tearDown()
+    @Test("didReceive creates actions but no image view when there is no attachment")
+    func didReceiveButtonsNoAttachment() {
+        let request = NotificationTestFixtures.makeRequest(userInfo: NotificationTestFixtures.currentFormatUserInfo())
+        let notification = MockUNNotification(request: request)
+        let context = MockExtensionContext()
+
+        service.didReceive(notification: notification, viewController: viewController, extensionContext: context)
+
+        #expect(service.context?.notificationActions.count == 2)
+        let hasImageView = viewController.view.subviews.contains { $0 is UIImageView }
+        #expect(!hasImageView)
     }
 
-    func testDidReceiveFromMindboxNotificationContentProtocol() {
-        let mockNotification = MockUNNotification(request: mockNotificationRequest)
+    @Test("didReceive creates no actions when the payload has no buttons")
+    func didReceiveNoButtons() {
+        let request = NotificationTestFixtures.makeRequest(
+            userInfo: NotificationTestFixtures.currentFormatUserInfo(includeButtons: false)
+        )
+        let notification = MockUNNotification(request: request)
+        let context = MockExtensionContext()
 
-        XCTAssertFalse(mockNotification.request.content.attachments.isEmpty)
+        service.didReceive(notification: notification, viewController: viewController, extensionContext: context)
 
-        service.didReceive(notification: mockNotification,
-                           viewController: mockViewController,
-                           extensionContext: mockExtensionContext)
-
-        XCTAssertEqual(service.viewController, mockViewController)
-        XCTAssertEqual(service.context, mockExtensionContext)
-
-        XCTAssertFalse(service.context!.notificationActions.isEmpty)
-        XCTAssertEqual(service.context!.notificationActions.count, 2)
-
-        let actionTitles = service.context!.notificationActions.map { $0.title }
-        XCTAssertTrue(actionTitles.contains("Documentation"))
-        XCTAssertTrue(actionTitles.contains("Button #1"))
-
-        let imageView = mockViewController.view.subviews.first { $0 is UIImageView } as? UIImageView
-        XCTAssertNotNil(imageView, "The UIImageView should be added to the ViewController")
-    }
-}
-
-@available(iOS 12.0, *)
-fileprivate class MockExtensionContext: NSExtensionContext {
-    var actions: [UNNotificationAction] = []
-
-    override var notificationActions: [UNNotificationAction] {
-        get {
-            return actions
-        }
-        set {
-            actions = newValue
-        }
-    }
-}
-
-@available(iOS 12.0, *)
-fileprivate class MockUNNotification: UNNotification {
-    private let mockRequest: UNNotificationRequest
-
-    init(request: UNNotificationRequest) {
-        self.mockRequest = request
-
-        let data = try! NSKeyedArchiver.archivedData(withRootObject: request, requiringSecureCoding: true)
-
-        let coder = try! NSKeyedUnarchiver(forReadingFrom: data)
-
-        super.init(coder: coder)!
+        #expect(service.context?.notificationActions.isEmpty == true)
     }
 
-    required init?(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
-    }
+    @Test("didReceive without an extension context creates no actions and does not crash")
+    func didReceiveNilContext() {
+        let request = NotificationTestFixtures.makeRequest(userInfo: NotificationTestFixtures.currentFormatUserInfo())
+        let notification = MockUNNotification(request: request)
 
-    override var request: UNNotificationRequest {
-        return mockRequest
+        service.didReceive(notification: notification, viewController: viewController, extensionContext: nil)
+
+        #expect(service.context == nil)
+        #expect(service.viewController === viewController)
     }
 }

--- a/MindboxNotificationsTests/MindboxNotificationServiceTests.swift
+++ b/MindboxNotificationsTests/MindboxNotificationServiceTests.swift
@@ -6,97 +6,152 @@
 //  Copyright © 2024 Mindbox. All rights reserved.
 //
 
-import XCTest
+import Testing
+import Foundation
+import UserNotifications
 @testable import MindboxNotifications
 
-// swiftlint:disable force_unwrapping
+// Serialized: the download tests register a process-global stub `URLProtocol` and share its
+// static state, so they must not run concurrently with each other.
+@Suite("MindboxNotificationService (NotificationService extension)", .tags(.notifications, .notificationService), .serialized)
+struct MindboxNotificationServiceTests {
 
-final class MindboxNotificationServiceTests: XCTestCase {
+    let service = MindboxNotificationService()
 
-    var service: MindboxNotificationServiceProtocol!
-    var mockNotificationRequest: UNNotificationRequest!
+    // MARK: - didReceive(_:withContentHandler:)
 
-    override func setUp() {
-        super.setUp()
-        service = MindboxNotificationService()
-
-        let aps: [AnyHashable: Any] = [
-            "mutable-content": 1,
-            "alert": [
-                "title": "Test title",
-                "body": "Test description"
-            ],
-            "content-available": 1,
-            "sound": "default"
-        ]
-
-        let userInfo: [AnyHashable: Any] = [
-            "clickUrl": "https://mindbox.ru/",
-            "payload": "{\n  \"payload\": \"data\"\n}",
-            "uniqueKey": "4cccb64d-ba46-41eb-9699-3a706f2b910b",
-            "imageUrl": "https://mobpush-images.mindbox.ru/Mpush-test/63/5933f4cd-47e3-4317-9237-bc5aad291aa9.png",
-            "buttons": [
-                [
-                    "url": "https://developers.mindbox.ru/docs/mindbox-sdk",
-                    "text": "Documentation",
-                    "uniqueKey": "1b112bcd-5eae-4914-8842-d77198466466"
-                ],
-                [
-                    "url": "https://google.com",
-                    "text": "Button #1",
-                    "uniqueKey": "cff05f38-6df4-4a10-9859-ea3bf0a65068"
-                ]
-            ],
-            "aps": aps
-        ]
-
-        let content = UNMutableNotificationContent()
-        content.userInfo = userInfo
-        content.title = "Test title"
-        content.body = "Test description"
-        mockNotificationRequest = UNNotificationRequest(identifier: "test", content: content, trigger: nil)
-    }
-
-    override func tearDown() {
-        service = nil
-        mockNotificationRequest = nil
-        super.tearDown()
-    }
-
-    func testDidReceiveWithContentHandler() {
-        let expectation = self.expectation(description: "Content Handler Called")
-        var receivedContent: UNNotificationContent?
-
-        service.didReceive(mockNotificationRequest) { content in
-            receivedContent = content
-            expectation.fulfill()
+    @Test("didReceive serves the image via a stubbed URL protocol, sets the category and invokes the handler")
+    func didReceiveDownloadsImageAndCallsHandler() async {
+        StubURLProtocol.reset()
+        StubURLProtocol.stubResponseData = NotificationTestFixtures.tinyPNGData()
+        URLProtocol.registerClass(StubURLProtocol.self)
+        defer {
+            URLProtocol.unregisterClass(StubURLProtocol.self)
+            StubURLProtocol.reset()
         }
 
-        waitForExpectations(timeout: 1, handler: nil)
-        XCTAssertNotNil(service.contentHandler)
-        XCTAssertNotNil(service.bestAttemptContent)
-        XCTAssertEqual(service.bestAttemptContent?.userInfo["uniqueKey"] as? String, "4cccb64d-ba46-41eb-9699-3a706f2b910b")
-        XCTAssertNotNil(receivedContent)
+        let request = NotificationTestFixtures.makeRequest(
+            userInfo: NotificationTestFixtures.currentFormatUserInfo(),
+            title: "Test title",
+            body: "Test description"
+        )
 
-        XCTAssertEqual(service.bestAttemptContent?.title, "Test title")
-        XCTAssertEqual(service.bestAttemptContent?.body, "Test description")
-        XCTAssertFalse(service.bestAttemptContent!.attachments.isEmpty)
-        XCTAssertTrue(service.bestAttemptContent!.attachments.count == 1)
+        let received: UNNotificationContent = await withCheckedContinuation { continuation in
+            service.didReceive(request) { content in
+                continuation.resume(returning: content)
+            }
+        }
+
+        #expect(StubURLProtocol.handledRequestCount > 0) // served from the stub, never the real network
+        #expect(service.contentHandler != nil)
+        #expect(service.bestAttemptContent != nil)
+        #expect(service.bestAttemptContent?.userInfo["uniqueKey"] as? String == NotificationTestFixtures.uniqueKey)
+        #expect(received.title == "Test title")
+        #expect(received.body == "Test description")
+        #expect(received.categoryIdentifier == Constants.categoryIdentifier)
+        #expect(service.bestAttemptContent?.attachments.count == 1)
     }
 
-    func testServiceExtensionTimeWillExpire_CallsProceedFinalStage() {
-        let expectation = self.expectation(description: "Content Handler Called")
-        var receivedContent: UNNotificationContent?
-
-        service.didReceive(mockNotificationRequest) { content in
-            receivedContent = content
-            expectation.fulfill()
+    @Test("didReceive still delivers (no attachment) when the image download fails")
+    func didReceiveDeliversWhenDownloadFails() async {
+        StubURLProtocol.reset()
+        StubURLProtocol.stubError = URLError(.timedOut)
+        URLProtocol.registerClass(StubURLProtocol.self)
+        defer {
+            URLProtocol.unregisterClass(StubURLProtocol.self)
+            StubURLProtocol.reset()
         }
+
+        let request = NotificationTestFixtures.makeRequest(
+            userInfo: NotificationTestFixtures.currentFormatUserInfo(),
+            title: "Test title",
+            body: "Test description"
+        )
+
+        let received: UNNotificationContent = await withCheckedContinuation { continuation in
+            service.didReceive(request) { continuation.resume(returning: $0) }
+        }
+
+        #expect(StubURLProtocol.handledRequestCount > 0)
+        #expect(received.categoryIdentifier == Constants.categoryIdentifier)
+        #expect(received.attachments.isEmpty)
+    }
+
+    @Test("didReceive delivers without an attachment when the data is not a recognized image")
+    func didReceiveDeliversForUnrecognizedImageData() async {
+        StubURLProtocol.reset()
+        StubURLProtocol.stubResponseData = Data([0x00, 0x01, 0x02, 0x03]) // unknown magic byte -> ImageFormat is nil
+        URLProtocol.registerClass(StubURLProtocol.self)
+        defer {
+            URLProtocol.unregisterClass(StubURLProtocol.self)
+            StubURLProtocol.reset()
+        }
+
+        let request = NotificationTestFixtures.makeRequest(
+            userInfo: NotificationTestFixtures.currentFormatUserInfo(),
+            title: "Test title",
+            body: "Test description"
+        )
+
+        let received: UNNotificationContent = await withCheckedContinuation { continuation in
+            service.didReceive(request) { continuation.resume(returning: $0) }
+        }
+
+        #expect(received.categoryIdentifier == Constants.categoryIdentifier)
+        #expect(received.attachments.isEmpty)
+    }
+
+    @Test("didReceive without an image URL delivers immediately and without an attachment")
+    func didReceiveWithoutImageProceedsImmediately() async {
+        let request = NotificationTestFixtures.makeRequest(
+            userInfo: NotificationTestFixtures.currentFormatUserInfo(includeImageUrl: false),
+            title: "No image",
+            body: "Body"
+        )
+
+        let received: UNNotificationContent = await withCheckedContinuation { continuation in
+            service.didReceive(request) { content in
+                continuation.resume(returning: content)
+            }
+        }
+
+        #expect(received.categoryIdentifier == Constants.categoryIdentifier)
+        #expect(received.attachments.isEmpty)
+        #expect(service.bestAttemptContent?.title == "No image")
+    }
+
+    // MARK: - serviceExtensionTimeWillExpire()
+
+    @Test("serviceExtensionTimeWillExpire delivers the stored best-attempt content")
+    func serviceExtensionTimeWillExpireDelivers() {
+        let content = NotificationTestFixtures.makeContent(userInfo: [:], title: "t", body: "b")
+        service.bestAttemptContent = content
+
+        var received: UNNotificationContent?
+        service.contentHandler = { received = $0 }
 
         service.serviceExtensionTimeWillExpire()
 
-        waitForExpectations(timeout: 1, handler: nil)
-        XCTAssertNotNil(receivedContent)
-        XCTAssertEqual(receivedContent?.categoryIdentifier, Constants.categoryIdentifier)
+        #expect(received != nil)
+        #expect(received?.categoryIdentifier == Constants.categoryIdentifier)
+    }
+
+    @Test("serviceExtensionTimeWillExpire is a no-op without best-attempt content")
+    func serviceExtensionTimeWillExpireNoContent() {
+        var called = false
+        service.contentHandler = { _ in called = true }
+
+        service.serviceExtensionTimeWillExpire()
+
+        #expect(!called)
+    }
+
+    // MARK: - pushDelivered(_:)
+
+    @Test("pushDelivered runs without producing best-attempt content")
+    func pushDeliveredRuns() {
+        let request = NotificationTestFixtures.makeRequest(userInfo: NotificationTestFixtures.currentFormatUserInfo())
+        service.pushDelivered(request)
+        #expect(service.bestAttemptContent == nil)
     }
 }

--- a/MindboxNotificationsTests/MindboxPushNotificationTests.swift
+++ b/MindboxNotificationsTests/MindboxPushNotificationTests.swift
@@ -1,0 +1,100 @@
+//
+//  MindboxPushNotificationTests.swift
+//  MindboxNotificationsTests
+//
+//  Created by Sergei Semko on 6/16/26.
+//  Copyright © 2026 Mindbox. All rights reserved.
+//
+
+import Testing
+import Foundation
+@testable import MindboxNotifications
+
+/// Covers the public `MindboxPushNotificationProtocol` surface on `MindboxNotificationService`
+/// and `MBPushNotification` decoding.
+@Suite("MindboxPushNotification public API", .tags(.notifications, .pushParsing))
+struct MindboxPushNotificationTests {
+
+    let service = MindboxNotificationService()
+
+    // MARK: - isMindboxPush
+
+    @Test("isMindboxPush is true for a current-format Mindbox push")
+    func isMindboxPushTrueForCurrent() {
+        #expect(service.isMindboxPush(userInfo: NotificationTestFixtures.currentFormatUserInfo()))
+    }
+
+    @Test("isMindboxPush is true for a legacy-format Mindbox push")
+    func isMindboxPushTrueForLegacy() {
+        #expect(service.isMindboxPush(userInfo: NotificationTestFixtures.legacyFormatUserInfo()))
+    }
+
+    @Test("isMindboxPush is false for a non-Mindbox push")
+    func isMindboxPushFalseForPlain() {
+        #expect(!service.isMindboxPush(userInfo: ["aps": ["alert": ["body": "plain"]]]))
+    }
+
+    @Test("isMindboxPush is false when no validator is configured")
+    func isMindboxPushFalseWithoutValidator() {
+        service.pushValidator = nil
+        #expect(!service.isMindboxPush(userInfo: NotificationTestFixtures.currentFormatUserInfo()))
+    }
+
+    // MARK: - getMindboxPushData
+
+    @Test("getMindboxPushData returns parsed data for a Mindbox push")
+    func getMindboxPushDataReturnsModel() throws {
+        let data = try #require(service.getMindboxPushData(userInfo: NotificationTestFixtures.currentFormatUserInfo()))
+        #expect(data.clickUrl == NotificationTestFixtures.clickUrl)
+        #expect(data.uniqueKey == NotificationTestFixtures.uniqueKey)
+        #expect(data.aps?.alert?.body == "Test description")
+    }
+
+    @Test("getMindboxPushData returns nil for a non-Mindbox push")
+    func getMindboxPushDataNilForPlain() {
+        #expect(service.getMindboxPushData(userInfo: ["aps": ["alert": ["body": "plain"]]]) == nil)
+    }
+
+    // MARK: - MBPushNotification Codable
+
+    @Test("MBPushNotification decodes nested aps keys with custom coding keys")
+    func mbPushNotificationDecodes() throws {
+        let json = """
+        {
+          "aps": {
+            "alert": { "title": "T", "body": "B" },
+            "sound": "default",
+            "mutable-content": 1,
+            "content-available": 1
+          },
+          "clickUrl": "https://mindbox.ru",
+          "imageUrl": "https://img",
+          "payload": "p",
+          "uniqueKey": "uk",
+          "buttons": [ { "text": "ok", "url": "https://a", "uniqueKey": "bk" } ]
+        }
+        """
+        let model = try JSONDecoder().decode(MBPushNotification.self, from: Data(json.utf8))
+        #expect(model.clickUrl == "https://mindbox.ru")
+        #expect(model.imageUrl == "https://img")
+        #expect(model.payload == "p")
+        #expect(model.uniqueKey == "uk")
+        #expect(model.aps?.alert?.title == "T")
+        #expect(model.aps?.alert?.body == "B")
+        #expect(model.aps?.sound == "default")
+        #expect(model.aps?.mutableContent == 1)
+        #expect(model.aps?.contentAvailable == 1)
+        #expect(model.buttons?.count == 1)
+        #expect(model.buttons?.first?.text == "ok")
+        #expect(model.buttons?.first?.url == "https://a")
+        #expect(model.buttons?.first?.uniqueKey == "bk")
+    }
+
+    @Test("MBPushNotification tolerates absent optional fields")
+    func mbPushNotificationDecodesMinimal() throws {
+        let model = try JSONDecoder().decode(MBPushNotification.self, from: Data("{}".utf8))
+        #expect(model.aps == nil)
+        #expect(model.clickUrl == nil)
+        #expect(model.buttons == nil)
+    }
+}

--- a/MindboxNotificationsTests/NotificationTestFixtures.swift
+++ b/MindboxNotificationsTests/NotificationTestFixtures.swift
@@ -1,0 +1,188 @@
+//
+//  NotificationTestFixtures.swift
+//  MindboxNotificationsTests
+//
+//  Created by Sergei Semko on 6/16/26.
+//  Copyright © 2026 Mindbox. All rights reserved.
+//
+
+import Foundation
+import UIKit
+import UserNotifications
+@testable import MindboxNotifications
+
+enum NotificationTestFixtures {
+
+    static let clickUrl = "https://mindbox.ru/"
+    static let uniqueKey = "4cccb64d-ba46-41eb-9699-3a706f2b910b"
+    static let imageUrl = "https://mobpush-images.mindbox.ru/Mpush-test/63/5933f4cd-47e3-4317-9237-bc5aad291aa9.png"
+    static let payloadString = "{\n  \"payload\": \"data\"\n}"
+
+    static let firstButtonKey = "1b112bcd-5eae-4914-8842-d77198466466"
+    static let secondButtonKey = "cff05f38-6df4-4a10-9859-ea3bf0a65068"
+
+    static let buttons: [[String: Any]] = [
+        [
+            "url": "https://developers.mindbox.ru/docs/mindbox-sdk",
+            "text": "Documentation",
+            "uniqueKey": firstButtonKey
+        ],
+        [
+            "url": "https://google.com",
+            "text": "Button #1",
+            "uniqueKey": secondButtonKey
+        ]
+    ]
+
+    static func currentFormatUserInfo(
+        includeBody: Bool = true,
+        includeClickUrl: Bool = true,
+        includeButtons: Bool = true,
+        includeImageUrl: Bool = true
+    ) -> [AnyHashable: Any] {
+        var alert: [String: Any] = ["title": "Test title"]
+        if includeBody { alert["body"] = "Test description" }
+
+        let aps: [String: Any] = [
+            "mutable-content": 1,
+            "alert": alert,
+            "content-available": 1,
+            "sound": "default"
+        ]
+
+        var userInfo: [AnyHashable: Any] = [
+            "payload": payloadString,
+            "uniqueKey": uniqueKey,
+            "aps": aps
+        ]
+        if includeClickUrl { userInfo["clickUrl"] = clickUrl }
+        if includeButtons { userInfo["buttons"] = buttons }
+        if includeImageUrl { userInfo["imageUrl"] = imageUrl }
+        return userInfo
+    }
+
+    static func legacyFormatUserInfo(
+        includeBody: Bool = true,
+        includeClickUrl: Bool = true,
+        includeButtons: Bool = true
+    ) -> [AnyHashable: Any] {
+        var alert: [String: Any] = ["title": "Test title"]
+        if includeBody { alert["body"] = "Test description" }
+
+        var aps: [String: Any] = [
+            "mutable-content": 1,
+            "alert": alert,
+            "content-available": 1,
+            "sound": "default",
+            "uniqueKey": uniqueKey,
+            "imageUrl": imageUrl,
+            "payload": payloadString
+        ]
+        if includeClickUrl { aps["clickUrl"] = clickUrl }
+        if includeButtons { aps["buttons"] = buttons }
+        return ["aps": aps]
+    }
+
+    static func makeContent(
+        userInfo: [AnyHashable: Any],
+        title: String? = nil,
+        body: String? = nil
+    ) -> UNMutableNotificationContent {
+        let content = UNMutableNotificationContent()
+        content.userInfo = userInfo
+        if let title { content.title = title }
+        if let body { content.body = body }
+        return content
+    }
+
+    static func makeRequest(
+        userInfo: [AnyHashable: Any],
+        title: String? = nil,
+        body: String? = nil
+    ) -> UNNotificationRequest {
+        let content = makeContent(userInfo: userInfo, title: title, body: body)
+        return UNNotificationRequest(identifier: "test", content: content, trigger: nil)
+    }
+
+    static func tinyPNGData() -> Data {
+        UIGraphicsImageRenderer(size: CGSize(width: 1, height: 1)).pngData { _ in }
+    }
+
+    static func makeImageAttachment() throws -> UNNotificationAttachment {
+        let fileURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("testImage_\(UUID().uuidString).png")
+        try tinyPNGData().write(to: fileURL)
+        return try UNNotificationAttachment(identifier: "identifier", url: fileURL, options: nil)
+    }
+}
+
+// MARK: - Test doubles
+
+final class MockExtensionContext: NSExtensionContext {
+    private var actions: [UNNotificationAction] = []
+
+    override var notificationActions: [UNNotificationAction] {
+        get { actions }
+        set { actions = newValue }
+    }
+}
+
+// `UNNotification` has no public initializer, so build one by round-tripping through secure coding.
+// swiftlint:disable force_unwrapping force_try
+final class MockUNNotification: UNNotification {
+    private let mockRequest: UNNotificationRequest
+
+    init(request: UNNotificationRequest) {
+        self.mockRequest = request
+        let data = try! NSKeyedArchiver.archivedData(withRootObject: request, requiringSecureCoding: true)
+        let coder = try! NSKeyedUnarchiver(forReadingFrom: data)
+        super.init(coder: coder)!
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override var request: UNNotificationRequest {
+        mockRequest
+    }
+}
+// swiftlint:enable force_unwrapping force_try
+
+// MARK: - URLProtocol stub
+
+/// Intercepts `URLSession.shared` requests so the notification-service download path runs
+/// against a local image instead of a real network fetch. Serves `stubResponseData` for
+/// every request while registered, and counts how many it handled.
+class StubURLProtocol: URLProtocol {
+    nonisolated(unsafe) static var stubResponseData: Data?
+    nonisolated(unsafe) static var stubError: Error?
+    nonisolated(unsafe) static var handledRequestCount = 0
+
+    static func reset() {
+        stubResponseData = nil
+        stubError = nil
+        handledRequestCount = 0
+    }
+
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+        StubURLProtocol.handledRequestCount += 1
+        if let error = StubURLProtocol.stubError {
+            client?.urlProtocol(self, didFailWithError: error)
+            return
+        }
+        if let url = request.url,
+           let response = HTTPURLResponse(url: url, statusCode: 200, httpVersion: nil, headerFields: nil) {
+            client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        }
+        if let data = StubURLProtocol.stubResponseData {
+            client?.urlProtocol(self, didLoad: data)
+        }
+        client?.urlProtocolDidFinishLoading(self)
+    }
+
+    override func stopLoading() {}
+}

--- a/MindboxNotificationsTests/PushNotificationParsingTests.swift
+++ b/MindboxNotificationsTests/PushNotificationParsingTests.swift
@@ -1,0 +1,157 @@
+//
+//  PushNotificationParsingTests.swift
+//  MindboxNotificationsTests
+//
+//  Created by Sergei Semko on 6/16/26.
+//  Copyright © 2026 Mindbox. All rights reserved.
+//
+
+import Testing
+import Foundation
+@testable import MindboxNotifications
+
+/// Exercises the push-format detection/parsing pipeline:
+/// `NotificationStrategyFactory` → `LegacyFormatStrategy`/`CurrentFormatStrategy`
+/// → `NotificationFormatter` → `MindboxPushValidator`.
+@Suite("Push notification parsing pipeline", .tags(.notifications, .pushParsing))
+struct PushNotificationParsingTests {
+
+    // MARK: - NotificationStrategyFactory
+
+    @Test("Factory selects the legacy strategy when aps carries clickUrl and uniqueKey")
+    func factoryPicksLegacyStrategy() {
+        let strategy = NotificationStrategyFactory.strategy(for: NotificationTestFixtures.legacyFormatUserInfo())
+        #expect(strategy is LegacyFormatStrategy)
+    }
+
+    @Test("Factory selects the current strategy for a top-level payload")
+    func factoryPicksCurrentStrategy() {
+        let strategy = NotificationStrategyFactory.strategy(for: NotificationTestFixtures.currentFormatUserInfo())
+        #expect(strategy is CurrentFormatStrategy)
+    }
+
+    @Test("Factory falls back to the current strategy without both legacy markers")
+    func factoryFallsBackToCurrent() {
+        let missingUniqueKey: [AnyHashable: Any] = ["aps": ["clickUrl": "https://mindbox.ru"]]
+        let missingClickUrl: [AnyHashable: Any] = ["aps": ["uniqueKey": "abc"]]
+        let neither: [AnyHashable: Any] = ["aps": ["alert": ["body": "hi"]]]
+        let noAps: [AnyHashable: Any] = ["foo": "bar"]
+
+        #expect(NotificationStrategyFactory.strategy(for: missingUniqueKey) is CurrentFormatStrategy)
+        #expect(NotificationStrategyFactory.strategy(for: missingClickUrl) is CurrentFormatStrategy)
+        #expect(NotificationStrategyFactory.strategy(for: neither) is CurrentFormatStrategy)
+        #expect(NotificationStrategyFactory.strategy(for: noAps) is CurrentFormatStrategy)
+    }
+
+    // MARK: - LegacyFormatStrategy
+
+    @Test("Legacy strategy maps a full payload into MBPushNotification")
+    func legacyStrategyParsesFullPayload() throws {
+        let result = try #require(LegacyFormatStrategy().handle(userInfo: NotificationTestFixtures.legacyFormatUserInfo()))
+        #expect(result.clickUrl == NotificationTestFixtures.clickUrl)
+        #expect(result.uniqueKey == NotificationTestFixtures.uniqueKey)
+        #expect(result.imageUrl == NotificationTestFixtures.imageUrl)
+        #expect(result.payload == NotificationTestFixtures.payloadString)
+        #expect(result.aps?.alert?.title == "Test title")
+        #expect(result.aps?.alert?.body == "Test description")
+        #expect(result.aps?.sound == "default")
+        #expect(result.aps?.mutableContent == 1)
+        #expect(result.aps?.contentAvailable == 1)
+        #expect(result.buttons?.count == 2)
+        #expect(result.buttons?.first?.uniqueKey == NotificationTestFixtures.firstButtonKey)
+        #expect(result.buttons?.first?.text == "Documentation")
+    }
+
+    @Test("Legacy strategy returns nil when the alert body is missing")
+    func legacyStrategyRequiresBody() {
+        #expect(LegacyFormatStrategy().handle(userInfo: NotificationTestFixtures.legacyFormatUserInfo(includeBody: false)) == nil)
+    }
+
+    @Test("Legacy strategy returns nil when clickUrl is missing")
+    func legacyStrategyRequiresClickUrl() {
+        #expect(LegacyFormatStrategy().handle(userInfo: NotificationTestFixtures.legacyFormatUserInfo(includeClickUrl: false)) == nil)
+    }
+
+    @Test("Legacy strategy rejects a current-format (top-level) payload")
+    func legacyStrategyRejectsCurrentFormat() {
+        #expect(LegacyFormatStrategy().handle(userInfo: NotificationTestFixtures.currentFormatUserInfo()) == nil)
+    }
+
+    @Test("Legacy strategy drops malformed buttons but keeps the notification")
+    func legacyStrategyDropsMalformedButtons() throws {
+        let aps: [String: Any] = [
+            "alert": ["title": "t", "body": "b"],
+            "clickUrl": "https://mindbox.ru",
+            "uniqueKey": "key",
+            "buttons": [
+                ["text": "ok", "url": "https://a", "uniqueKey": "k1"],
+                ["text": "missing url", "uniqueKey": "k2"]
+            ]
+        ]
+        let result = try #require(LegacyFormatStrategy().handle(userInfo: ["aps": aps]))
+        #expect(result.buttons?.count == 1)
+        #expect(result.buttons?.first?.uniqueKey == "k1")
+    }
+
+    @Test("Legacy strategy yields nil buttons when the buttons array is absent")
+    func legacyStrategyNilButtonsWhenAbsent() throws {
+        let result = try #require(LegacyFormatStrategy().handle(userInfo: NotificationTestFixtures.legacyFormatUserInfo(includeButtons: false)))
+        #expect(result.buttons == nil)
+    }
+
+    // MARK: - CurrentFormatStrategy
+
+    @Test("Current strategy decodes a top-level payload")
+    func currentStrategyParsesPayload() throws {
+        let result = try #require(CurrentFormatStrategy().handle(userInfo: NotificationTestFixtures.currentFormatUserInfo()))
+        #expect(result.clickUrl == NotificationTestFixtures.clickUrl)
+        #expect(result.uniqueKey == NotificationTestFixtures.uniqueKey)
+        #expect(result.imageUrl == NotificationTestFixtures.imageUrl)
+        #expect(result.aps?.alert?.title == "Test title")
+        #expect(result.aps?.alert?.body == "Test description")
+        #expect(result.buttons?.count == 2)
+    }
+
+    @Test("Current strategy returns nil when clickUrl is missing")
+    func currentStrategyRequiresClickUrl() {
+        #expect(CurrentFormatStrategy().handle(userInfo: NotificationTestFixtures.currentFormatUserInfo(includeClickUrl: false)) == nil)
+    }
+
+    @Test("Current strategy returns nil when the alert body is missing")
+    func currentStrategyRequiresBody() {
+        #expect(CurrentFormatStrategy().handle(userInfo: NotificationTestFixtures.currentFormatUserInfo(includeBody: false)) == nil)
+    }
+
+    // MARK: - NotificationFormatter
+
+    @Test("Formatter parses a current-format push")
+    func formatterParsesCurrent() throws {
+        let result = try #require(NotificationFormatter.formatNotification(NotificationTestFixtures.currentFormatUserInfo()))
+        #expect(result.clickUrl == NotificationTestFixtures.clickUrl)
+    }
+
+    @Test("Formatter parses a legacy-format push")
+    func formatterParsesLegacy() throws {
+        let result = try #require(NotificationFormatter.formatNotification(NotificationTestFixtures.legacyFormatUserInfo()))
+        #expect(result.uniqueKey == NotificationTestFixtures.uniqueKey)
+    }
+
+    @Test("Formatter returns nil for a non-Mindbox payload")
+    func formatterReturnsNilForPlainPush() {
+        #expect(NotificationFormatter.formatNotification(["aps": ["alert": ["body": "Just a plain push"]]]) == nil)
+    }
+
+    // MARK: - MindboxPushValidator
+
+    @Test("Validator accepts current- and legacy-format Mindbox pushes")
+    func validatorAcceptsMindboxPushes() {
+        let validator = MindboxPushValidator()
+        #expect(validator.isValid(item: NotificationTestFixtures.currentFormatUserInfo()))
+        #expect(validator.isValid(item: NotificationTestFixtures.legacyFormatUserInfo()))
+    }
+
+    @Test("Validator rejects a non-Mindbox push")
+    func validatorRejectsPlainPush() {
+        #expect(!MindboxPushValidator().isValid(item: ["aps": ["alert": ["body": "plain"]]]))
+    }
+}

--- a/MindboxNotificationsTests/SharedInternalMethodsTests.swift
+++ b/MindboxNotificationsTests/SharedInternalMethodsTests.swift
@@ -6,131 +6,74 @@
 //  Copyright © 2024 Mindbox. All rights reserved.
 //
 
-import XCTest
+import Testing
+import Foundation
+import UserNotifications
 @testable import MindboxNotifications
 
-final class SharedInternalMethodsTests: XCTestCase {
+@Suite("SharedInternalMethods", .tags(.notifications, .pushParsing))
+struct SharedInternalMethodsTests {
 
-    var service: MindboxNotificationService!
-    var mockNotificationRequest: UNNotificationRequest!
+    let service = MindboxNotificationService()
 
-    override func setUp() {
-        super.setUp()
-        service = MindboxNotificationService()
+    // MARK: - parse(request:)
 
-        let aps: [AnyHashable: Any] = [
-            "mutable-content": 1,
-            "alert": [
-                "title": "Test title",
-                "body": "Test description"
-            ],
-            "content-available": 1,
-            "sound": "default"
-        ]
+    @Test("parse maps a current-format request into a Payload")
+    func parseCurrentFormat() throws {
+        let request = NotificationTestFixtures.makeRequest(userInfo: NotificationTestFixtures.currentFormatUserInfo())
+        let payload = try #require(service.parse(request: request))
 
-        let userInfo: [AnyHashable: Any] = [
-            "clickUrl": "https://mindbox.ru/",
-            "payload": "{\n  \"payload\": \"data\"\n}",
-            "uniqueKey": "4cccb64d-ba46-41eb-9699-3a706f2b910b",
-            "imageUrl": "https://mobpush-images.mindbox.ru/Mpush-test/63/5933f4cd-47e3-4317-9237-bc5aad291aa9.png",
-            "buttons": [
-                [
-                    "url": "https://developers.mindbox.ru/docs/mindbox-sdk",
-                    "text": "Documentation",
-                    "uniqueKey": "1b112bcd-5eae-4914-8842-d77198466466"
-                ],
-                [
-                    "url": "https://google.com",
-                    "text": "Button #1",
-                    "uniqueKey": "cff05f38-6df4-4a10-9859-ea3bf0a65068"
-                ]
-            ],
-            "aps": aps
-        ]
-
-        let content = UNMutableNotificationContent()
-        content.userInfo = userInfo
-        mockNotificationRequest = UNNotificationRequest(identifier: "test", content: content, trigger: nil)
+        let button = try #require(payload.withButton)
+        #expect(button.buttons?.first?.uniqueKey == NotificationTestFixtures.firstButtonKey)
+        #expect(button.buttons?.first?.text == "Documentation")
+        #expect(button.buttons?.last?.uniqueKey == NotificationTestFixtures.secondButtonKey)
+        #expect(button.buttons?.last?.text == "Button #1")
+        #expect(payload.withImageURL?.imageUrl == NotificationTestFixtures.imageUrl)
     }
 
-    override func tearDown() {
-        service = nil
-        mockNotificationRequest = nil
-        super.tearDown()
+    @Test("Payload.Button.debugDescription includes the unique key")
+    func payloadButtonDebugDescription() throws {
+        let request = NotificationTestFixtures.makeRequest(userInfo: NotificationTestFixtures.currentFormatUserInfo())
+        let button = try #require(service.parse(request: request)?.withButton)
+        #expect(button.debugDescription == "uniqueKey: \(button.uniqueKey)")
     }
 
-    func testParseToPayload() {
-        let payload = service.parse(request: mockNotificationRequest)
-        XCTAssertNotNil(payload)
-        XCTAssertNotNil(payload?.withButton)
-        XCTAssertEqual(payload?.withButton?.buttons?.first?.uniqueKey, "1b112bcd-5eae-4914-8842-d77198466466")
-        XCTAssertEqual(payload?.withButton?.buttons?.first?.text, "Documentation")
-        XCTAssertEqual(payload?.withButton?.buttons?.last?.uniqueKey, "cff05f38-6df4-4a10-9859-ea3bf0a65068")
-        XCTAssertEqual(payload?.withButton?.buttons?.last?.text, "Button #1")
-        XCTAssertNotNil(payload?.withImageURL)
-        XCTAssertEqual(payload?.withImageURL?.imageUrl, "https://mobpush-images.mindbox.ru/Mpush-test/63/5933f4cd-47e3-4317-9237-bc5aad291aa9.png")
+    // parse(request:)'s nil paths are unreachable here: getUserInfo never returns nil, and the
+    // only JSONSerialization failures throw an ObjC exception that `try?` can't catch (it crashes).
+
+    // MARK: - getUserInfo(from:)
+
+    @Test("getUserInfo returns the outer payload for the current format")
+    func getUserInfoCurrentFormat() throws {
+        let request = NotificationTestFixtures.makeRequest(userInfo: NotificationTestFixtures.currentFormatUserInfo())
+        let result = try #require(service.getUserInfo(from: request))
+
+        #expect(result["uniqueKey"] as? String == NotificationTestFixtures.uniqueKey)
+        #expect(result["clickUrl"] as? String == NotificationTestFixtures.clickUrl)
+
+        let aps = try #require(result["aps"] as? [AnyHashable: Any])
+        #expect(aps["sound"] as? String == "default")
+        #expect(aps["mutable-content"] as? Int == 1)
+        #expect(aps["content-available"] as? Int == 1)
+
+        let alert = try #require(aps["alert"] as? [String: String])
+        #expect(alert["title"] == "Test title")
+        #expect(alert["body"] == "Test description")
     }
 
-    func testGetUserInfo() {
-        let result = service.getUserInfo(from: mockNotificationRequest)
-        XCTAssertNotNil(result)
-        XCTAssertEqual(result?["uniqueKey"] as? String, "4cccb64d-ba46-41eb-9699-3a706f2b910b")
-        XCTAssertEqual(result?["clickUrl"] as? String, "https://mindbox.ru/")
+    @Test("getUserInfo unwraps the aps dictionary for the legacy format")
+    func getUserInfoLegacyFormat() throws {
+        let request = NotificationTestFixtures.makeRequest(userInfo: NotificationTestFixtures.legacyFormatUserInfo())
+        let result = try #require(service.getUserInfo(from: request))
 
-        let apsResult = result?["aps"] as? [AnyHashable: Any]
-        XCTAssertNotNil(apsResult)
-        XCTAssertEqual(apsResult?["mutable-content"] as? Int, 1)
-        XCTAssertEqual(apsResult?["content-available"] as? Int, 1)
-        XCTAssertEqual(apsResult?["sound"] as? String, "default")
+        #expect(result["uniqueKey"] as? String == NotificationTestFixtures.uniqueKey)
+        #expect(result["clickUrl"] as? String == NotificationTestFixtures.clickUrl)
+        #expect(result["sound"] as? String == "default")
+        #expect(result["mutable-content"] as? Int == 1)
+        #expect(result["content-available"] as? Int == 1)
 
-        let alertResult = apsResult?["alert"] as? [String: String]
-        XCTAssertNotNil(alertResult)
-        XCTAssertEqual(alertResult?["title"], "Test title")
-        XCTAssertEqual(alertResult?["body"], "Test description")
-    }
-
-    func testGetUserInfoLegacyPushFormat() {
-        let aps: [AnyHashable: Any] = [
-            "aps": [
-                "mutable-content": 1,
-                "alert": [
-                    "title": "Test title",
-                    "body": "Test description"
-                ],
-                "content-available": 1,
-                "sound": "default",
-                "clickUrl": "https://mindbox.ru/",
-                "payload": "{\n  \"payload\": \"data\"\n}",
-                "uniqueKey": "4cccb64d-ba46-41eb-9699-3a706f2b910b",
-                "imageUrl": "https://mobpush-images.mindbox.ru/Mpush-test/63/5933f4cd-47e3-4317-9237-bc5aad291aa9.png",
-                "buttons": [
-                    [
-                        "url": "https://developers.mindbox.ru/docs/mindbox-sdk",
-                        "text": "Documentation",
-                        "uniqueKey": "1b112bcd-5eae-4914-8842-d77198466466"
-                    ]
-                ]
-            ]
-        ]
-
-        let userInfo: [AnyHashable: Any] = aps
-
-        let content = UNMutableNotificationContent()
-        content.userInfo = userInfo
-        let request = UNNotificationRequest(identifier: "test", content: content, trigger: nil)
-
-        let result = service.getUserInfo(from: request)
-        XCTAssertNotNil(result)
-        XCTAssertEqual(result?["uniqueKey"] as? String, "4cccb64d-ba46-41eb-9699-3a706f2b910b")
-        XCTAssertEqual(result?["clickUrl"] as? String, "https://mindbox.ru/")
-
-        XCTAssertEqual(result?["mutable-content"] as? Int, 1)
-        XCTAssertEqual(result?["content-available"] as? Int, 1)
-        XCTAssertEqual(result?["sound"] as? String, "default")
-
-        let alertResult = result?["alert"] as? [String: String]
-        XCTAssertNotNil(alertResult)
-        XCTAssertEqual(alertResult?["title"], "Test title")
-        XCTAssertEqual(alertResult?["body"], "Test description")
+        let alert = try #require(result["alert"] as? [String: String])
+        #expect(alert["title"] == "Test title")
+        #expect(alert["body"] == "Test description")
     }
 }

--- a/MindboxNotificationsTests/Tag+Extensions.swift
+++ b/MindboxNotificationsTests/Tag+Extensions.swift
@@ -1,0 +1,30 @@
+//
+//  Tag+Extensions.swift
+//  MindboxNotificationsTests
+//
+//  Created by Sergei Semko on 6/16/26.
+//  Copyright © 2026 Mindbox. All rights reserved.
+//
+
+import Foundation
+import Testing
+
+extension Tag {
+    /// Umbrella tag applied to every MindboxNotifications test.
+    @Tag static var notifications: Self
+
+    // MARK: Subject areas
+
+    /// Push-format detection, decoding and validation: strategy factory, legacy/current
+    /// strategies, formatter, validator, payload parsing and `MBPushNotification`.
+    @Tag static var pushParsing: Self
+
+    /// Image magic-byte format detection (`ImageFormat`).
+    @Tag static var imageFormat: Self
+
+    /// Notification Service Extension delivery flow (`didReceive(_:withContentHandler:)`, expiry, push delivered).
+    @Tag static var notificationService: Self
+
+    /// Notification Content Extension UI flow (`didReceive(notification:…)`, actions, image view).
+    @Tag static var notificationContent: Self
+}


### PR DESCRIPTION
Brings the `MindboxNotifications` target up to ~96% coverage (from 64.6%) and
clears out a dead dependency.

The existing three suites move from XCTest to Swift Testing, and the push-parsing
pipeline that was completely untested — the format strategies, factory, formatter
and validator — now gets covered, along with ImageFormat, the public isMindboxPush/
getMindboxPushData API, and MBPushNotification decoding. 6 tests become 43; no
production code changes here.

Separately, MindboxNotifications linked MindboxLogger but never used it, so that
dependency is removed — one less framework in integrators' notification extensions.

All 43 tests pass (and stay green across 430 repeated runs), the full scheme builds,
and SwiftLint --strict is clean.

Worth a follow-up: legacy "defaultIosWithoutTitle" pushes, where aps.alert is a
plain string instead of a title/body object, aren't recognized by isMindboxPush/
getMindboxPushData today — the strategy expects an alert object.
