### PR TITLE
MOBILE-187: Remove AppGroup misconfiguration crash

### DIFF
--- a/Example/Example/NotificationCenter/SwiftDataManager.swift
+++ b/Example/Example/NotificationCenter/SwiftDataManager.swift
@@ -78,7 +78,9 @@ public struct SwiftDataManager {
                 print("Application Support directory already exists at \(applicationSupportURL.path)")
             }
         } else {
-            fatalError("Could not find App Group container URL.")
+            // Best-effort: the SwiftData store falls back to the app's default
+            // location, so a missing App Group container must not crash the host.
+            print("App Group container URL is unavailable; skipping SwiftData directory setup.")
         }
     }
 }

--- a/Mindbox.xcodeproj/project.pbxproj
+++ b/Mindbox.xcodeproj/project.pbxproj
@@ -474,6 +474,8 @@
 		D2F7E24A2BADC2AB00B24BB8 /* SessionManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2F7E2492BADC2AB00B24BB8 /* SessionManager.swift */; };
 		D2F7E24C2BADC4CA00B24BB8 /* MockSessionManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2F7E24B2BADC4CA00B24BB8 /* MockSessionManager.swift */; };
 		DAE90A6BC9F524C24F9B5BA7 /* LoggerDatabaseLoaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 447CD2C35E75139236BFAFAE /* LoggerDatabaseLoaderTests.swift */; };
+		12D1798EE18C448EA75C93DE /* FileManagerStoreURLTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 658C153BCCF94DD89AEBAB14 /* FileManagerStoreURLTests.swift */; };
+		C7705AB22E0A2F0000C0FFEE /* MBLoggerUtilitiesFetcherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7705AB12E0A2F0000C0FFEE /* MBLoggerUtilitiesFetcherTests.swift */; };
 		DEC482157E5249DBBFAEFC9A /* FeatureTogglesModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9778038796A8426ABDED1E97 /* FeatureTogglesModel.swift */; };
 		EA395B77BB16CEFE6DC91D1D /* TransparentViewSyncOperationResponseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B7DAFAB687945FA908DB1AC /* TransparentViewSyncOperationResponseTests.swift */; };
 		EEF7A48FC34733D3D1D1E5EE /* PushNotificationParsingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEDFA644103A7CA5760F368C /* PushNotificationParsingTests.swift */; };
@@ -505,6 +507,7 @@
 		F32E536F2C3F2B05002C7CA0 /* DITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F32E536E2C3F2B05002C7CA0 /* DITests.swift */; };
 		F32E53792C3FD64A002C7CA0 /* DIMainModuleRegistrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F32E53782C3FD64A002C7CA0 /* DIMainModuleRegistrationTests.swift */; };
 		F32E537B2C3FDA30002C7CA0 /* DIMainModuleReplaceableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F32E537A2C3FDA30002C7CA0 /* DIMainModuleReplaceableTests.swift */; };
+		B7705CA22E0A1F0000C0FFEE /* AppGroupUnavailableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7705CA12E0A1F0000C0FFEE /* AppGroupUnavailableTests.swift */; };
 		F32E537D2C3FDB6D002C7CA0 /* DITestModuleReplaceableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F32E537C2C3FDB6D002C7CA0 /* DITestModuleReplaceableTests.swift */; };
 		F33087662C37590600F8DF10 /* InjectInappTools.swift in Sources */ = {isa = PBXBuildFile; fileRef = F33087652C37590600F8DF10 /* InjectInappTools.swift */; };
 		F331DC842A80983000222120 /* FailableDecodableArray.swift in Sources */ = {isa = PBXBuildFile; fileRef = F331DC832A80983000222120 /* FailableDecodableArray.swift */; };
@@ -850,6 +853,8 @@
 		3456BAC56F984378B6CED7CB /* FeatureToggleManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeatureToggleManager.swift; sourceTree = "<group>"; };
 		4190724EF9D389EF2AD89F61 /* TestContainers.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TestContainers.swift; sourceTree = "<group>"; };
 		447CD2C35E75139236BFAFAE /* LoggerDatabaseLoaderTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LoggerDatabaseLoaderTests.swift; sourceTree = "<group>"; };
+		658C153BCCF94DD89AEBAB14 /* FileManagerStoreURLTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = FileManagerStoreURLTests.swift; sourceTree = "<group>"; };
+		C7705AB12E0A2F0000C0FFEE /* MBLoggerUtilitiesFetcherTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MBLoggerUtilitiesFetcherTests.swift; sourceTree = "<group>"; };
 		472179A62C80755A00C15E7F /* ShownInAppsIDsMigration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShownInAppsIDsMigration.swift; sourceTree = "<group>"; };
 		472765512E0D52A500A5A060 /* RemoveBackgroundTaskDataMigration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoveBackgroundTaskDataMigration.swift; sourceTree = "<group>"; };
 		472F549D2C6E272A0008C465 /* MBPushNotification.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MBPushNotification.swift; sourceTree = "<group>"; };
@@ -1253,6 +1258,7 @@
 		F32E536E2C3F2B05002C7CA0 /* DITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DITests.swift; sourceTree = "<group>"; };
 		F32E53782C3FD64A002C7CA0 /* DIMainModuleRegistrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DIMainModuleRegistrationTests.swift; sourceTree = "<group>"; };
 		F32E537A2C3FDA30002C7CA0 /* DIMainModuleReplaceableTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DIMainModuleReplaceableTests.swift; sourceTree = "<group>"; };
+		B7705CA12E0A1F0000C0FFEE /* AppGroupUnavailableTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppGroupUnavailableTests.swift; sourceTree = "<group>"; };
 		F32E537C2C3FDB6D002C7CA0 /* DITestModuleReplaceableTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DITestModuleReplaceableTests.swift; sourceTree = "<group>"; };
 		F33087652C37590600F8DF10 /* InjectInappTools.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InjectInappTools.swift; sourceTree = "<group>"; };
 		F331DC832A80983000222120 /* FailableDecodableArray.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FailableDecodableArray.swift; sourceTree = "<group>"; };
@@ -1535,6 +1541,8 @@
 				7524712342EB4F8843422A42 /* Mocks */,
 				D8BDF175A75C9AA9138161F4 /* DateFormatTests.swift */,
 				447CD2C35E75139236BFAFAE /* LoggerDatabaseLoaderTests.swift */,
+				658C153BCCF94DD89AEBAB14 /* FileManagerStoreURLTests.swift */,
+				C7705AB12E0A2F0000C0FFEE /* MBLoggerUtilitiesFetcherTests.swift */,
 				65709D595F60BEBEE72B7129 /* LogStoreTrimmerTests.swift */,
 				6EDC7BDB5357E8B393398E83 /* MBLoggerCoreDataManagerTests.swift */,
 				B672B00D84EF4718617DD73B /* Tag+Extensions.swift */,
@@ -2509,6 +2517,7 @@
 				F32E536E2C3F2B05002C7CA0 /* DITests.swift */,
 				F32E53782C3FD64A002C7CA0 /* DIMainModuleRegistrationTests.swift */,
 				F32E537A2C3FDA30002C7CA0 /* DIMainModuleReplaceableTests.swift */,
+				B7705CA12E0A1F0000C0FFEE /* AppGroupUnavailableTests.swift */,
 				F32E537C2C3FDB6D002C7CA0 /* DITestModuleReplaceableTests.swift */,
 			);
 			path = DI;
@@ -4713,6 +4722,7 @@
 				47EFF0FD2E8D85B700E72D0A /* DatabaseMetadataMigrationTests.swift in Sources */,
 				840C38B325D133B000D50183 /* GuaranteedDeliveryTestCase.swift in Sources */,
 				F32E537B2C3FDA30002C7CA0 /* DIMainModuleReplaceableTests.swift in Sources */,
+				B7705CA22E0A1F0000C0FFEE /* AppGroupUnavailableTests.swift in Sources */,
 				F32B68882CF83B030088BCDD /* InappConfigurationTests.swift in Sources */,
 				84FCD3B925CA109E00D1E574 /* MockNetworkFetcher.swift in Sources */,
 				9B9C9538292111A700BB29DA /* MockUUIDDebugService.swift in Sources */,
