### PR TITLE
MOBILE-206: Fix infinite layout loop in modal in-app messages

### DIFF
--- a/Mindbox.xcodeproj/project.pbxproj
+++ b/Mindbox.xcodeproj/project.pbxproj
@@ -588,6 +588,7 @@
 		F361284D2BA31E36000382D9 /* PushPermissionActionUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = F361284C2BA31E36000382D9 /* PushPermissionActionUseCase.swift */; };
 		F367301B2B7B6E7600DD0039 /* MindboxPushValidatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F367301A2B7B6E7600DD0039 /* MindboxPushValidatorTests.swift */; };
 		F367301D2B7B8B6A00DD0039 /* NotificationFormatTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F367301C2B7B8B6A00DD0039 /* NotificationFormatTests.swift */; };
+		F367D3782FE43B2900455DB0 /* ModalViewControllerLayoutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F367D3772FE43B2900455DB0 /* ModalViewControllerLayoutTests.swift */; };
 		F370940B2B8F9CDE00655AC7 /* InAppConfigurationDataFacade.swift in Sources */ = {isa = PBXBuildFile; fileRef = F370940A2B8F9CDE00655AC7 /* InAppConfigurationDataFacade.swift */; };
 		F37613E12A6A8CFF009F2EE4 /* UIColor+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = F37613E02A6A8CFF009F2EE4 /* UIColor+Extensions.swift */; };
 		F382F20B2BAC50D000BC97FF /* VisitTargeting.swift in Sources */ = {isa = PBXBuildFile; fileRef = F382F20A2BAC50D000BC97FF /* VisitTargeting.swift */; };
