### PR TITLE
MOBILE-121: Add Gitleaks secret-scanning workflow

### DIFF
--- a/.github/workflows/gitleaks-secrets-validate.yml
+++ b/.github/workflows/gitleaks-secrets-validate.yml
@@ -1,0 +1,23 @@
+name: Gitleaks Secrets Validate
+on:
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  scan:
+    name: gitleaks
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          fetch-depth: 0
+
+      - name: Run Gitleaks
+        uses: gitleaks/gitleaks-action@e0c47f4f8be36e29cdc102c57e68cb5cbf0e8d1e # v3.0.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITLEAKS_LICENSE: ${{ secrets.MINDBOX_GITLEAKS_LICENSE }}


### PR DESCRIPTION
ios-sdk was the only SDK repo without Gitleaks; aligns secret scanning with android/flutter/react-native. Requires the org MINDBOX_GITLEAKS_LICENSE secret (Actions + Dependabot).