### PR TITLE
MOBILE-230: Fix sync operation error delivery and date-migration hour cycle

### DIFF
--- a/Mindbox/Mindbox.swift
+++ b/Mindbox/Mindbox.swift
@@ -423,8 +423,8 @@ public class Mindbox: NSObject {
 
     /// Off-main tail of the executeSyncOperation overloads: build the sync event on
     /// eventQueue and hand it to EventRepository, which delivers `completion` on main.
-    /// Invalid JSON drops the operation without invoking `completion` - long-standing
-    /// behavior, fix ticketed. The repository is resolved at call time on purpose.
+    /// Invalid JSON fails the operation with a `.parsing` error delivered on main, so the
+    /// completion contract holds on every path. The repository is resolved at call time on purpose.
     private func enqueueSyncEvent<P: OperationResponseType>(
         operationSystemName: String,
         payloadJSON: String,
@@ -435,6 +435,9 @@ public class Mindbox: NSObject {
         eventQueue.async { [self] in
             if validatePayloadAsJSON, !Self.isValidJSON(payloadJSON) {
                 Logger.common(message: "Operation body is not valid JSON", level: .error, category: .notification)
+                // Match the EventRepository contract: completion is always delivered, on main.
+                let error = MindboxError(.init(errorKey: .parsing, reason: "Operation body is not valid JSON"))
+                DispatchQueue.main.async { completion(.failure(error)) }
                 return
             }
             let customEvent = CustomEvent(name: operationSystemName, payload: payloadJSON)

--- a/Mindbox/Mindbox.swift
+++ b/Mindbox/Mindbox.swift
@@ -303,7 +303,10 @@ public class Mindbox: NSObject {
         operationBody: T,
         completion: @escaping (Result<OperationResponse, MindboxError>) -> Void
     ) where T: OperationBodyRequestType {
-        guard validateOperationName(operationSystemName) else { return }
+        guard validateOperationName(operationSystemName) else {
+            failSyncOperation(reason: "Invalid operation name: \(operationSystemName)", completion: completion)
+            return
+        }
         // Caller-side encode: same mutable-body snapshot contract as executeAsyncOperation.
         let operationBodyJSON = BodyEncoder(encodable: operationBody).body
         enqueueSyncEvent(operationSystemName: operationSystemName, payloadJSON: operationBodyJSON, completion: completion)
@@ -322,7 +325,10 @@ public class Mindbox: NSObject {
         json: String,
         completion: @escaping (Result<OperationResponse, MindboxError>) -> Void
     ) {
-        guard validateOperationName(operationSystemName) else { return }
+        guard validateOperationName(operationSystemName) else {
+            failSyncOperation(reason: "Invalid operation name: \(operationSystemName)", completion: completion)
+            return
+        }
         enqueueSyncEvent(operationSystemName: operationSystemName, payloadJSON: json, validatePayloadAsJSON: true, completion: completion)
     }
 
@@ -343,7 +349,10 @@ public class Mindbox: NSObject {
         customResponseType: P.Type,
         completion: @escaping (Result<P, MindboxError>) -> Void
     ) where T: OperationBodyRequestType, P: OperationResponseType {
-        guard validateOperationName(operationSystemName) else { return }
+        guard validateOperationName(operationSystemName) else {
+            failSyncOperation(reason: "Invalid operation name: \(operationSystemName)", completion: completion)
+            return
+        }
         // Caller-side encode: same mutable-body snapshot contract as executeAsyncOperation.
         let operationBodyJSON = BodyEncoder(encodable: operationBody).body
         enqueueSyncEvent(operationSystemName: operationSystemName, payloadJSON: operationBodyJSON, completion: completion)
@@ -396,6 +405,19 @@ public class Mindbox: NSObject {
         return true
     }
 
+    /// Delivers a `.validationError` failure on the main thread for sync operation overloads
+    /// that detect an invalid input before reaching the event queue.
+    private func failSyncOperation<P>(
+        reason: String,
+        completion: @escaping (Result<P, MindboxError>) -> Void
+    ) {
+        let error = MindboxError.validationError(ValidationError(
+            status: .validationError,
+            validationMessages: [ValidationMessage(message: reason, location: "operationSystemName")]
+        ))
+        DispatchQueue.main.async { completion(.failure(error)) }
+    }
+
     /// Off-main tail of the executeAsyncOperation overloads: build the event on eventQueue
     /// and persist it for guaranteed delivery. `payloadJSON` must be an immutable snapshot
     /// taken on the caller; host-provided JSON strings are validated here, off-main.
@@ -435,9 +457,7 @@ public class Mindbox: NSObject {
         eventQueue.async { [self] in
             if validatePayloadAsJSON, !Self.isValidJSON(payloadJSON) {
                 Logger.common(message: "Operation body is not valid JSON", level: .error, category: .notification)
-                // Match the EventRepository contract: completion is always delivered, on main.
-                let error = MindboxError(.init(errorKey: .parsing, reason: "Operation body is not valid JSON"))
-                DispatchQueue.main.async { completion(.failure(error)) }
+                self.failSyncOperation(reason: "Operation body is not valid JSON", completion: completion)
                 return
             }
             let customEvent = CustomEvent(name: operationSystemName, payload: payloadJSON)

--- a/Mindbox/Mindbox.swift
+++ b/Mindbox/Mindbox.swift
@@ -409,11 +409,12 @@ public class Mindbox: NSObject {
     /// that detect an invalid input before reaching the event queue.
     private func failSyncOperation<P>(
         reason: String,
+        location: String = "operationSystemName",
         completion: @escaping (Result<P, MindboxError>) -> Void
     ) {
         let error = MindboxError.validationError(ValidationError(
             status: .validationError,
-            validationMessages: [ValidationMessage(message: reason, location: "operationSystemName")]
+            validationMessages: [ValidationMessage(message: reason, location: location)]
         ))
         DispatchQueue.main.async { completion(.failure(error)) }
     }
@@ -445,7 +446,7 @@ public class Mindbox: NSObject {
 
     /// Off-main tail of the executeSyncOperation overloads: build the sync event on
     /// eventQueue and hand it to EventRepository, which delivers `completion` on main.
-    /// Invalid JSON fails the operation with a `.parsing` error delivered on main, so the
+    /// Invalid JSON fails the operation with a `.validationError` delivered on main, so the
     /// completion contract holds on every path. The repository is resolved at call time on purpose.
     private func enqueueSyncEvent<P: OperationResponseType>(
         operationSystemName: String,
@@ -457,7 +458,7 @@ public class Mindbox: NSObject {
         eventQueue.async { [self] in
             if validatePayloadAsJSON, !Self.isValidJSON(payloadJSON) {
                 Logger.common(message: "Operation body is not valid JSON", level: .error, category: .notification)
-                self.failSyncOperation(reason: "Operation body is not valid JSON", completion: completion)
+                self.failSyncOperation(reason: "Operation body is not valid JSON", location: "operationBody", completion: completion)
                 return
             }
             let customEvent = CustomEvent(name: operationSystemName, payload: payloadJSON)

--- a/Mindbox/Utilities/Migrations/ImplementationOfMigrations/DateFormatMigration.swift
+++ b/Mindbox/Utilities/Migrations/ImplementationOfMigrations/DateFormatMigration.swift
@@ -64,11 +64,27 @@ final class DateFormatMigration: MigrationProtocol {
         }
 
         let base = Locale.current.identifier
-        // Join the hour-cycle Unicode keyword with the correct separator: `@` for the first
-        // keyword, `;` if the current identifier already carries one (e.g. `@calendar=…`).
+        // Rebuild the identifier with the hour cycle forced. iOS encodes the device's 12h/24h
+        // setting straight into `Locale.current` as an `@hours=…` keyword, so naively appending a
+        // second `hours=` would produce a duplicate (`…@hours=h12;hours=h23`) that ICU resolves to
+        // the *first* occurrence — silently defeating the override and leaving every candidate on
+        // the device's own hour cycle. We therefore strip any pre-existing hour-cycle keyword
+        // (`hours`/`hc`) before adding ours, while preserving the rest (language, region, calendar…).
         func identifier(forcingHourCycle hourCycle: String) -> String {
-            let separator = base.contains("@") ? ";" : "@"
-            return base + separator + "hours=" + hourCycle
+            let parts = base.split(separator: "@", maxSplits: 1, omittingEmptySubsequences: false)
+            let languageAndRegion = String(parts[0])
+            var keywords: [(key: String, value: String)] = []
+            if parts.count == 2 {
+                for keyword in parts[1].split(separator: ";") {
+                    let pair = keyword.split(separator: "=", maxSplits: 1)
+                    guard pair.count == 2 else { continue }
+                    keywords.append((String(pair[0]), String(pair[1])))
+                }
+            }
+            keywords.removeAll { $0.key == "hours" || $0.key == "hc" }
+            keywords.append(("hours", hourCycle))
+            let keywordString = keywords.map { "\($0.key)=\($0.value)" }.joined(separator: ";")
+            return languageAndRegion + "@" + keywordString
         }
 
         return [

--- a/MindboxTests/MindboxOperationsTests.swift
+++ b/MindboxTests/MindboxOperationsTests.swift
@@ -196,41 +196,41 @@ struct MindboxOperationsTests {
         #expect(result?.isFailure == true)
     }
 
-    @Test("executeSyncOperation with invalid name delivers a .failure on the main thread")
-    func syncInvalidNameDeliversFailureOnMain() async {
+    @Test("executeSyncOperation with invalid name delivers a .validationError on the main thread")
+    func syncInvalidNameDeliversValidationErrorOnMain() async {
         // configuration is nil after reset() in init, but name validation fires before
         // enqueueSyncEvent is called — so the completion must arrive regardless.
-        let box = ResultBox<(onMain: Bool, isFailure: Bool)>()
+        let box = ResultBox<(onMain: Bool, isValidationError: Bool)>()
         Mindbox.shared.executeSyncOperation(operationSystemName: "плохое имя", json: "{}") { result in
-            if case .failure = result {
-                box.set((Thread.isMainThread, true))
+            if case .failure(.validationError(let error)) = result {
+                box.set((Thread.isMainThread, error.validationMessages.first?.location == "operationSystemName"))
             } else {
                 box.set((Thread.isMainThread, false))
             }
         }
         let result = await waitForValue(in: box)
         #expect(result?.onMain == true, "completion not delivered (nil) or delivered off main")
-        #expect(result?.isFailure == true, "invalid name must deliver a .failure, not a .success")
+        #expect(result?.isValidationError == true, "invalid name must deliver a .validationError located on operationSystemName")
     }
 
-    @Test("executeSyncOperation with invalid JSON delivers a .failure on the main thread")
-    func syncInvalidJSONDeliversFailureOnMain() async throws {
+    @Test("executeSyncOperation with invalid JSON delivers a .validationError on the main thread")
+    func syncInvalidJSONDeliversValidationErrorOnMain() async throws {
         // Configure the SDK so the only path to a failure is the invalid-JSON branch, not
         // the "Configuration is not set" early error. This pins the regression where invalid
         // JSON dropped the operation without ever invoking `completion`, hanging the caller.
         persistenceStorage.configuration = try MBConfiguration(endpoint: "test-endpoint", domain: "api.mindbox.ru")
         persistenceStorage.deviceUUID = "00000000-0000-0000-0000-000000000001"
 
-        let box = ResultBox<(onMain: Bool, isFailure: Bool)>()
+        let box = ResultBox<(onMain: Bool, isValidationError: Bool)>()
         Mindbox.shared.executeSyncOperation(operationSystemName: "Test.Sync", json: "not json at all") { result in
-            if case .failure = result {
-                box.set((Thread.isMainThread, true))
+            if case .failure(.validationError(let error)) = result {
+                box.set((Thread.isMainThread, error.validationMessages.first?.location == "operationBody"))
             } else {
                 box.set((Thread.isMainThread, false))
             }
         }
         let result = await waitForValue(in: box)
         #expect(result?.onMain == true, "completion not delivered (nil) or delivered off main")
-        #expect(result?.isFailure == true, "invalid JSON must deliver a .failure, not a .success")
+        #expect(result?.isValidationError == true, "invalid JSON must deliver a .validationError located on operationBody")
     }
 }

--- a/MindboxTests/MindboxOperationsTests.swift
+++ b/MindboxTests/MindboxOperationsTests.swift
@@ -195,4 +195,25 @@ struct MindboxOperationsTests {
         #expect(result?.onMain == true)
         #expect(result?.isFailure == true)
     }
+
+    @Test("executeSyncOperation with invalid JSON delivers a .failure on the main thread")
+    func syncInvalidJSONDeliversFailureOnMain() async throws {
+        // Configure the SDK so the only path to a failure is the invalid-JSON branch, not
+        // the "Configuration is not set" early error. This pins the regression where invalid
+        // JSON dropped the operation without ever invoking `completion`, hanging the caller.
+        persistenceStorage.configuration = try MBConfiguration(endpoint: "test-endpoint", domain: "api.mindbox.ru")
+        persistenceStorage.deviceUUID = "00000000-0000-0000-0000-000000000001"
+
+        let box = ResultBox<(onMain: Bool, isFailure: Bool)>()
+        Mindbox.shared.executeSyncOperation(operationSystemName: "Test.Sync", json: "not json at all") { result in
+            if case .failure = result {
+                box.set((Thread.isMainThread, true))
+            } else {
+                box.set((Thread.isMainThread, false))
+            }
+        }
+        let result = await waitForValue(in: box)
+        #expect(result?.onMain == true, "completion not delivered (nil) or delivered off main")
+        #expect(result?.isFailure == true, "invalid JSON must deliver a .failure, not a .success")
+    }
 }

--- a/MindboxTests/MindboxOperationsTests.swift
+++ b/MindboxTests/MindboxOperationsTests.swift
@@ -196,6 +196,23 @@ struct MindboxOperationsTests {
         #expect(result?.isFailure == true)
     }
 
+    @Test("executeSyncOperation with invalid name delivers a .failure on the main thread")
+    func syncInvalidNameDeliversFailureOnMain() async {
+        // configuration is nil after reset() in init, but name validation fires before
+        // enqueueSyncEvent is called — so the completion must arrive regardless.
+        let box = ResultBox<(onMain: Bool, isFailure: Bool)>()
+        Mindbox.shared.executeSyncOperation(operationSystemName: "плохое имя", json: "{}") { result in
+            if case .failure = result {
+                box.set((Thread.isMainThread, true))
+            } else {
+                box.set((Thread.isMainThread, false))
+            }
+        }
+        let result = await waitForValue(in: box)
+        #expect(result?.onMain == true, "completion not delivered (nil) or delivered off main")
+        #expect(result?.isFailure == true, "invalid name must deliver a .failure, not a .success")
+    }
+
     @Test("executeSyncOperation with invalid JSON delivers a .failure on the main thread")
     func syncInvalidJSONDeliversFailureOnMain() async throws {
         // Configure the SDK so the only path to a failure is the invalid-JSON branch, not


### PR DESCRIPTION
## Description

Three related MOBILE-230 fixes around sync operations and the date-format migration.

**Sync operations (`Mindbox.swift`)**
- `executeSyncOperation` no longer drops the completion handler when the operation body is invalid JSON — the caller now always gets a result.
- Invalid operation name / invalid JSON now consistently deliver `.validationError` across all sync overloads, instead of failing silently.

**Date-format migration (`DateFormatMigration.swift`)**
- Fixed the hour-cycle override when building legacy formatters. iOS encodes the device 12h/24h setting into `Locale.current` as an `@hours=` keyword, so appending a second `hours=` produced a duplicate (`…@hours=h12;hours=h23`) that ICU resolves to the *first* occurrence — silently defeating the override and leaving every candidate on the device's own hour cycle.
- Now any pre-existing `hours`/`hc` keyword is stripped before forcing the cycle (other keywords like language/region/calendar preserved), so legacy values written under the opposite hour cycle parse and migrate correctly.

## Type of Change
- Bug fix

## Test Procedure
- Added/extended `MindboxOperationsTests` for the sync-operation error paths.
- `DateFormatMigrationTests` (11 tests) — including the previously-failing `runConvertsLegacyInstallationDateWrittenIn24hFormat()` — now pass.
- Full suite green: **1055 / 1055** on iPhone 16 Pro (iOS 18.5).