@@ -1335,6 +1336,7 @@
 		F361284C2BA31E36000382D9 /* PushPermissionActionUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PushPermissionActionUseCase.swift; sourceTree = "<group>"; };
 		F367301A2B7B6E7600DD0039 /* MindboxPushValidatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MindboxPushValidatorTests.swift; sourceTree = "<group>"; };
 		F367301C2B7B8B6A00DD0039 /* NotificationFormatTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationFormatTests.swift; sourceTree = "<group>"; };
+		F367D3772FE43B2900455DB0 /* ModalViewControllerLayoutTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModalViewControllerLayoutTests.swift; sourceTree = "<group>"; };
 		F370940A2B8F9CDE00655AC7 /* InAppConfigurationDataFacade.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InAppConfigurationDataFacade.swift; sourceTree = "<group>"; };
 		F37613E02A6A8CFF009F2EE4 /* UIColor+Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIColor+Extensions.swift"; sourceTree = "<group>"; };
 		F382F20A2BAC50D000BC97FF /* VisitTargeting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VisitTargeting.swift; sourceTree = "<group>"; };
@@ -2751,6 +2753,7 @@
 		9B5256FD28D1A86F0029B1BC /* Tests */ = {
 			isa = PBXGroup;
 			children = (
+				F367D3772FE43B2900455DB0 /* ModalViewControllerLayoutTests.swift */,
 				F385631E2DB6729000D91208 /* InappConfigurationDataFacade */,
 				F3DEB38C2D47CBA200D0EFA4 /* InappSessionManagerTests */,
 				F39B67B62A3FAA62005C0CCA /* ABTesting */,
@@ -4786,6 +4789,7 @@
 				84FCD3B525CA0FD300D1E574 /* MockPersistenceStorage.swift in Sources */,
 				F3A8B99C2A3A47F800E9C055 /* ABTestVariantsValidatorTests.swift in Sources */,
 				848A89592620C3AE00EDFB6D /* APNSTokenGenerator.swift in Sources */,
+				F367D3782FE43B2900455DB0 /* ModalViewControllerLayoutTests.swift in Sources */,
 				F32E536F2C3F2B05002C7CA0 /* DITests.swift in Sources */,
 				F3D818B32A3885F50002957C /* ABTestDeviceMixerTests.swift in Sources */,
 				F391170B2AB2E74F00852298 /* InappFilterServiceTests.swift in Sources */,

--- a/Mindbox/InAppMessages/Presentation/Views/ModalView/ModalViewController.swift
+++ b/Mindbox/InAppMessages/Presentation/Views/ModalView/ModalViewController.swift
@@ -50,6 +50,7 @@ final class ModalViewController: UIViewController, InappViewControllerProtocol {
     private let onTapAction: InAppMessageTapAction
 
     private var viewWillAppearWasCalled = false
+    private var lastElementsLayoutSize: CGSize = .zero
 
     private enum Constants {
         static let defaultAlphaBackgroundColor: CGFloat = 0.2
@@ -96,14 +97,21 @@ final class ModalViewController: UIViewController, InappViewControllerProtocol {
     override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
 
-        if let inappView = layers.first(where: { $0 is InAppImageOnlyView }) {
-            Logger.common(message: "In-app modal height: [\(inappView.frame.height) pt]")
-            Logger.common(message: "In-app modal width: [\(inappView.frame.width) pt]")
+        guard let inappView = layers.first(where: { $0 is InAppImageOnlyView }) else {
+            return
         }
 
-        elements.forEach({
-            $0.removeFromSuperview()
-        })
+        // Rebuild elements only when the content size actually changes.
+        // Doing it on every pass is not allowed: addSubview + activate(constraints)
+        // mark the layout dirty again → infinite viewDidLayoutSubviews loop.
+        let size = inappView.frame.size
+        guard size != lastElementsLayoutSize else {
+            return
+        }
+        lastElementsLayoutSize = size
+
+        Logger.common(message: "In-app modal height: [\(inappView.frame.height) pt]")
+        Logger.common(message: "In-app modal width: [\(inappView.frame.width) pt]")
 
         setupElements()
     }
@@ -141,6 +149,9 @@ final class ModalViewController: UIViewController, InappViewControllerProtocol {
     }
 
     private func setupElements() {
+        elements.forEach { $0.removeFromSuperview() }
+        elements.removeAll()
+
         guard let elements = model.content.elements,
               let inappView = layers.first(where: { $0 is InAppImageOnlyView }) else {
             return

--- a/MindboxTests/InApp/Tests/ModalViewControllerLayoutTests.swift
+++ b/MindboxTests/InApp/Tests/ModalViewControllerLayoutTests.swift
@@ -124,7 +124,7 @@ struct ModalViewControllerLayoutTests {
     /// `removeAll()` + recreate, the count would stay 1 even if the size guard were
     /// removed and the loop returned. Object identity catches a re-run that count cannot.
     @Test("Stable size does not re-run setupElements (element instance is reused)")
-    func setupElementsNotReRunOnStableSize() throws {
+    func setupElementsNoGrowthOnStableSize() throws {
         let key = "image-key"
         let vc = makeController(model: try makeModel(imageKey: key), imagesDict: [key: makeImage()])
         let window = host(vc, size: CGSize(width: 320, height: 568))
@@ -135,7 +135,7 @@ struct ModalViewControllerLayoutTests {
         for _ in 0..<20 {
             vc.viewDidLayoutSubviews()
             #expect(vc.elements.first === initialElement,
-                    "setupElements must not re-run at a stable size — the size guard broke the layout loop")
+                    "setupElements must not growth at a stable size — the size guard broke the layout loop")
         }
     }
 

--- a/MindboxTests/InApp/Tests/ModalViewControllerLayoutTests.swift
+++ b/MindboxTests/InApp/Tests/ModalViewControllerLayoutTests.swift
@@ -1,0 +1,185 @@
+//
+//  ModalViewControllerLayoutTests.swift
+//  MindboxTests
+//
+//  Created by Claude on 17.06.2026.
+//  Copyright © 2026 Mindbox. All rights reserved.
+//
+
+import Testing
+import Foundation
+import UIKit
+@testable import Mindbox
+
+/// Regression tests for the `ModalViewController` layout fix.
+///
+/// `viewDidLayoutSubviews()` used to rebuild the elements on *every* layout pass,
+/// which caused two bugs:
+///   1. an infinite layout loop (`addSubview` + constraint activation re-dirtied the
+///      layout, re-triggering `viewDidLayoutSubviews`);
+///   2. unbounded growth of the `elements` array (old views were removed from the
+///      superview but never dropped from `self.elements`, while `setupElements`
+///      kept appending).
+///
+/// The fix caches the inapp content size in `lastElementsLayoutSize` and only rebuilds
+/// when it changes, and `setupElements()` now clears `elements` before re-adding.
+@MainActor
+@Suite("ModalViewController layout regression")
+struct ModalViewControllerLayoutTests {
+
+    // MARK: - Fixtures
+
+    /// Modal config with one image background layer (source value `imageKey`) and one
+    /// close-button element.
+    private func makeModel(imageKey: String) throws -> ModalFormVariant {
+        let json = """
+        {
+          "content": {
+            "background": {
+              "layers": [
+                {
+                  "$type": "image",
+                  "action": { "$type": "redirectUrl", "intentPayload": "payload", "value": "https://example.com" },
+                  "source": { "$type": "url", "value": "\(imageKey)" }
+                }
+              ]
+            },
+            "elements": [
+              {
+                "$type": "closeButton",
+                "color": "#FFFFFF",
+                "lineWidth": 2,
+                "size": { "kind": "dp", "width": 24, "height": 24 },
+                "position": { "margin": { "kind": "proportion", "top": 0.02, "right": 0.02, "left": 0.02, "bottom": 0.02 } }
+              }
+            ]
+          }
+        }
+        """
+        let data = Data(json.utf8)
+        return try JSONDecoder().decode(ModalFormVariant.self, from: data)
+    }
+
+    private func makeImage() -> UIImage {
+        let size = CGSize(width: 1, height: 1)
+        let renderer = UIGraphicsImageRenderer(size: size)
+        return renderer.image { context in
+            UIColor.red.setFill()
+            context.fill(CGRect(origin: .zero, size: size))
+        }
+    }
+
+    private func makeController(
+        model: ModalFormVariant,
+        imagesDict: [String: UIImage]
+    ) -> ModalViewController {
+        ModalViewController(
+            model: model,
+            id: "test-id",
+            imagesDict: imagesDict,
+            onPresented: {},
+            onTapAction: { _, _ in },
+            onClose: {}
+        )
+    }
+
+    /// Hosts the controller in a window of the given size and forces a real layout pass,
+    /// so the `InAppImageOnlyView` gets a non-zero frame.
+    private func host(_ vc: UIViewController, size: CGSize) -> UIWindow {
+        let window = UIWindow(frame: CGRect(origin: .zero, size: size))
+        window.rootViewController = vc
+        window.makeKeyAndVisible()
+        window.layoutIfNeeded()
+        return window
+    }
+
+    // MARK: - Tests
+
+    /// Repeated layout passes at the same size must not grow the `elements` array
+    /// (guards against both the infinite loop and the array-growth bug).
+    @Test("No element growth across repeated layout passes at a stable size")
+    func noGrowthOnStableSize() throws {
+        let key = "image-key"
+        let vc = makeController(model: try makeModel(imageKey: key), imagesDict: [key: makeImage()])
+        let window = host(vc, size: CGSize(width: 320, height: 568))
+        defer { window.isHidden = true }
+
+        // The first real layout builds exactly the close button.
+        #expect(vc.elements.count == 1)
+
+        // Simulate many extra layout passes at the same size.
+        for _ in 0..<20 {
+            vc.viewDidLayoutSubviews()
+        }
+        vc.view.setNeedsLayout()
+        vc.view.layoutIfNeeded()
+
+        #expect(vc.elements.count == 1, "elements array must not grow on stable-size layout passes")
+    }
+
+    /// Root-cause guard for the infinite-loop bug: at a stable size, `setupElements()`
+    /// must NOT run again, so the element view instance stays identical across passes.
+    ///
+    /// This is stricter than `noGrowthOnStableSize`: because `setupElements()` now does
+    /// `removeAll()` + recreate, the count would stay 1 even if the size guard were
+    /// removed and the loop returned. Object identity catches a re-run that count cannot.
+    @Test("Stable size does not re-run setupElements (element instance is reused)")
+    func setupElementsNotReRunOnStableSize() throws {
+        let key = "image-key"
+        let vc = makeController(model: try makeModel(imageKey: key), imagesDict: [key: makeImage()])
+        let window = host(vc, size: CGSize(width: 320, height: 568))
+        defer { window.isHidden = true }
+
+        let initialElement = try #require(vc.elements.first)
+
+        for _ in 0..<20 {
+            vc.viewDidLayoutSubviews()
+            #expect(vc.elements.first === initialElement,
+                    "setupElements must not re-run at a stable size — the size guard broke the layout loop")
+        }
+    }
+
+    /// A genuine size change must rebuild the elements: the count stays correct (not
+    /// doubled) and the previous element view is removed from the hierarchy.
+    @Test("Elements are rebuilt — not duplicated — when the content size changes")
+    func rebuildOnSizeChange() throws {
+        let key = "image-key"
+        let vc = makeController(model: try makeModel(imageKey: key), imagesDict: [key: makeImage()])
+        let window = host(vc, size: CGSize(width: 320, height: 568))
+        defer { window.isHidden = true }
+
+        #expect(vc.elements.count == 1)
+        let firstElement = try #require(vc.elements.first)
+        #expect(firstElement.superview != nil)
+
+        // Change the window size so the InAppImageOnlyView frame (and thus content size) changes.
+        window.frame = CGRect(x: 0, y: 0, width: 414, height: 896)
+        vc.view.frame = window.bounds
+        window.setNeedsLayout()
+        window.layoutIfNeeded()
+
+        #expect(vc.elements.count == 1, "size change must rebuild, not append")
+        let secondElement = try #require(vc.elements.first)
+        #expect(secondElement !== firstElement, "a new element view should be created on rebuild")
+        #expect(firstElement.superview == nil, "the previous element view must be removed from the superview")
+    }
+
+    /// When there is no `InAppImageOnlyView` in `layers` (here: the image is missing from
+    /// `imagesDict`, so no layer view is created), layout must not crash and must not
+    /// build any elements.
+    @Test("No InAppImageOnlyView: no elements built, no crash")
+    func noInappViewMeansNoElements() throws {
+        let vc = makeController(model: try makeModel(imageKey: "image-key"), imagesDict: [:])
+        let window = host(vc, size: CGSize(width: 320, height: 568))
+        defer { window.isHidden = true }
+
+        #expect(vc.layers.isEmpty)
+        #expect(vc.elements.isEmpty)
+
+        // Extra passes must stay safe.
+        vc.viewDidLayoutSubviews()
+        vc.view.setNeedsLayout()
+        vc.view.layoutIfNeeded()
+        #expect(vc.elements.isEmpty)
+    }
+}


### PR DESCRIPTION
## Description

`ModalViewController.viewDidLayoutSubviews()` rebuilt the content elements on **every** layout pass. Because `setupElements()` calls `addSubview` + constraint activation, each rebuild re-dirtied the layout and re-triggered `viewDidLayoutSubviews` — an infinite layout loop. The old views were also removed from the superview but never dropped from the `elements` array, so the array grew unbounded.

## Changes

- Cache the in-app content size in `lastElementsLayoutSize` and rebuild elements only when the size actually changes (breaks the layout loop).
- `setupElements()` now clears `elements` (`removeFromSuperview` + `removeAll`) before re-adding, preventing unbounded array growth.
- Early-return guard when there is no `InAppImageOnlyView` layer.

## Type of Change

- Bug fix

## Tests

Added `ModalViewControllerLayoutTests` (Swift Testing) covering:
- no element growth across repeated layout passes at a stable size;
- `setupElements` is not re-run at a stable size (element instance reused — strict guard for the loop fix);
- elements are rebuilt (not duplicated) on a genuine size change;
- no `InAppImageOnlyView` → no elements, no crash.

All tests pass locally.