@@ -4900,6 +4910,8 @@
 			files = (
 				B85C0ADF4CEB785D63D8AFDD /* DateFormatTests.swift in Sources */,
 				DAE90A6BC9F524C24F9B5BA7 /* LoggerDatabaseLoaderTests.swift in Sources */,
+				12D1798EE18C448EA75C93DE /* FileManagerStoreURLTests.swift in Sources */,
+				C7705AB22E0A2F0000C0FFEE /* MBLoggerUtilitiesFetcherTests.swift in Sources */,
 				9975EFB6A9873E934A5DECC3 /* LogStoreTrimmerTests.swift in Sources */,
 				BF9A3BD95CEEDED8B57E3A87 /* MBLoggerCoreDataManagerTests.swift in Sources */,
 				ABB2BA4CBAC379C38C6F33C7 /* TestContainers.swift in Sources */,

--- a/Mindbox/CoreController/CoreController.swift
+++ b/Mindbox/CoreController/CoreController.swift
@@ -30,6 +30,9 @@ final class CoreController {
 
             DI.injectOrFail(MigrationManagerProtocol.self).migrate()
 
+            // Report a local-fallback → App Group storage transition if one happened (issue #705 follow-up).
+            AppGroupStorageTransitionReporter().reportIfNeeded()
+
             SessionTemporaryStorage.shared.isInstalledFromPersistenceStorageBeforeInitSDK = self.persistenceStorage.isInstalled
 
             self.configValidation.compare(configuration, self.persistenceStorage.configuration)

--- a/Mindbox/CoreController/CoreController.swift
+++ b/Mindbox/CoreController/CoreController.swift
@@ -30,9 +30,6 @@ final class CoreController {
 
             DI.injectOrFail(MigrationManagerProtocol.self).migrate()
 
-            // Report a local-fallback → App Group storage transition if one happened (issue #705 follow-up).
-            AppGroupStorageTransitionReporter().reportIfNeeded()
-
             SessionTemporaryStorage.shared.isInstalledFromPersistenceStorageBeforeInitSDK = self.persistenceStorage.isInstalled
 
             self.configValidation.compare(configuration, self.persistenceStorage.configuration)
@@ -42,6 +39,8 @@ final class CoreController {
             } else {
                 self.repeatInitialization(with: configuration)
             }
+
+            AppGroupStorageTransitionReporter().reportIfNeeded()
 
             self.guaranteedDeliveryManager.canScheduleOperations = true
 

--- a/Mindbox/DI/Injections/InjectReplaceable.swift
+++ b/Mindbox/DI/Injections/InjectReplaceable.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 import UIKit
+import MindboxLogger
 
 extension MBContainer {
     func registerReplaceableUtilities() -> Self {
@@ -29,10 +30,31 @@ extension MBContainer {
 
         register(PersistenceStorage.self) {
             let utilitiesFetcher = DI.injectOrFail(UtilitiesFetcher.self)
-            guard let defaults = UserDefaults(suiteName: utilitiesFetcher.applicationGroupIdentifier) else {
-                assertionFailure("Failed to create UserDefaults with suite name: \(utilitiesFetcher.applicationGroupIdentifier). Check and set up your AppGroups correctly.")
-                return MBPersistenceStorage(defaults: UserDefaults.standard)
+            let appGroup = utilitiesFetcher.applicationGroupIdentifier
+
+            guard !appGroup.isEmpty else {
+                // App Group unavailable (already reported by the fetcher) — fall back to
+                // local defaults so the SDK keeps working without the shared suite instead
+                // of crashing the host (issue #705).
+                //
+                // Broken→fixed transition (future reference): while the group is missing,
+                // install identity (deviceUUID, installationDate, …) is written to
+                // `.standard`. If the integrator later fixes the App Group, the now-used
+                // suite is empty, so the SDK sees `isInstalled == false` and re-registers
+                // the install. deviceUUID is re-derived from IDFV and stays stable on the
+                // same device (no duplicate device), but a fresh install event is sent and
+                // local state (in-app caps, counters) resets. This is accepted rather than
+                // migrating `.standard`→suite; a one-shot carry-over could be added later
+                // if re-registration churn becomes a problem.
+                return MBPersistenceStorage(defaults: .standard)
             }
+
+            guard let defaults = UserDefaults(suiteName: appGroup) else {
+                // Unreachable for a resolved App Group id; degrade without trapping (issue #705).
+                Logger.common(message: "[PersistenceStorage] UserDefaults(suiteName: \(appGroup)) failed; using .standard.", level: .fault, category: .general)
+                return MBPersistenceStorage(defaults: .standard)
+            }
+
             return MBPersistenceStorage(defaults: defaults)
         }
 

--- a/Mindbox/DI/Injections/InjectReplaceable.swift
+++ b/Mindbox/DI/Injections/InjectReplaceable.swift
@@ -34,18 +34,8 @@ extension MBContainer {
 
             guard !appGroup.isEmpty else {
                 // App Group unavailable (already reported by the fetcher) — fall back to
-                // local defaults so the SDK keeps working without the shared suite instead
-                // of crashing the host (issue #705).
-                //
-                // Broken→fixed transition (future reference): while the group is missing,
-                // install identity (deviceUUID, installationDate, …) is written to
-                // `.standard`. If the integrator later fixes the App Group, the now-used
-                // suite is empty, so the SDK sees `isInstalled == false` and re-registers
-                // the install. deviceUUID is re-derived from IDFV and stays stable on the
-                // same device (no duplicate device), but a fresh install event is sent and
-                // local state (in-app caps, counters) resets. This is accepted rather than
-                // migrating `.standard`→suite; a one-shot carry-over could be added later
-                // if re-registration churn becomes a problem.
+                // `.standard` so the SDK keeps working instead of crashing the host (issue #705).
+                // A later App Group fix re-registers the install; see `AppGroupStorageTransitionReporter`.
                 return MBPersistenceStorage(defaults: .standard)
             }
 

--- a/Mindbox/PersistenceStorage/MBPersistenceStorage.swift
+++ b/Mindbox/PersistenceStorage/MBPersistenceStorage.swift
@@ -372,9 +372,11 @@ extension MBPersistenceStorage {
 /// fallback store and the App Group suite — the fingerprint of a device that ran in local
 /// fallback while the App Group was unavailable and silently re-registered once it became
 /// available. Read-only by design: it never mutates either store, so a re-break stays a
-/// continuing install and any cleanup is left to a future carry-over migration. Fires on the
-/// launch after the fix (the suite is empty until re-registration) and on each cold start
-/// while the fingerprint persists.
+/// continuing install and any cleanup is left to a future carry-over migration.
+///
+/// `reportIfNeeded()` runs before re-registration writes the marker to the suite, so the recovery
+/// launch itself does not fire (the suite is still empty then); it first fires on the next cold
+/// start, and on every cold start after while the fingerprint persists.
 struct AppGroupStorageTransitionReporter {
 
     private let localDefaults: UserDefaults

--- a/Mindbox/PersistenceStorage/MBPersistenceStorage.swift
+++ b/Mindbox/PersistenceStorage/MBPersistenceStorage.swift
@@ -385,7 +385,7 @@ struct AppGroupStorageTransitionReporter {
     init(activeDefaults: UserDefaults = MBPersistenceStorage.defaults,
          localDefaults: UserDefaults = .standard) {
         self.localDefaults = localDefaults
-        self.sharedDefaults = (activeDefaults == localDefaults) ? nil : activeDefaults
+        self.sharedDefaults = (activeDefaults === localDefaults) ? nil : activeDefaults
     }
 
     @discardableResult

--- a/Mindbox/PersistenceStorage/MBPersistenceStorage.swift
+++ b/Mindbox/PersistenceStorage/MBPersistenceStorage.swift
@@ -351,3 +351,58 @@ fileprivate extension UserDefaults {
         return object(forKey: key) != nil
     }
 }
+
+// MARK: - Install-state probing across stores
+
+extension MBPersistenceStorage {
+
+    /// Backing key for `isInstalled`, exposed so the storage-transition reporter can probe a
+    /// specific store (`.standard` vs. the App Group suite) without duplicating the raw string.
+    static var installationDataKey: String {
+        UserDefaultsWrapper<String>.Key.installationData.rawValue
+    }
+
+    /// Whether install state is present in `defaults`, independent of the active store.
+    static func isInstalled(in defaults: UserDefaults) -> Bool {
+        defaults.object(forKey: installationDataKey) != nil
+    }
+}
+
+/// Reports (issue #705 follow-up) when install state is present in BOTH the local `.standard`
+/// fallback store and the App Group suite — the fingerprint of a device that ran in local
+/// fallback while the App Group was unavailable and silently re-registered once it became
+/// available. Read-only by design: it never mutates either store, so a re-break stays a
+/// continuing install and any cleanup is left to a future carry-over migration. Fires on the
+/// launch after the fix (the suite is empty until re-registration) and on each cold start
+/// while the fingerprint persists.
+struct AppGroupStorageTransitionReporter {
+
+    private let localDefaults: UserDefaults
+    private let sharedDefaults: UserDefaults?
+
+    /// `activeDefaults` is the store the SDK currently persists to (the App Group suite when
+    /// available, else `.standard`); when it *is* the local store there is nothing to compare.
+    init(activeDefaults: UserDefaults = MBPersistenceStorage.defaults,
+         localDefaults: UserDefaults = .standard) {
+        self.localDefaults = localDefaults
+        self.sharedDefaults = (activeDefaults == localDefaults) ? nil : activeDefaults
+    }
+
+    @discardableResult
+    func reportIfNeeded() -> Bool {
+        guard let sharedDefaults else { return false }
+        guard MBPersistenceStorage.isInstalled(in: localDefaults),
+              MBPersistenceStorage.isInstalled(in: sharedDefaults) else { return false }
+
+        Logger.common(
+            message: "[Storage] Install state found in BOTH the local fallback store and the "
+                + "App Group suite. The device ran in local-storage fallback (App Group "
+                + "unavailable) and the App Group has since become available, so the install was "
+                + "re-registered on the shared container (deviceUUID stays stable via IDFV; "
+                + "in-app caps/counters reset).",
+            level: .fault,
+            category: .general
+        )
+        return true
+    }
+}

--- a/Mindbox/PersistenceStorage/MBPersistenceStorage.swift
+++ b/Mindbox/PersistenceStorage/MBPersistenceStorage.swift
@@ -394,7 +394,7 @@ struct AppGroupStorageTransitionReporter {
                 + "unavailable) and the App Group has since become available, so the install was "
                 + "re-registered on the shared container (deviceUUID stays stable, re-derived from IDFA/IDFV; "
                 + "in-app caps/counters reset).",
-            level: .fault,
+            level: .info,
             category: .general
         )
         return true

--- a/Mindbox/PersistenceStorage/MBPersistenceStorage.swift
+++ b/Mindbox/PersistenceStorage/MBPersistenceStorage.swift
@@ -368,8 +368,8 @@ extension MBPersistenceStorage {
 
 /// Reports (issue #705 follow-up) a fallback-then-recovery fingerprint: install state in BOTH the
 /// `.standard` fallback and the App Group suite. Read-only by design (cleanup deferred to a future
-/// migration). Runs before re-registration, so it first fires on the cold start after the recovery
-/// launch, then on every cold start while the fingerprint persists.
+/// migration). Runs after re-registration, so it fires on the recovery launch itself and on every
+/// cold start while the fingerprint persists.
 struct AppGroupStorageTransitionReporter {
 
     private let localDefaults: UserDefaults

--- a/Mindbox/PersistenceStorage/MBPersistenceStorage.swift
+++ b/Mindbox/PersistenceStorage/MBPersistenceStorage.swift
@@ -366,11 +366,10 @@ extension MBPersistenceStorage {
     }
 }
 
-/// Reports (issue #705 follow-up) when install state is in BOTH the local `.standard` fallback and
-/// the App Group suite — the fingerprint of a device that ran in fallback while the App Group was
-/// unavailable, then re-registered once it became available. Read-only: never mutates either store;
-/// cleanup is left to a future carry-over migration. Runs before re-registration, so it first fires
-/// on the cold start *after* the recovery launch, then on every cold start while the fingerprint persists.
+/// Reports (issue #705 follow-up) a fallback-then-recovery fingerprint: install state in BOTH the
+/// `.standard` fallback and the App Group suite. Read-only by design (cleanup deferred to a future
+/// migration). Runs before re-registration, so it first fires on the cold start after the recovery
+/// launch, then on every cold start while the fingerprint persists.
 struct AppGroupStorageTransitionReporter {
 
     private let localDefaults: UserDefaults
@@ -393,7 +392,7 @@ struct AppGroupStorageTransitionReporter {
             message: "[Storage] Install state found in BOTH the local fallback store and the "
                 + "App Group suite. The device ran in local-storage fallback (App Group "
                 + "unavailable) and the App Group has since become available, so the install was "
-                + "re-registered on the shared container (deviceUUID stays stable via IDFV; "
+                + "re-registered on the shared container (deviceUUID stays stable, re-derived from IDFA/IDFV; "
                 + "in-app caps/counters reset).",
             level: .fault,
             category: .general

--- a/Mindbox/PersistenceStorage/MBPersistenceStorage.swift
+++ b/Mindbox/PersistenceStorage/MBPersistenceStorage.swift
@@ -356,34 +356,27 @@ fileprivate extension UserDefaults {
 
 extension MBPersistenceStorage {
 
-    /// Backing key for `isInstalled`, exposed so the storage-transition reporter can probe a
-    /// specific store (`.standard` vs. the App Group suite) without duplicating the raw string.
+    /// Backing key for `isInstalled`, exposed so the reporter can probe a specific store.
     static var installationDataKey: String {
         UserDefaultsWrapper<String>.Key.installationData.rawValue
     }
 
-    /// Whether install state is present in `defaults`, independent of the active store.
     static func isInstalled(in defaults: UserDefaults) -> Bool {
         defaults.object(forKey: installationDataKey) != nil
     }
 }
 
-/// Reports (issue #705 follow-up) when install state is present in BOTH the local `.standard`
-/// fallback store and the App Group suite — the fingerprint of a device that ran in local
-/// fallback while the App Group was unavailable and silently re-registered once it became
-/// available. Read-only by design: it never mutates either store, so a re-break stays a
-/// continuing install and any cleanup is left to a future carry-over migration.
-///
-/// `reportIfNeeded()` runs before re-registration writes the marker to the suite, so the recovery
-/// launch itself does not fire (the suite is still empty then); it first fires on the next cold
-/// start, and on every cold start after while the fingerprint persists.
+/// Reports (issue #705 follow-up) when install state is in BOTH the local `.standard` fallback and
+/// the App Group suite — the fingerprint of a device that ran in fallback while the App Group was
+/// unavailable, then re-registered once it became available. Read-only: never mutates either store;
+/// cleanup is left to a future carry-over migration. Runs before re-registration, so it first fires
+/// on the cold start *after* the recovery launch, then on every cold start while the fingerprint persists.
 struct AppGroupStorageTransitionReporter {
 
     private let localDefaults: UserDefaults
     private let sharedDefaults: UserDefaults?
 
-    /// `activeDefaults` is the store the SDK currently persists to (the App Group suite when
-    /// available, else `.standard`); when it *is* the local store there is nothing to compare.
+    /// In fallback the active store *is* `.standard`, so there's nothing to compare.
     init(activeDefaults: UserDefaults = MBPersistenceStorage.defaults,
          localDefaults: UserDefaults = .standard) {
         self.localDefaults = localDefaults

--- a/Mindbox/Utilities/UtilitiesFetcher/MBUtilitiesFetcher.swift
+++ b/Mindbox/Utilities/UtilitiesFetcher/MBUtilitiesFetcher.swift
@@ -51,7 +51,7 @@ class MBUtilitiesFetcher: UtilitiesFetcher {
         guard FileManager.default.containerURL(forSecurityApplicationGroupIdentifier: identifier) != nil else {
             let message = "App Group '\(identifier)' container is unavailable. "
                 + "Enable the App Group capability with this exact value on every target (app + extensions). "
-                + "See developers.mindbox.ru/docs/ios-sdk-initialization"
+                + "See https://developers.mindbox.ru/docs/ios-sdk-initialization"
             Logger.common(message: message, level: .fault, category: .general)
             return ""
         }

--- a/Mindbox/Utilities/UtilitiesFetcher/MBUtilitiesFetcher.swift
+++ b/Mindbox/Utilities/UtilitiesFetcher/MBUtilitiesFetcher.swift
@@ -29,19 +29,13 @@ class MBUtilitiesFetcher: UtilitiesFetcher {
         return bundle
     }()
 
-    /// Identifier of the shared App Group container used for the SDK's persistent
-    /// storage (the events database and the `UserDefaults` suite).
+    /// Identifier of the shared App Group container for the SDK's persistent storage
+    /// (events database + `UserDefaults` suite).
     ///
-    /// Returns an empty string when the host bundle identifier is missing or the
-    /// App Group container is unavailable, so the SDK can fall back to local
-    /// storage instead of crashing the host process (see issue #705).
-    ///
-    /// The SDK must never crash the host over this — not even in Debug. Automated
-    /// device farms run Debug builds on real devices and frequently lack a
-    /// configured App Group (signing/capability is easy to forget for test builds),
-    /// so any trap (fatalError/assertionFailure/precondition) would break exactly
-    /// the automated-testing scenario issue #705 is about. The misconfiguration is
-    /// surfaced as a `.fault` log instead, on every platform.
+    /// Returns `""` when the host bundle id is missing or the container is unavailable,
+    /// so the SDK falls back to local storage instead of crashing the host (issue #705).
+    /// Must never trap — not even in Debug: Debug builds on device farms routinely lack a
+    /// configured App Group, the exact scenario #705 is about. Surfaced as a `.fault` log.
     var applicationGroupIdentifier: String {
         guard let hostApplicationName = hostApplicationName else {
             Logger.common(message: "[MBUtilitiesFetcher] Host application bundle identifier is unavailable", level: .fault, category: .general)

--- a/Mindbox/Utilities/UtilitiesFetcher/MBUtilitiesFetcher.swift
+++ b/Mindbox/Utilities/UtilitiesFetcher/MBUtilitiesFetcher.swift
@@ -29,20 +29,31 @@ class MBUtilitiesFetcher: UtilitiesFetcher {
         return bundle
     }()
 
+    /// Identifier of the shared App Group container used for the SDK's persistent
+    /// storage (the events database and the `UserDefaults` suite).
+    ///
+    /// Returns an empty string when the host bundle identifier is missing or the
+    /// App Group container is unavailable, so the SDK can fall back to local
+    /// storage instead of crashing the host process (see issue #705).
+    ///
+    /// The SDK must never crash the host over this — not even in Debug. Automated
+    /// device farms run Debug builds on real devices and frequently lack a
+    /// configured App Group (signing/capability is easy to forget for test builds),
+    /// so any trap (fatalError/assertionFailure/precondition) would break exactly
+    /// the automated-testing scenario issue #705 is about. The misconfiguration is
+    /// surfaced as a `.fault` log instead, on every platform.
     var applicationGroupIdentifier: String {
         guard let hostApplicationName = hostApplicationName else {
-            fatalError("CFBundleShortVersionString not found for host app")
+            Logger.common(message: "[MBUtilitiesFetcher] Host application bundle identifier is unavailable", level: .fault, category: .general)
+            return ""
         }
         let identifier = "group.cloud.Mindbox.\(hostApplicationName)"
-        let url = FileManager.default.containerURL(forSecurityApplicationGroupIdentifier: identifier)
-        guard url != nil else {
-            #if targetEnvironment(simulator)
-            return ""
-            #else
-            let message = "AppGroup for \(hostApplicationName) not found. Add AppGroup with value: \(identifier)"
+        guard FileManager.default.containerURL(forSecurityApplicationGroupIdentifier: identifier) != nil else {
+            let message = "App Group '\(identifier)' container is unavailable. "
+                + "Enable the App Group capability with this exact value on every target (app + extensions). "
+                + "See developers.mindbox.ru/docs/ios-sdk-initialization"
             Logger.common(message: message, level: .fault, category: .general)
-            fatalError(message)
-            #endif
+            return ""
         }
         return identifier
     }

--- a/MindboxLogger/Shared/Extensions/FileManager+Extensions.swift
+++ b/MindboxLogger/Shared/Extensions/FileManager+Extensions.swift
@@ -9,9 +9,28 @@
 import Foundation
 
 extension FileManager {
-    static func storeURL(for appGroup: String, databaseName: String) -> URL {
+
+    /// Error thrown when a shared App Group container cannot be resolved.
+    enum StoreURLError: LocalizedError, Equatable {
+        /// The App Group container for `appGroup` is unavailable — typically a missing,
+        /// misconfigured, or unprovisioned App Group capability. (On a clean Simulator
+        /// install the container has also been seen to resolve late, though that isn't
+        /// documented.)
+        case containerUnavailable(appGroup: String)
+
+        var errorDescription: String? {
+            switch self {
+            case .containerUnavailable(let appGroup):
+                return "App Group container '\(appGroup)' is unavailable. "
+                    + "Set up your AppGroup correctly — it must be the same for all your targets. "
+                    + "Read the documentation: developers.mindbox.ru/docs/ios-sdk-initialization"
+            }
+        }
+    }
+
+    static func storeURL(for appGroup: String, databaseName: String) throws -> URL {
         guard let fileContainer = FileManager.default.containerURL(forSecurityApplicationGroupIdentifier: appGroup) else {
-            fatalError("Container couldn't be created, please set up your AppGroup correctly. It must be the same for all your targets. Read the documentation developers.mindbox.ru/docs/ios-sdk-initialization")
+            throw StoreURLError.containerUnavailable(appGroup: appGroup)
         }
 
         return fileContainer.appendingPathComponent("\(databaseName).sqlite")

--- a/MindboxLogger/Shared/Extensions/FileManager+Extensions.swift
+++ b/MindboxLogger/Shared/Extensions/FileManager+Extensions.swift
@@ -23,7 +23,7 @@ extension FileManager {
             case .containerUnavailable(let appGroup):
                 return "App Group container '\(appGroup)' is unavailable. "
                     + "Set up your AppGroup correctly — it must be the same for all your targets. "
-                    + "Read the documentation: developers.mindbox.ru/docs/ios-sdk-initialization"
+                    + "Read the documentation: https://developers.mindbox.ru/docs/ios-sdk-initialization"
             }
         }
     }

--- a/MindboxLogger/Shared/Extensions/MBLoggerUtilitiesFetcher.swift
+++ b/MindboxLogger/Shared/Extensions/MBLoggerUtilitiesFetcher.swift
@@ -16,19 +16,23 @@ class MBLoggerUtilitiesFetcher {
         return bundle
     }()
 
-    var applicationGroupIdentifier: String {
+    /// Identifier of the shared App Group container the logger persists its
+    /// database in, or `nil` when no shared container is available.
+    ///
+    /// Returns `nil` when the host bundle identifier is missing or the App Group
+    /// container is unavailable (a missing, misconfigured, or unprovisioned capability).
+    /// A `nil` identifier makes `LoggerDatabaseLoader` fall back to the app's local
+    /// (caches) store, so
+    /// the logger keeps working — just not in the shared container — instead of
+    /// being disabled. This must never `fatalError`: the SDK must not bring down
+    /// its host over an unavailable container, on simulator or device (issue #705).
+    var applicationGroupIdentifier: String? {
         guard let hostApplicationName = hostApplicationName else {
-            fatalError("CFBundleShortVersionString not found for host app")
+            return nil
         }
         let identifier = "group.cloud.Mindbox.\(hostApplicationName)"
-        let url = FileManager.default.containerURL(forSecurityApplicationGroupIdentifier: identifier)
-        guard url != nil else {
-            #if targetEnvironment(simulator)
-            return ""
-            #else
-            let message = "AppGroup for \(hostApplicationName) not found. Add AppGroup with value: \(identifier)"
-            fatalError(message)
-            #endif
+        guard FileManager.default.containerURL(forSecurityApplicationGroupIdentifier: identifier) != nil else {
+            return nil
         }
 
         return identifier

--- a/MindboxLogger/Shared/Extensions/MBLoggerUtilitiesFetcher.swift
+++ b/MindboxLogger/Shared/Extensions/MBLoggerUtilitiesFetcher.swift
@@ -16,16 +16,12 @@ class MBLoggerUtilitiesFetcher {
         return bundle
     }()
 
-    /// Identifier of the shared App Group container the logger persists its
-    /// database in, or `nil` when no shared container is available.
+    /// Identifier of the shared App Group container the logger persists its database in,
+    /// or `nil` when none is available (missing/misconfigured/unprovisioned capability).
     ///
-    /// Returns `nil` when the host bundle identifier is missing or the App Group
-    /// container is unavailable (a missing, misconfigured, or unprovisioned capability).
-    /// A `nil` identifier makes `LoggerDatabaseLoader` fall back to the app's local
-    /// (caches) store, so
-    /// the logger keeps working — just not in the shared container — instead of
-    /// being disabled. This must never `fatalError`: the SDK must not bring down
-    /// its host over an unavailable container, on simulator or device (issue #705).
+    /// `nil` makes `LoggerDatabaseLoader` fall back to the app's local caches store, so the
+    /// logger keeps working instead of being disabled. Must never trap — the SDK must not
+    /// bring down its host over an unavailable container, on simulator or device (issue #705).
     var applicationGroupIdentifier: String? {
         guard let hostApplicationName = hostApplicationName else {
             return nil

--- a/MindboxLogger/Shared/LoggerRepository/LoggerDatabaseLoader.swift
+++ b/MindboxLogger/Shared/LoggerRepository/LoggerDatabaseLoader.swift
@@ -174,7 +174,7 @@ final class LoggerDatabaseLoader: LoggerDatabaseLoading {
             return explicitURL
         }
         if let applicationGroupId = configuration.applicationGroupId {
-            return FileManager.storeURL(for: applicationGroupId, databaseName: configuration.modelName)
+            return try FileManager.storeURL(for: applicationGroupId, databaseName: configuration.modelName)
         }
         let cachesDirectory = try FileManager.default.url(
             for: .cachesDirectory,

--- a/MindboxLoggerTests/FileManagerStoreURLTests.swift
+++ b/MindboxLoggerTests/FileManagerStoreURLTests.swift
@@ -1,0 +1,71 @@
+//
+//  FileManagerStoreURLTests.swift
+//  MindboxLoggerTests
+//
+//  Copyright © 2026 Mindbox. All rights reserved.
+//
+
+import Testing
+import Foundation
+import CoreData
+@testable import MindboxLogger
+
+/// Regression coverage for App Group store-URL resolution (issue #705).
+///
+/// Previously `FileManager.storeURL(for:databaseName:)` called `fatalError` when
+/// the shared container was unavailable, which crashed the host straight through
+/// the logger's `do/catch`. Now:
+///  - `storeURL` *throws* for an unresolvable explicit group (defensive), and
+///  - when no App Group is available `MBLoggerUtilitiesFetcher` returns `nil`, so
+///    `LoggerDatabaseLoader` falls back to the app's local (caches) store and the
+///    logger keeps working — just not in the shared container — instead of
+///    crashing or disabling.
+///
+/// Note on the empty-string trigger: on the iOS Simulator
+/// `containerURL(forSecurityApplicationGroupIdentifier:)` vends a container for any
+/// *non-empty* identifier, so only the empty string deterministically yields a
+/// `nil` container in a unit test.
+@Suite("FileManager.storeURL App Group resolution")
+struct FileManagerStoreURLTests {
+
+    @Test("storeURL throws .containerUnavailable instead of crashing when the container is unavailable")
+    func throwsWhenContainerUnavailable() {
+        #expect(throws: FileManager.StoreURLError.containerUnavailable(appGroup: "")) {
+            try FileManager.storeURL(for: "", databaseName: "CDLogMessage")
+        }
+    }
+
+    @Test("Thrown error carries a localized, actionable description naming the group")
+    func errorDescriptionNamesTheGroup() throws {
+        let group = "group.cloud.Mindbox.NonExistent.AppGroup.For.Repro"
+        let error = FileManager.StoreURLError.containerUnavailable(appGroup: group)
+
+        let description = try #require(error.errorDescription)
+        #expect(description.contains(group))
+        #expect(description.localizedCaseInsensitiveContains("unavailable"))
+    }
+
+    @Test("Loader falls back to local storage and stays enabled when no App Group is available")
+    func loaderFallsBackToLocalStorageWhenNoAppGroup() throws {
+        // Production path when MBLoggerUtilitiesFetcher reports no shared container
+        // (returns nil): the loader must resolve a local store and keep the logger
+        // working — not throw, not disable.
+        let config = LoggerDatabaseLoaderConfig(
+            modelName: "CDLogMessage",
+            applicationGroupId: nil,
+            storeURL: nil,
+            descriptions: nil
+        )
+        let loader = LoggerDatabaseLoader(config)
+        defer { try? loader.destroyIfExists() }
+
+        let (container, _) = try loader.loadContainer()
+
+        let stores = container.persistentStoreCoordinator.persistentStores
+        #expect(!stores.isEmpty)
+
+        let storeURL = try #require(stores.first?.url)
+        #expect(storeURL.lastPathComponent == "CDLogMessage.sqlite")
+        #expect(storeURL.path.contains("Caches"))
+    }
+}

--- a/MindboxLoggerTests/MBLoggerUtilitiesFetcherTests.swift
+++ b/MindboxLoggerTests/MBLoggerUtilitiesFetcherTests.swift
@@ -1,0 +1,28 @@
+//
+//  MBLoggerUtilitiesFetcherTests.swift
+//  MindboxLoggerTests
+//
+//  Copyright © 2026 Mindbox. All rights reserved.
+//
+
+import Testing
+import Foundation
+@testable import MindboxLogger
+
+/// Regression coverage for issue #705: `MBLoggerUtilitiesFetcher.applicationGroupIdentifier`
+/// must NEVER trap. It used to `fatalError` when the shared container was unavailable; it now
+/// returns `nil` so `LoggerDatabaseLoader` falls back to the app's local store.
+@Suite("MBLoggerUtilitiesFetcher App Group resolution")
+struct MBLoggerUtilitiesFetcherTests {
+
+    /// #705 core invariant: the getter must resolve WITHOUT trapping. It used to `fatalError`
+    /// when the shared container was unavailable; a `fatalError` would tear down the test
+    /// runner, so this test reaching its assertion at all proves the trap is gone.
+    @Test
+    func resolvesWithoutTrapping() {
+        let id = MBLoggerUtilitiesFetcher().applicationGroupIdentifier
+        if let id {
+            #expect(id.hasPrefix("group.cloud.Mindbox."))
+        }
+    }
+}

--- a/MindboxTests/DI/AppGroupUnavailableTests.swift
+++ b/MindboxTests/DI/AppGroupUnavailableTests.swift
@@ -52,7 +52,14 @@ struct AppGroupUnavailableTests {
     /// fetcher reporting `""`.
     @Test
     func persistenceStorageFallsBackToStandardWhenAppGroupEmpty() {
-        defer { MBInject.mode = .standard }
+        // `buildTestContainer` and `mode` are global; restore both so this minimal
+        // container can't leak into later `.test`-mode tests that expect the full stub builder.
+        let savedBuilder = MBInject.buildTestContainer
+        let savedMode = MBInject.mode
+        defer {
+            MBInject.buildTestContainer = savedBuilder
+            MBInject.mode = savedMode
+        }
 
         MBInject.buildTestContainer = {
             let container = MBContainer()

--- a/MindboxTests/DI/AppGroupUnavailableTests.swift
+++ b/MindboxTests/DI/AppGroupUnavailableTests.swift
@@ -11,21 +11,13 @@ import CoreData
 import MindboxLogger
 @testable import Mindbox
 
-/// Regression coverage for issue #705 on the **core SDK** path: when the App Group
-/// container is unavailable the SDK must degrade to local storage instead of crashing
-/// the host — in Debug and Release alike. Covers the previously-untested fallback branches:
-///  - `MBUtilitiesFetcher.applicationGroupIdentifier` resolves without trapping (it used to
-///    `fatalError` on an unavailable container),
-///  - the DI `PersistenceStorage` factory falls back to `UserDefaults.standard` on an empty group, and
-///  - the events store's `MBPersistentContainer` resolves to the app-local directory on an empty group.
-///
-/// Serialized because the cases mutate global state (`MBInject`, `MBPersistenceStorage.defaults`,
-/// `MBPersistentContainer.applicationGroupIdentifier`).
+/// Regression coverage for issue #705 on the core SDK path: when the App Group container is
+/// unavailable the SDK must degrade to local storage, not crash the host. Serialized — the cases
+/// mutate global `MBInject` / `MBPersistenceStorage.defaults` / `MBPersistentContainer`.
 @Suite("App Group unavailable — core SDK fallback", .serialized)
 struct AppGroupUnavailableTests {
 
-    /// Stub fetcher reporting an unavailable App Group (empty identifier). Lets the DI fallback
-    /// be driven deterministically, independent of the simulator's container behavior.
+    /// Stub fetcher reporting an unavailable App Group (`""`), independent of the simulator's containers.
     private struct EmptyAppGroupUtilitiesFetcher: UtilitiesFetcher {
         var appVerson: String? { "1.0.0" }
         var sdkVersion: String? { "test" }
@@ -34,28 +26,19 @@ struct AppGroupUnavailableTests {
         func getDeviceUUID(completion: @escaping (String) -> Void) { completion(UUID().uuidString) }
     }
 
-    // MARK: - The core fetcher no longer traps (issue #705 device crash site)
-
-    /// #705 core invariant: the getter must resolve WITHOUT trapping. It used to `fatalError`
-    /// on an unavailable container; a `fatalError` would tear down the runner, so reaching the
-    /// assertion at all proves the trap is gone.
+    /// #705: the getter used to `fatalError` on an unavailable container — a trap would tear down
+    /// the runner, so simply reaching the assertion proves it's gone.
     @Test
     func coreFetcherResolvesWithoutTrapping() {
         let id = MBUtilitiesFetcher().applicationGroupIdentifier
         #expect(id.isEmpty || id.hasPrefix("group.cloud.Mindbox."))
     }
 
-    // MARK: - DI falls back to UserDefaults.standard on an empty App Group
-
-    /// With an empty App Group the `PersistenceStorage` DI factory must back the storage with
-    /// `UserDefaults.standard` — not crash, not a nil suite. Drives the real factory with a stub
-    /// fetcher reporting `""`.
+    /// Empty App Group → the DI factory must back storage with `UserDefaults.standard`, not crash.
     @Test
     func persistenceStorageFallsBackToStandardWhenAppGroupEmpty() {
-        // `buildTestContainer` and `mode` are global; restore both so this minimal container
-        // can't leak into later `.test`-mode tests that expect the full stub builder.
-        // `MBPersistenceStorage(defaults:)` also writes the static `MBPersistenceStorage.defaults`,
-        // so save/restore that too.
+        // All three are global (and `MBPersistenceStorage(defaults:)` writes the static `.defaults`);
+        // save/restore so this minimal container can't leak into later `.test`-mode tests.
         let savedBuilder = MBInject.buildTestContainer
         let savedMode = MBInject.mode
         let savedDefaults = MBPersistenceStorage.defaults
@@ -77,12 +60,8 @@ struct AppGroupUnavailableTests {
         #expect(MBPersistenceStorage.defaults === UserDefaults.standard)
     }
 
-    // MARK: - Events Core Data store falls back to a local directory on an empty App Group
-
-    /// The events store's container must resolve to the app-local default directory — not a
-    /// shared container — when the App Group is unavailable, so events keep persisting locally
-    /// instead of crashing. The core fetcher reports `""` in that case, and `containerURL("")`
-    /// is nil, so `defaultDirectoryURL()` must fall through to `super`'s app-local directory.
+    /// Empty App Group → `containerURL("")` is nil, so the events store's `defaultDirectoryURL()`
+    /// must fall through to `super`'s app-local directory rather than crash.
     @Test
     func eventsStoreFallsBackToLocalDirectoryWhenAppGroupEmpty() {
         let saved = MBPersistentContainer.applicationGroupIdentifier
@@ -93,8 +72,7 @@ struct AppGroupUnavailableTests {
     }
 }
 
-/// Coverage for the storage-transition reporter (issue #705 follow-up): it reports only when
-/// install state is in BOTH stores and is read-only. Uses isolated per-case `UserDefaults`.
+/// Storage-transition reporter (#705 follow-up): reports only when install state is in BOTH stores; read-only.
 @Suite("App Group storage-transition reporter")
 struct AppGroupStorageTransitionReporterTests {
 
@@ -127,11 +105,9 @@ struct AppGroupStorageTransitionReporterTests {
         let reporter = AppGroupStorageTransitionReporter(activeDefaults: activeStore, localDefaults: localStore)
 
         #expect(reporter.reportIfNeeded() == expectReport)
-        // Read-only: neither store is modified, regardless of whether we reported.
-        #expect(MBPersistenceStorage.isInstalled(in: localStore) == local)
+        #expect(MBPersistenceStorage.isInstalled(in: localStore) == local)   // read-only: stores unchanged
         #expect(MBPersistenceStorage.isInstalled(in: activeStore) == active)
-        // Not one-shot: while the fingerprint persists it reports again on the next call.
-        #expect(reporter.reportIfNeeded() == expectReport)
+        #expect(reporter.reportIfNeeded() == expectReport)                   // not one-shot: re-fires while the fingerprint persists
     }
 
     @Test("No report in local fallback (App Group unavailable → active store IS the local store)")
@@ -140,7 +116,6 @@ struct AppGroupStorageTransitionReporterTests {
         let store = makeStore(name, installed: true)
         defer { store.removePersistentDomain(forName: name) }
 
-        // In fallback the active store and the local store are the same instance.
         let didReport = AppGroupStorageTransitionReporter(activeDefaults: store, localDefaults: store)
             .reportIfNeeded()
 
@@ -148,30 +123,26 @@ struct AppGroupStorageTransitionReporterTests {
         #expect(MBPersistenceStorage.isInstalled(in: store) == true)
     }
 
-    /// Production-fidelity guard for the reporter's core assumption (issue #705 review): a real App
-    /// Group suite must NOT read through to `.standard`'s domain. If it did, `isInstalled(in: suite)`
-    /// would be true whenever `.standard` holds the marker, collapsing the "in BOTH stores" check and
-    /// firing on the recovery launch regardless of re-registration. Confirmed on a real device
-    /// (re-registration runs ⇒ the suite didn't see `.standard`'s marker) and locked in here — the
-    /// test runner, unlike a command-line process, has a real bundle id, so the search lists are real.
+    /// The reporter assumes a real App Group suite does NOT read through to `.standard`; if it did,
+    /// `isInstalled(in: suite)` would be true whenever `.standard` holds the marker and it would
+    /// mis-fire. Verified on device; locked here (the runner has a real bundle id → real search lists).
     @Test("A real App Group suite does not read through to .standard's install marker")
     func suiteDoesNotReadThroughToStandard() {
         let key = MBPersistenceStorage.installationDataKey
         let group = "group.cloud.Mindbox.ReadThroughProbe"
         let suite = UserDefaults(suiteName: group)!
 
-        // Save/restore `.standard`'s real value so this can't pollute the (serialized) run.
-        let savedStandard = UserDefaults.standard.object(forKey: key)
+        let savedStandard = UserDefaults.standard.object(forKey: key)   // save/restore: don't pollute the run
         defer {
             if let savedStandard { UserDefaults.standard.set(savedStandard, forKey: key) }
             else { UserDefaults.standard.removeObject(forKey: key) }
             suite.removePersistentDomain(forName: group)
         }
 
-        suite.removePersistentDomain(forName: group)                  // suite's own domain empty
-        UserDefaults.standard.set("23.05.2026 10:00:00", forKey: key) // marker only in .standard
+        suite.removePersistentDomain(forName: group)                   // suite's own domain empty
+        UserDefaults.standard.set("23.05.2026 10:00:00", forKey: key)  // marker only in .standard
 
         #expect(MBPersistenceStorage.isInstalled(in: .standard) == true)
-        #expect(MBPersistenceStorage.isInstalled(in: suite) == false) // no read-through
+        #expect(MBPersistenceStorage.isInstalled(in: suite) == false)
     }
 }

--- a/MindboxTests/DI/AppGroupUnavailableTests.swift
+++ b/MindboxTests/DI/AppGroupUnavailableTests.swift
@@ -11,9 +11,8 @@ import CoreData
 import MindboxLogger
 @testable import Mindbox
 
-/// Regression coverage for issue #705 on the core SDK path: when the App Group container is
-/// unavailable the SDK must degrade to local storage, not crash the host. Serialized — the cases
-/// mutate global `MBInject` / `MBPersistenceStorage.defaults` / `MBPersistentContainer`.
+/// #705 core-SDK fallback: an unavailable App Group must degrade to local storage, not crash.
+/// Serialized — the cases mutate global `MBInject` / `MBPersistenceStorage.defaults` / `MBPersistentContainer`.
 @Suite("App Group unavailable — core SDK fallback", .serialized)
 struct AppGroupUnavailableTests {
 
@@ -34,7 +33,6 @@ struct AppGroupUnavailableTests {
         #expect(id.isEmpty || id.hasPrefix("group.cloud.Mindbox."))
     }
 
-    /// Empty App Group → the DI factory must back storage with `UserDefaults.standard`, not crash.
     @Test
     func persistenceStorageFallsBackToStandardWhenAppGroupEmpty() {
         // All three are global (and `MBPersistenceStorage(defaults:)` writes the static `.defaults`);
@@ -60,14 +58,15 @@ struct AppGroupUnavailableTests {
         #expect(MBPersistenceStorage.defaults === UserDefaults.standard)
     }
 
-    /// Empty App Group → `containerURL("")` is nil, so the events store's `defaultDirectoryURL()`
-    /// must fall through to `super`'s app-local directory rather than crash.
-    @Test
-    func eventsStoreFallsBackToLocalDirectoryWhenAppGroupEmpty() {
+    /// Unavailable App Group (nil id from the logger path, "" from the core fetcher) → the events
+    /// store's directory must fall through to the app-local default rather than crash. Covers both
+    /// `MBPersistentContainer.defaultDirectoryURL()` fallbacks: the nil guard and `containerURL("") ?? super`.
+    @Test(arguments: [nil, ""] as [String?])
+    func eventsStoreFallsBackToLocalDirectory(groupId: String?) {
         let saved = MBPersistentContainer.applicationGroupIdentifier
         defer { MBPersistentContainer.applicationGroupIdentifier = saved }
 
-        MBPersistentContainer.applicationGroupIdentifier = ""
+        MBPersistentContainer.applicationGroupIdentifier = groupId
         #expect(MBPersistentContainer.defaultDirectoryURL() == NSPersistentContainer.defaultDirectoryURL())
     }
 }
@@ -123,23 +122,24 @@ struct AppGroupStorageTransitionReporterTests {
         #expect(MBPersistenceStorage.isInstalled(in: store) == true)
     }
 
-    /// The reporter assumes a real App Group suite does NOT read through to `.standard`; if it did,
+    /// The reporter relies on the App Group suite NOT reading through to `.standard`; otherwise
     /// `isInstalled(in: suite)` would be true whenever `.standard` holds the marker and it would
-    /// mis-fire. Verified on device; locked here (the runner has a real bundle id → real search lists).
-    @Test("A real App Group suite does not read through to .standard's install marker")
+    /// mis-fire. A separately-registered suite is its own read domain, so this holds — the real
+    /// provisioned-App-Group case was confirmed on device; the runner exercises the same isolation.
+    @Test("A separate UserDefaults suite does not read through to .standard's install marker")
     func suiteDoesNotReadThroughToStandard() {
         let key = MBPersistenceStorage.installationDataKey
         let group = "group.cloud.Mindbox.ReadThroughProbe"
         let suite = UserDefaults(suiteName: group)!
 
-        let savedStandard = UserDefaults.standard.object(forKey: key)   // save/restore: don't pollute the run
+        let savedStandard = UserDefaults.standard.object(forKey: key)
         defer {
             if let savedStandard { UserDefaults.standard.set(savedStandard, forKey: key) }
             else { UserDefaults.standard.removeObject(forKey: key) }
             suite.removePersistentDomain(forName: group)
         }
 
-        suite.removePersistentDomain(forName: group)                   // suite's own domain empty
+        suite.removePersistentDomain(forName: group)
         UserDefaults.standard.set("23.05.2026 10:00:00", forKey: key)  // marker only in .standard
 
         #expect(MBPersistenceStorage.isInstalled(in: .standard) == true)

--- a/MindboxTests/DI/AppGroupUnavailableTests.swift
+++ b/MindboxTests/DI/AppGroupUnavailableTests.swift
@@ -1,0 +1,139 @@
+//
+//  AppGroupUnavailableTests.swift
+//  MindboxTests
+//
+//  Copyright © 2026 Mindbox. All rights reserved.
+//
+
+import Testing
+import Foundation
+import CoreData
+import MindboxLogger
+@testable import Mindbox
+
+/// Regression coverage for issue #705 on the **core SDK** path: when the App Group
+/// container is unavailable the SDK must degrade to local storage instead of crashing
+/// the host — in Debug and Release alike. Covers the previously-untested fallback branches:
+///  - `MBUtilitiesFetcher.applicationGroupIdentifier` resolves without trapping (it used to
+///    `fatalError` on an unavailable container),
+///  - the DI `PersistenceStorage` factory falls back to `UserDefaults.standard` on an empty group, and
+///  - the events store's `MBPersistentContainer` resolves to the app-local directory on an empty group.
+///
+/// Serialized because the cases mutate global state (`MBInject`, `MBPersistenceStorage.defaults`,
+/// `MBPersistentContainer.applicationGroupIdentifier`).
+@Suite("App Group unavailable — core SDK fallback", .serialized)
+struct AppGroupUnavailableTests {
+
+    /// Stub fetcher reporting an unavailable App Group (empty identifier). Lets the DI fallback
+    /// be driven deterministically, independent of the simulator's container behavior.
+    private struct EmptyAppGroupUtilitiesFetcher: UtilitiesFetcher {
+        var appVerson: String? { "1.0.0" }
+        var sdkVersion: String? { "test" }
+        var hostApplicationName: String? { "cloud.Mindbox.MindboxTests" }
+        var applicationGroupIdentifier: String { "" }
+        func getDeviceUUID(completion: @escaping (String) -> Void) { completion(UUID().uuidString) }
+    }
+
+    // MARK: - The core fetcher no longer traps (issue #705 device crash site)
+
+    /// #705 core invariant: the getter must resolve WITHOUT trapping. It used to `fatalError`
+    /// on an unavailable container; a `fatalError` would tear down the runner, so reaching the
+    /// assertion at all proves the trap is gone.
+    @Test
+    func coreFetcherResolvesWithoutTrapping() {
+        let id = MBUtilitiesFetcher().applicationGroupIdentifier
+        #expect(id.isEmpty || id.hasPrefix("group.cloud.Mindbox."))
+    }
+
+    // MARK: - DI falls back to UserDefaults.standard on an empty App Group
+
+    /// With an empty App Group the `PersistenceStorage` DI factory must back the storage with
+    /// `UserDefaults.standard` — not crash, not a nil suite. Drives the real factory with a stub
+    /// fetcher reporting `""`.
+    @Test
+    func persistenceStorageFallsBackToStandardWhenAppGroupEmpty() {
+        defer { MBInject.mode = .standard }
+
+        MBInject.buildTestContainer = {
+            let container = MBContainer()
+            container.register(UtilitiesFetcher.self) { EmptyAppGroupUtilitiesFetcher() }
+            return container.registerReplaceableUtilities()
+        }
+        MBInject.mode = .test
+
+        let storage = DI.injectOrFail(PersistenceStorage.self)
+        #expect(storage is MBPersistenceStorage)
+        #expect(MBPersistenceStorage.defaults === UserDefaults.standard)
+    }
+
+    // MARK: - Events Core Data store falls back to a local directory on an empty App Group
+
+    /// The events store's container must resolve to the app-local default directory — not a
+    /// shared container — when the App Group is unavailable, so events keep persisting locally
+    /// instead of crashing. The core fetcher reports `""` in that case, and `containerURL("")`
+    /// is nil, so `defaultDirectoryURL()` must fall through to `super`'s app-local directory.
+    @Test
+    func eventsStoreFallsBackToLocalDirectoryWhenAppGroupEmpty() {
+        let saved = MBPersistentContainer.applicationGroupIdentifier
+        defer { MBPersistentContainer.applicationGroupIdentifier = saved }
+
+        MBPersistentContainer.applicationGroupIdentifier = ""
+        #expect(MBPersistentContainer.defaultDirectoryURL() == NSPersistentContainer.defaultDirectoryURL())
+    }
+}
+
+/// Coverage for the storage-transition reporter (issue #705 follow-up): it reports only when
+/// install state is in BOTH stores and is read-only. Uses isolated per-case `UserDefaults`.
+@Suite("App Group storage-transition reporter")
+struct AppGroupStorageTransitionReporterTests {
+
+    private func makeStore(_ name: String, installed: Bool) -> UserDefaults {
+        let defaults = UserDefaults(suiteName: name)!
+        defaults.removePersistentDomain(forName: name)
+        if installed {
+            defaults.set("23.05.2026 10:00:00", forKey: MBPersistenceStorage.installationDataKey)
+        }
+        return defaults
+    }
+
+    @Test("Reports only when install state is in BOTH stores, and never mutates either store",
+          arguments: [
+            (active: true,  local: true,  expectReport: true),
+            (active: false, local: true,  expectReport: false),
+            (active: true,  local: false, expectReport: false),
+            (active: false, local: false, expectReport: false),
+          ])
+    func reportsOnlyWhenInstalledInBothStores(active: Bool, local: Bool, expectReport: Bool) {
+        let activeName = "test.appgroup.active.\(active).\(local)"
+        let localName = "test.appgroup.local.\(active).\(local)"
+        let activeStore = makeStore(activeName, installed: active)
+        let localStore = makeStore(localName, installed: local)
+        defer {
+            activeStore.removePersistentDomain(forName: activeName)
+            localStore.removePersistentDomain(forName: localName)
+        }
+
+        let reporter = AppGroupStorageTransitionReporter(activeDefaults: activeStore, localDefaults: localStore)
+
+        #expect(reporter.reportIfNeeded() == expectReport)
+        // Read-only: neither store is modified, regardless of whether we reported.
+        #expect(MBPersistenceStorage.isInstalled(in: localStore) == local)
+        #expect(MBPersistenceStorage.isInstalled(in: activeStore) == active)
+        // Not one-shot: while the fingerprint persists it reports again on the next call.
+        #expect(reporter.reportIfNeeded() == expectReport)
+    }
+
+    @Test("No report in local fallback (App Group unavailable → active store IS the local store)")
+    func noReportInFallback() {
+        let name = "test.appgroup.fallback"
+        let store = makeStore(name, installed: true)
+        defer { store.removePersistentDomain(forName: name) }
+
+        // In fallback the active store and the local store are the same instance.
+        let didReport = AppGroupStorageTransitionReporter(activeDefaults: store, localDefaults: store)
+            .reportIfNeeded()
+
+        #expect(didReport == false)
+        #expect(MBPersistenceStorage.isInstalled(in: store) == true)
+    }
+}

--- a/MindboxTests/DI/AppGroupUnavailableTests.swift
+++ b/MindboxTests/DI/AppGroupUnavailableTests.swift
@@ -52,13 +52,17 @@ struct AppGroupUnavailableTests {
     /// fetcher reporting `""`.
     @Test
     func persistenceStorageFallsBackToStandardWhenAppGroupEmpty() {
-        // `buildTestContainer` and `mode` are global; restore both so this minimal
-        // container can't leak into later `.test`-mode tests that expect the full stub builder.
+        // `buildTestContainer` and `mode` are global; restore both so this minimal container
+        // can't leak into later `.test`-mode tests that expect the full stub builder.
+        // `MBPersistenceStorage(defaults:)` also writes the static `MBPersistenceStorage.defaults`,
+        // so save/restore that too.
         let savedBuilder = MBInject.buildTestContainer
         let savedMode = MBInject.mode
+        let savedDefaults = MBPersistenceStorage.defaults
         defer {
             MBInject.buildTestContainer = savedBuilder
             MBInject.mode = savedMode
+            MBPersistenceStorage.defaults = savedDefaults
         }
 
         MBInject.buildTestContainer = {
@@ -142,5 +146,32 @@ struct AppGroupStorageTransitionReporterTests {
 
         #expect(didReport == false)
         #expect(MBPersistenceStorage.isInstalled(in: store) == true)
+    }
+
+    /// Production-fidelity guard for the reporter's core assumption (issue #705 review): a real App
+    /// Group suite must NOT read through to `.standard`'s domain. If it did, `isInstalled(in: suite)`
+    /// would be true whenever `.standard` holds the marker, collapsing the "in BOTH stores" check and
+    /// firing on the recovery launch regardless of re-registration. Confirmed on a real device
+    /// (re-registration runs ⇒ the suite didn't see `.standard`'s marker) and locked in here — the
+    /// test runner, unlike a command-line process, has a real bundle id, so the search lists are real.
+    @Test("A real App Group suite does not read through to .standard's install marker")
+    func suiteDoesNotReadThroughToStandard() {
+        let key = MBPersistenceStorage.installationDataKey
+        let group = "group.cloud.Mindbox.ReadThroughProbe"
+        let suite = UserDefaults(suiteName: group)!
+
+        // Save/restore `.standard`'s real value so this can't pollute the (serialized) run.
+        let savedStandard = UserDefaults.standard.object(forKey: key)
+        defer {
+            if let savedStandard { UserDefaults.standard.set(savedStandard, forKey: key) }
+            else { UserDefaults.standard.removeObject(forKey: key) }
+            suite.removePersistentDomain(forName: group)
+        }
+
+        suite.removePersistentDomain(forName: group)                  // suite's own domain empty
+        UserDefaults.standard.set("23.05.2026 10:00:00", forKey: key) // marker only in .standard
+
+        #expect(MBPersistenceStorage.isInstalled(in: .standard) == true)
+        #expect(MBPersistenceStorage.isInstalled(in: suite) == false) // no read-through
     }
 }


### PR DESCRIPTION
[Issue](https://tracker.yandex.ru/MOBILE-187)

The SDK no longer crashes the host app when the App Group container is unavailable (missing/misconfigured/unprovisioned capability): every fatalError/assertionFailure on that path (core fetcher, DI persistence factory, logger store, Example) now degrades to local storage and surfaces a .fault log instead. Adds a read-only diagnostic that logs when it detects a fallback→App-Group re-registration (install state in both stores), plus regression tests for all the fallback branches. Verified end-to-end on a real iPhone 12 — no crash through the full broken→fixed lifecycle.