### PR TITLE
MOBILE-213: Send in-app tags in tracking events and WebView operations

### DIFF
--- a/Mindbox.xcodeproj/project.pbxproj
+++ b/Mindbox.xcodeproj/project.pbxproj
@@ -668,6 +668,7 @@
 		FA39EE97042009DCEC24E971 /* InAppTagsGatingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 045EA348681AB859FB298A57 /* InAppTagsGatingTests.swift */; };
 		1E316CC518D9111F0BD25590 /* InAppMessagesTrackerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F60DC2E1435521EBF0E2C5E4 /* InAppMessagesTrackerTests.swift */; };
 		AB0E83C770AAB9A2DC8E9BF5 /* JSONValueTagsMergeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55E67F6257F15F143DEA87DE /* JSONValueTagsMergeTests.swift */; };
+		7A3F1B2C9D4E5F60718293A5 /* TransparentViewJSBridgeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A3F1B2C9D4E5F60718293A4 /* TransparentViewJSBridgeTests.swift */; };
 		F3CD20262F600A800065392A /* MBConfigurationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3CD20272F600A800065392A /* MBConfigurationTests.swift */; };
 		F3CD20292F600A800065392A /* HostNormalizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3CD202A2F600A800065392A /* HostNormalizer.swift */; };
 		F3CD202B2F600A800065392A /* HostNormalizerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3CD202C2F600A800065392A /* HostNormalizerTests.swift */; };
@@ -1405,6 +1406,7 @@
 		045EA348681AB859FB298A57 /* InAppTagsGatingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InAppTagsGatingTests.swift; sourceTree = "<group>"; };
 		F60DC2E1435521EBF0E2C5E4 /* InAppMessagesTrackerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InAppMessagesTrackerTests.swift; sourceTree = "<group>"; };
 		55E67F6257F15F143DEA87DE /* JSONValueTagsMergeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONValueTagsMergeTests.swift; sourceTree = "<group>"; };
+		7A3F1B2C9D4E5F60718293A4 /* TransparentViewJSBridgeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransparentViewJSBridgeTests.swift; sourceTree = "<group>"; };
 		F3CD20272F600A800065392A /* MBConfigurationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MBConfigurationTests.swift; sourceTree = "<group>"; };
 		F3CD202A2F600A800065392A /* HostNormalizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HostNormalizer.swift; sourceTree = "<group>"; };
 		F3CD202C2F600A800065392A /* HostNormalizerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HostNormalizerTests.swift; sourceTree = "<group>"; };
@@ -1518,6 +1520,7 @@
 			children = (
 				0CFCC82B8014DE7276C217CD /* WebViewLocalStateStorageTests.swift */,
 				55E67F6257F15F143DEA87DE /* JSONValueTagsMergeTests.swift */,
+				7A3F1B2C9D4E5F60718293A4 /* TransparentViewJSBridgeTests.swift */,
 				A1B2C3D400000006E1010101 /* BridgeMessagePermissionTests.swift */,
 				BD1BE43AA9EAEA03F8ED400C /* HapticRequestParserTests.swift */,
 				BD1BE43AA9EAEA03F8ED400D /* HapticRequestValidatorTests.swift */,
@@ -4709,6 +4712,7 @@
 				FA39EE97042009DCEC24E971 /* InAppTagsGatingTests.swift in Sources */,
 				1E316CC518D9111F0BD25590 /* InAppMessagesTrackerTests.swift in Sources */,
 				AB0E83C770AAB9A2DC8E9BF5 /* JSONValueTagsMergeTests.swift in Sources */,
+				7A3F1B2C9D4E5F60718293A5 /* TransparentViewJSBridgeTests.swift in Sources */,
 				D216DE512C0716B70020F58A /* StringExtensionsTests.swift in Sources */,
 				D216DE532C0716B80020F58A /* TimeIntervalTimeSpanTests.swift in Sources */,
 				A17958812978B3FA00609E91 /* InAppResponseModelTests.swift in Sources */,

--- a/Mindbox.xcodeproj/project.pbxproj
+++ b/Mindbox.xcodeproj/project.pbxproj
@@ -566,6 +566,7 @@
 		F351F1C02CE380A40053423E /* InappMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = F351F1BF2CE380A40053423E /* InappMapper.swift */; };
 		F351F1C22CE5F23A0053423E /* InappMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F351F1C12CE5F23A0053423E /* InappMapperTests.swift */; };
 		F351F1C42CE60CA90053423E /* 1-Targeting.json in Resources */ = {isa = PBXBuildFile; fileRef = F351F1C32CE60CA90053423E /* 1-Targeting.json */; };
+		7A3F1B2C9D4E5F60718293A7 /* Tags-FailedTargeting.json in Resources */ = {isa = PBXBuildFile; fileRef = 7A3F1B2C9D4E5F60718293A6 /* Tags-FailedTargeting.json */; };
 		F351F1C62CE626450053423E /* 15-Targeting.json in Resources */ = {isa = PBXBuildFile; fileRef = F351F1C52CE626450053423E /* 15-Targeting.json */; };
 		F351F1C82CE72B300053423E /* 44-Targeting.json in Resources */ = {isa = PBXBuildFile; fileRef = F351F1C72CE72B300053423E /* 44-Targeting.json */; };
 		F351F1CB2CE72D460053423E /* 46-Targeting.json in Resources */ = {isa = PBXBuildFile; fileRef = F351F1CA2CE72D460053423E /* 46-Targeting.json */; };
@@ -1304,6 +1305,7 @@
 		F351F1BF2CE380A40053423E /* InappMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InappMapper.swift; sourceTree = "<group>"; };
 		F351F1C12CE5F23A0053423E /* InappMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InappMapperTests.swift; sourceTree = "<group>"; };
 		F351F1C32CE60CA90053423E /* 1-Targeting.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "1-Targeting.json"; sourceTree = "<group>"; };
+		7A3F1B2C9D4E5F60718293A6 /* Tags-FailedTargeting.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "Tags-FailedTargeting.json"; sourceTree = "<group>"; };
 		F351F1C52CE626450053423E /* 15-Targeting.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "15-Targeting.json"; sourceTree = "<group>"; };
 		F351F1C72CE72B300053423E /* 44-Targeting.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "44-Targeting.json"; sourceTree = "<group>"; };
 		F351F1C92CE72D460053423E /* 45-Targeting.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "45-Targeting.json"; sourceTree = "<group>"; };
@@ -3098,6 +3100,7 @@
 			isa = PBXGroup;
 			children = (
 				F351F1C32CE60CA90053423E /* 1-Targeting.json */,
+				7A3F1B2C9D4E5F60718293A6 /* Tags-FailedTargeting.json */,
 				F31470882B96387C00E01E5C /* 3-4-5-TargetingRequests.json */,
 				F314708B2B96464900E01E5C /* 7-TargetingRequests.json */,
 				F314708D2B964BFF00E01E5C /* 8-TargetingRequests.json */,
@@ -4192,6 +4195,7 @@
 				F39117112AB4BD4500852298 /* missingBackgroundSection.json in Resources */,
 				F31470962B96681F00E01E5C /* 27-TargetingRequests.json in Resources */,
 				F351F1C42CE60CA90053423E /* 1-Targeting.json in Resources */,
+				7A3F1B2C9D4E5F60718293A7 /* Tags-FailedTargeting.json in Resources */,
 				31EB907425C402F900368FFB /* TestConfig2.plist in Resources */,
 				31EB907325C402F900368FFB /* TestConfig3.plist in Resources */,
 				F391170F2AB4B31800852298 /* unknownVariantType.json in Resources */,

--- a/Mindbox.xcodeproj/project.pbxproj
+++ b/Mindbox.xcodeproj/project.pbxproj
@@ -100,6 +100,7 @@
 		33E42E5C268323E60046CBCB /* CashdeskRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33E42E5B268323E60046CBCB /* CashdeskRequest.swift */; };
 		33EBF0B0264E6283002A35D5 /* MBSessionManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33EBF0AF264E6283002A35D5 /* MBSessionManager.swift */; };
 		3FB93AC126964AD3A061B4A7 /* FeatureToggleManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3456BAC56F984378B6CED7CB /* FeatureToggleManager.swift */; };
+		B202CDC049DDB7A2F9833ADF /* InAppTagsGating.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E8D4000B12B31961251F6C7 /* InAppTagsGating.swift */; };
 		472179A72C80755A00C15E7F /* ShownInAppsIDsMigration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 472179A62C80755A00C15E7F /* ShownInAppsIDsMigration.swift */; };
 		472765522E0D52A500A5A060 /* RemoveBackgroundTaskDataMigration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 472765512E0D52A500A5A060 /* RemoveBackgroundTaskDataMigration.swift */; };
 		472F549E2C6E272A0008C465 /* MBPushNotification.swift in Sources */ = {isa = PBXBuildFile; fileRef = 472F549D2C6E272A0008C465 /* MBPushNotification.swift */; };
@@ -555,6 +556,8 @@
 		F34A103D2F455B840065392A /* FeatureTogglesConfigParsingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F34A103A2F455B840065392A /* FeatureTogglesConfigParsingTests.swift */; };
 		F34A10442F455C5B0065392A /* SettingsFeatureTogglesShouldSendInAppShowErrorMissing.json in Resources */ = {isa = PBXBuildFile; fileRef = F34A10402F455C5B0065392A /* SettingsFeatureTogglesShouldSendInAppShowErrorMissing.json */; };
 		F34A10452F455C5B0065392A /* SettingsFeatureTogglesShouldSendInAppShowErrorFalse.json in Resources */ = {isa = PBXBuildFile; fileRef = F34A103F2F455C5B0065392A /* SettingsFeatureTogglesShouldSendInAppShowErrorFalse.json */; };
+		F34A104B2F455C5B0065392A /* SettingsFeatureTogglesShouldSendInAppTagsFalse.json in Resources */ = {isa = PBXBuildFile; fileRef = F34A10492F455C5B0065392A /* SettingsFeatureTogglesShouldSendInAppTagsFalse.json */; };
+		F34A104C2F455C5B0065392A /* SettingsFeatureTogglesShouldSendInAppTagsTypeError.json in Resources */ = {isa = PBXBuildFile; fileRef = F34A104A2F455C5B0065392A /* SettingsFeatureTogglesShouldSendInAppTagsTypeError.json */; };
 		F34A10462F455C5B0065392A /* SettingsFeatureTogglesError.json in Resources */ = {isa = PBXBuildFile; fileRef = F34A103E2F455C5B0065392A /* SettingsFeatureTogglesError.json */; };
 		F34A10472F455C5B0065392A /* SettingsFeatureTogglesShouldSendInAppShowErrorTypeError.json in Resources */ = {isa = PBXBuildFile; fileRef = F34A10412F455C5B0065392A /* SettingsFeatureTogglesShouldSendInAppShowErrorTypeError.json */; };
 		F34A10482F455C5B0065392A /* SettingsFeatureTogglesTypeError.json in Resources */ = {isa = PBXBuildFile; fileRef = F34A10422F455C5B0065392A /* SettingsFeatureTogglesTypeError.json */; };
@@ -662,6 +665,9 @@
 		F3C1A0022F5B100100ABC001 /* InappShowFailureManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3C1A0012F5B100100ABC001 /* InappShowFailureManager.swift */; };
 		F3C1A0042F5B100100ABC001 /* InAppShowFailure.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3C1A0032F5B100100ABC001 /* InAppShowFailure.swift */; };
 		F3C1A0062F5B100100ABC001 /* InappShowFailureManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3C1A0052F5B100100ABC001 /* InappShowFailureManagerTests.swift */; };
+		FA39EE97042009DCEC24E971 /* InAppTagsGatingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 045EA348681AB859FB298A57 /* InAppTagsGatingTests.swift */; };
+		1E316CC518D9111F0BD25590 /* InAppMessagesTrackerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F60DC2E1435521EBF0E2C5E4 /* InAppMessagesTrackerTests.swift */; };
+		AB0E83C770AAB9A2DC8E9BF5 /* JSONValueTagsMergeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55E67F6257F15F143DEA87DE /* JSONValueTagsMergeTests.swift */; };
 		F3CD20262F600A800065392A /* MBConfigurationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3CD20272F600A800065392A /* MBConfigurationTests.swift */; };
 		F3CD20292F600A800065392A /* HostNormalizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3CD202A2F600A800065392A /* HostNormalizer.swift */; };
 		F3CD202B2F600A800065392A /* HostNormalizerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3CD202C2F600A800065392A /* HostNormalizerTests.swift */; };
@@ -830,6 +836,7 @@
 		33E42E5B268323E60046CBCB /* CashdeskRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CashdeskRequest.swift; sourceTree = "<group>"; };
 		33EBF0AF264E6283002A35D5 /* MBSessionManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MBSessionManager.swift; sourceTree = "<group>"; };
 		3456BAC56F984378B6CED7CB /* FeatureToggleManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeatureToggleManager.swift; sourceTree = "<group>"; };
+		3E8D4000B12B31961251F6C7 /* InAppTagsGating.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InAppTagsGating.swift; sourceTree = "<group>"; };
 		472179A62C80755A00C15E7F /* ShownInAppsIDsMigration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShownInAppsIDsMigration.swift; sourceTree = "<group>"; };
 		472765512E0D52A500A5A060 /* RemoveBackgroundTaskDataMigration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoveBackgroundTaskDataMigration.swift; sourceTree = "<group>"; };
 		472F549D2C6E272A0008C465 /* MBPushNotification.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MBPushNotification.swift; sourceTree = "<group>"; };
@@ -1286,6 +1293,8 @@
 		F34A103B2F455B840065392A /* SettingsConfigParsingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsConfigParsingTests.swift; sourceTree = "<group>"; };
 		F34A103E2F455C5B0065392A /* SettingsFeatureTogglesError.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = SettingsFeatureTogglesError.json; sourceTree = "<group>"; };
 		F34A103F2F455C5B0065392A /* SettingsFeatureTogglesShouldSendInAppShowErrorFalse.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = SettingsFeatureTogglesShouldSendInAppShowErrorFalse.json; sourceTree = "<group>"; };
+		F34A10492F455C5B0065392A /* SettingsFeatureTogglesShouldSendInAppTagsFalse.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = SettingsFeatureTogglesShouldSendInAppTagsFalse.json; sourceTree = "<group>"; };
+		F34A104A2F455C5B0065392A /* SettingsFeatureTogglesShouldSendInAppTagsTypeError.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = SettingsFeatureTogglesShouldSendInAppTagsTypeError.json; sourceTree = "<group>"; };
 		F34A10402F455C5B0065392A /* SettingsFeatureTogglesShouldSendInAppShowErrorMissing.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = SettingsFeatureTogglesShouldSendInAppShowErrorMissing.json; sourceTree = "<group>"; };
 		F34A10412F455C5B0065392A /* SettingsFeatureTogglesShouldSendInAppShowErrorTypeError.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = SettingsFeatureTogglesShouldSendInAppShowErrorTypeError.json; sourceTree = "<group>"; };
 		F34A10422F455C5B0065392A /* SettingsFeatureTogglesTypeError.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = SettingsFeatureTogglesTypeError.json; sourceTree = "<group>"; };
@@ -1393,6 +1402,9 @@
 		F3C1A0012F5B100100ABC001 /* InappShowFailureManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InappShowFailureManager.swift; sourceTree = "<group>"; };
 		F3C1A0032F5B100100ABC001 /* InAppShowFailure.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InAppShowFailure.swift; sourceTree = "<group>"; };
 		F3C1A0052F5B100100ABC001 /* InappShowFailureManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InappShowFailureManagerTests.swift; sourceTree = "<group>"; };
+		045EA348681AB859FB298A57 /* InAppTagsGatingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InAppTagsGatingTests.swift; sourceTree = "<group>"; };
+		F60DC2E1435521EBF0E2C5E4 /* InAppMessagesTrackerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InAppMessagesTrackerTests.swift; sourceTree = "<group>"; };
+		55E67F6257F15F143DEA87DE /* JSONValueTagsMergeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONValueTagsMergeTests.swift; sourceTree = "<group>"; };
 		F3CD20272F600A800065392A /* MBConfigurationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MBConfigurationTests.swift; sourceTree = "<group>"; };
 		F3CD202A2F600A800065392A /* HostNormalizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HostNormalizer.swift; sourceTree = "<group>"; };
 		F3CD202C2F600A800065392A /* HostNormalizerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HostNormalizerTests.swift; sourceTree = "<group>"; };
@@ -1496,6 +1508,7 @@
 			isa = PBXGroup;
 			children = (
 				3456BAC56F984378B6CED7CB /* FeatureToggleManager.swift */,
+				3E8D4000B12B31961251F6C7 /* InAppTagsGating.swift */,
 			);
 			path = FeatureToggleManager;
 			sourceTree = "<group>";
@@ -1504,6 +1517,7 @@
 			isa = PBXGroup;
 			children = (
 				0CFCC82B8014DE7276C217CD /* WebViewLocalStateStorageTests.swift */,
+				55E67F6257F15F143DEA87DE /* JSONValueTagsMergeTests.swift */,
 				A1B2C3D400000006E1010101 /* BridgeMessagePermissionTests.swift */,
 				BD1BE43AA9EAEA03F8ED400C /* HapticRequestParserTests.swift */,
 				BD1BE43AA9EAEA03F8ED400D /* HapticRequestValidatorTests.swift */,
@@ -2691,6 +2705,8 @@
 				F3B70A042F250A0100AABB03 /* TimeToDisplayBackgroundTests.swift */,
 				F3A0B0012F28A00100CE7E63 /* TransparentViewTests.swift */,
 				F3C1A0052F5B100100ABC001 /* InappShowFailureManagerTests.swift */,
+				045EA348681AB859FB298A57 /* InAppTagsGatingTests.swift */,
+				F60DC2E1435521EBF0E2C5E4 /* InAppMessagesTrackerTests.swift */,
 				2B4C84F6EDD4B7D977F67A95 /* WebView */,
 				A1B2C3D400000007E1010101 /* Permissions */,
 				4B7DAFAB687945FA908DB1AC /* TransparentViewSyncOperationResponseTests.swift */,
@@ -3494,6 +3510,8 @@
 				F34A10402F455C5B0065392A /* SettingsFeatureTogglesShouldSendInAppShowErrorMissing.json */,
 				F34A10412F455C5B0065392A /* SettingsFeatureTogglesShouldSendInAppShowErrorTypeError.json */,
 				F34A10422F455C5B0065392A /* SettingsFeatureTogglesTypeError.json */,
+				F34A10492F455C5B0065392A /* SettingsFeatureTogglesShouldSendInAppTagsFalse.json */,
+				F34A104A2F455C5B0065392A /* SettingsFeatureTogglesShouldSendInAppTagsTypeError.json */,
 			);
 			path = FeatureTogglesError;
 			sourceTree = "<group>";
@@ -4084,6 +4102,8 @@
 				F34A10462F455C5B0065392A /* SettingsFeatureTogglesError.json in Resources */,
 				F34A10472F455C5B0065392A /* SettingsFeatureTogglesShouldSendInAppShowErrorTypeError.json in Resources */,
 				F34A10482F455C5B0065392A /* SettingsFeatureTogglesTypeError.json in Resources */,
+				F34A104B2F455C5B0065392A /* SettingsFeatureTogglesShouldSendInAppTagsFalse.json in Resources */,
+				F34A104C2F455C5B0065392A /* SettingsFeatureTogglesShouldSendInAppTagsTypeError.json in Resources */,
 				F3BA10552F500A800065392A /* SettingsBaseAddressesError.json in Resources */,
 				F3BA10562F500A800065392A /* SettingsBaseAddressesTypeError.json in Resources */,
 				F3BA10572F500A800065392A /* SettingsBaseAddressesOperationsError.json in Resources */,
@@ -4517,6 +4537,7 @@
 				F3A4EFDC2D5224C700DB96A8 /* SlidingExpirationModel.swift in Sources */,
 				DEC482157E5249DBBFAEFC9A /* FeatureTogglesModel.swift in Sources */,
 				3FB93AC126964AD3A061B4A7 /* FeatureToggleManager.swift in Sources */,
+				B202CDC049DDB7A2F9833ADF /* InAppTagsGating.swift in Sources */,
 				47DF1FB02E7D6F90009BC4A0 /* DatabaseLoaderProtocol.swift in Sources */,
 				F31A94802BC7E61800E6C978 /* InappFrequencyValidator.swift in Sources */,
 				33072F322664C357001F1AB2 /* ProductListResponse.swift in Sources */,
@@ -4685,6 +4706,9 @@
 				F3B70A052F250A0100AABB03 /* TimeToDisplayBackgroundTests.swift in Sources */,
 				F3A0B0022F28A00100CE7E63 /* TransparentViewTests.swift in Sources */,
 				F3C1A0062F5B100100ABC001 /* InappShowFailureManagerTests.swift in Sources */,
+				FA39EE97042009DCEC24E971 /* InAppTagsGatingTests.swift in Sources */,
+				1E316CC518D9111F0BD25590 /* InAppMessagesTrackerTests.swift in Sources */,
+				AB0E83C770AAB9A2DC8E9BF5 /* JSONValueTagsMergeTests.swift in Sources */,
 				D216DE512C0716B70020F58A /* StringExtensionsTests.swift in Sources */,
 				D216DE532C0716B80020F58A /* TimeIntervalTimeSpanTests.swift in Sources */,
 				A17958812978B3FA00609E91 /* InAppResponseModelTests.swift in Sources */,

--- a/Mindbox/DI/Injections/InjectInappTools.swift
+++ b/Mindbox/DI/Injections/InjectInappTools.swift
@@ -90,7 +90,8 @@ extension MBContainer {
     func registerInappPresentation() -> Self {
         register(InAppMessagesTracker.self) {
             let databaseRepository = DI.injectOrFail(DatabaseRepositoryProtocol.self)
-            return InAppMessagesTracker(databaseRepository: databaseRepository)
+            let featureToggleManager = DI.injectOrFail(FeatureToggleManager.self)
+            return InAppMessagesTracker(databaseRepository: databaseRepository, featureToggleManager: featureToggleManager)
         }
 
         register(PresentationDisplayUseCase.self) {

--- a/Mindbox/InAppMessages/FeatureToggleManager/FeatureToggleManager.swift
+++ b/Mindbox/InAppMessages/FeatureToggleManager/FeatureToggleManager.swift
@@ -25,10 +25,15 @@ enum FeatureFlag {
 
 final class FeatureToggleManager {
 
+    /// Guards `featureToggles`: it is written on the config-fetch queue and read from arbitrary queues (tracking, WebView JS-bridge).
+    private let lock = NSLock()
     private var featureToggles: Settings.FeatureToggles?
 
     func applyFeatureToggles(_ featureToggles: Settings.FeatureToggles?) {
+        lock.lock()
         self.featureToggles = featureToggles
+        lock.unlock()
+
         let flags: [String] = [
             featureToggles?.shouldSendInAppShowError.map { "MobileSdkShouldSendInAppShowError=\($0)" },
             featureToggles?.shouldSendInAppTags.map { "MobileSdkShouldSendInAppTags=\($0)" }
@@ -39,8 +44,12 @@ final class FeatureToggleManager {
             category: .inAppMessages
         )
     }
-    
+
     func isFeatureEnabled(_ feature: FeatureFlag) -> Bool {
+        lock.lock()
+        let featureToggles = self.featureToggles
+        lock.unlock()
+
         switch feature {
         case .shouldSendInAppShowError:
             return featureToggles?.shouldSendInAppShowError ?? feature.defaultValue

--- a/Mindbox/InAppMessages/FeatureToggleManager/FeatureToggleManager.swift
+++ b/Mindbox/InAppMessages/FeatureToggleManager/FeatureToggleManager.swift
@@ -11,10 +11,13 @@ import MindboxLogger
 
 enum FeatureFlag {
     case shouldSendInAppShowError
+    case shouldSendInAppTags
 
     var defaultValue: Bool {
         switch self {
         case .shouldSendInAppShowError:
+            return true
+        case .shouldSendInAppTags:
             return true
         }
     }
@@ -27,7 +30,8 @@ final class FeatureToggleManager {
     func applyFeatureToggles(_ featureToggles: Settings.FeatureToggles?) {
         self.featureToggles = featureToggles
         let flags: [String] = [
-            featureToggles?.shouldSendInAppShowError.map { "MobileSdkShouldSendInAppShowError=\($0)" }
+            featureToggles?.shouldSendInAppShowError.map { "MobileSdkShouldSendInAppShowError=\($0)" },
+            featureToggles?.shouldSendInAppTags.map { "MobileSdkShouldSendInAppTags=\($0)" }
         ].compactMap { $0 }
         Logger.common(
             message: "[FeatureToggles] \(flags)",
@@ -40,6 +44,8 @@ final class FeatureToggleManager {
         switch feature {
         case .shouldSendInAppShowError:
             return featureToggles?.shouldSendInAppShowError ?? feature.defaultValue
+        case .shouldSendInAppTags:
+            return featureToggles?.shouldSendInAppTags ?? feature.defaultValue
         }
     }
 }

--- a/Mindbox/InAppMessages/FeatureToggleManager/InAppTagsGating.swift
+++ b/Mindbox/InAppMessages/FeatureToggleManager/InAppTagsGating.swift
@@ -15,3 +15,10 @@ extension Optional where Wrapped == [String: String] {
         return self
     }
 }
+
+extension FeatureToggleManager {
+    /// Returns `tags` when `MobileSdkShouldSendInAppTags` is enabled and the dictionary is non-empty, `nil` otherwise.
+    func gatedTags(_ tags: [String: String]?) -> [String: String]? {
+        tags.gatedTags(isTagsFeatureEnabled: isFeatureEnabled(.shouldSendInAppTags))
+    }
+}

--- a/Mindbox/InAppMessages/FeatureToggleManager/InAppTagsGating.swift
+++ b/Mindbox/InAppMessages/FeatureToggleManager/InAppTagsGating.swift
@@ -8,17 +8,15 @@
 
 import Foundation
 
-extension Optional where Wrapped == [String: String] {
-    /// Returns `self` when the tags feature is enabled and the dictionary is non-empty, `nil` otherwise.
-    func gatedTags(isTagsFeatureEnabled: Bool) -> [String: String]? {
-        guard isTagsFeatureEnabled, let self, !self.isEmpty else { return nil }
-        return self
-    }
-}
-
 extension FeatureToggleManager {
+    /// Returns `tags` when `isEnabled` is `true` and the dictionary is non-empty, `nil` otherwise.
+    static func gatedTags(_ tags: [String: String]?, isEnabled: Bool) -> [String: String]? {
+        guard isEnabled, let tags, !tags.isEmpty else { return nil }
+        return tags
+    }
+
     /// Returns `tags` when `MobileSdkShouldSendInAppTags` is enabled and the dictionary is non-empty, `nil` otherwise.
     func gatedTags(_ tags: [String: String]?) -> [String: String]? {
-        tags.gatedTags(isTagsFeatureEnabled: isFeatureEnabled(.shouldSendInAppTags))
+        Self.gatedTags(tags, isEnabled: isFeatureEnabled(.shouldSendInAppTags))
     }
 }

--- a/Mindbox/InAppMessages/FeatureToggleManager/InAppTagsGating.swift
+++ b/Mindbox/InAppMessages/FeatureToggleManager/InAppTagsGating.swift
@@ -1,0 +1,17 @@
+//
+//  InAppTagsGating.swift
+//  Mindbox
+//
+//  Created by Akylbek Utekeshev on 01.07.2026.
+//  Copyright © 2026 Mindbox. All rights reserved.
+//
+
+import Foundation
+
+extension Optional where Wrapped == [String: String] {
+    /// Returns `self` when the tags feature is enabled and the dictionary is non-empty, `nil` otherwise.
+    func gatedTags(isTagsFeatureEnabled: Bool) -> [String: String]? {
+        guard isTagsFeatureEnabled, let self, !self.isEmpty else { return nil }
+        return self
+    }
+}

--- a/Mindbox/InAppMessages/InAppConfigurationMapper/InappMapper.swift
+++ b/Mindbox/InAppMessages/InAppConfigurationMapper/InappMapper.swift
@@ -91,7 +91,10 @@ class InappMapper: InappMapperProtocol {
             let suitableInapps = self.inappFilterService.filterInappsByTargeting(inapps: inapps, targetingChecker: self.targetingChecker)
             let suitableIds = Set(suitableInapps.map(\.inAppId))
             let failedTargetingInappIds = Set(inapps.map(\.id)).subtracting(suitableIds)
-            self.dataFacade.collectTargetingFailures(forFailedTargetingInappIds: failedTargetingInappIds)
+            let tagsByInappId: [String: [String: String]?] = inapps.reduce(into: [:]) { result, inapp in
+                result[inapp.id] = inapp.tags
+            }
+            self.dataFacade.collectTargetingFailures(forFailedTargetingInappIds: failedTargetingInappIds, tagsByInappId: tagsByInappId)
 
             if suitableInapps.isEmpty {
                 completion(nil)
@@ -152,7 +155,7 @@ class InappMapper: InappMapperProtocol {
                 for imageValue in imageValues {
                     group.enter()
                     Logger.common(message: "[InappMapper] Initiating the process of image loading from the URL: \(imageValue)", level: .debug, category: .inAppMessages)
-                    self.dataFacade.downloadImage(withUrl: imageValue, inappId: inapp.inAppId) { result in
+                    self.dataFacade.downloadImage(withUrl: imageValue, inappId: inapp.inAppId, tags: inapp.tags) { result in
                         defer {
                             group.leave()
                         }
@@ -189,7 +192,7 @@ class InappMapper: InappMapperProtocol {
             group.notify(queue: .main) {
                 DispatchQueue.main.async { [weak self] in
                     if let id = formData?.inAppId {
-                        self?.dataFacade.trackTargeting(id: id)
+                        self?.dataFacade.trackTargeting(id: id, tags: formData?.tags)
                         self?.shownInappIDWithHashValue[id] = self?.getEventHashValue()
                     }
 
@@ -239,7 +242,7 @@ class InappMapper: InappMapperProtocol {
                 if self.shownInappIDWithHashValue[inapp.inAppId] != self.getEventHashValue(),
                    let inapp = self.inappFilterService.validInapps.first(where: { $0.id == inapp.inAppId }),
                     self.targetingChecker.check(targeting: inapp.targeting) {
-                       self.dataFacade.trackTargeting(id: inapp.id)
+                       self.dataFacade.trackTargeting(id: inapp.id, tags: inapp.tags)
                 }
             }
             

--- a/Mindbox/InAppMessages/InAppConfigurationMapper/InappMapper.swift
+++ b/Mindbox/InAppMessages/InAppConfigurationMapper/InappMapper.swift
@@ -91,8 +91,9 @@ class InappMapper: InappMapperProtocol {
             let suitableInapps = self.inappFilterService.filterInappsByTargeting(inapps: inapps, targetingChecker: self.targetingChecker)
             let suitableIds = Set(suitableInapps.map(\.inAppId))
             let failedTargetingInappIds = Set(inapps.map(\.id)).subtracting(suitableIds)
-            let tagsByInappId: [String: [String: String]?] = inapps.reduce(into: [:]) { result, inapp in
-                result[inapp.id] = inapp.tags
+            let tagsByInappId: [String: [String: String]] = inapps.reduce(into: [:]) { result, inapp in
+                guard failedTargetingInappIds.contains(inapp.id), let tags = inapp.tags else { return }
+                result[inapp.id] = tags
             }
             self.dataFacade.collectTargetingFailures(forFailedTargetingInappIds: failedTargetingInappIds, tagsByInappId: tagsByInappId)
 

--- a/Mindbox/InAppMessages/InAppConfigurationMapper/Services/InAppConfigurationDataFacade.swift
+++ b/Mindbox/InAppMessages/InAppConfigurationMapper/Services/InAppConfigurationDataFacade.swift
@@ -16,7 +16,7 @@ protocol InAppConfigurationDataFacadeProtocol {
         shouldCollectFailures: Bool,
         _ completion: @escaping () -> Void
     )
-    func collectTargetingFailures(forFailedTargetingInappIds failedTargetingInappIds: Set<String>, tagsByInappId: [String: [String: String]?])
+    func collectTargetingFailures(forFailedTargetingInappIds failedTargetingInappIds: Set<String>, tagsByInappId: [String: [String: String]])
     func downloadImage(withUrl url: String, inappId: String, tags: [String: String]?, completion: @escaping (Result<UIImage, MindboxError>) -> Void)
     func trackTargeting(id: String?, tags: [String: String]?)
 }
@@ -70,7 +70,7 @@ class InAppConfigurationDataFacade: InAppConfigurationDataFacadeProtocol {
         }
     }
 
-    func collectTargetingFailures(forFailedTargetingInappIds failedTargetingInappIds: Set<String>, tagsByInappId: [String: [String: String]?]) {
+    func collectTargetingFailures(forFailedTargetingInappIds failedTargetingInappIds: Set<String>, tagsByInappId: [String: [String: String]]) {
         defer {
             pendingTargetingFailureDetails.removeAll()
         }
@@ -82,7 +82,7 @@ class InAppConfigurationDataFacade: InAppConfigurationDataFacadeProtocol {
         pendingTargetingFailureDetails.forEach { reason, details in
             let inappIds = inappIds(for: reason)
             failedTargetingInappIds.intersection(inappIds).forEach {
-                failureManager.addFailure(inappId: $0, reason: reason, details: details, tags: tagsByInappId[$0] ?? nil)
+                failureManager.addFailure(inappId: $0, reason: reason, details: details, tags: tagsByInappId[$0])
             }
         }
     }

--- a/Mindbox/InAppMessages/InAppConfigurationMapper/Services/InAppConfigurationDataFacade.swift
+++ b/Mindbox/InAppMessages/InAppConfigurationMapper/Services/InAppConfigurationDataFacade.swift
@@ -16,9 +16,9 @@ protocol InAppConfigurationDataFacadeProtocol {
         shouldCollectFailures: Bool,
         _ completion: @escaping () -> Void
     )
-    func collectTargetingFailures(forFailedTargetingInappIds failedTargetingInappIds: Set<String>)
-    func downloadImage(withUrl url: String, inappId: String, completion: @escaping (Result<UIImage, MindboxError>) -> Void)
-    func trackTargeting(id: String?)
+    func collectTargetingFailures(forFailedTargetingInappIds failedTargetingInappIds: Set<String>, tagsByInappId: [String: [String: String]?])
+    func downloadImage(withUrl url: String, inappId: String, tags: [String: String]?, completion: @escaping (Result<UIImage, MindboxError>) -> Void)
+    func trackTargeting(id: String?, tags: [String: String]?)
 }
 
 extension InAppConfigurationDataFacadeProtocol {
@@ -70,7 +70,7 @@ class InAppConfigurationDataFacade: InAppConfigurationDataFacadeProtocol {
         }
     }
 
-    func collectTargetingFailures(forFailedTargetingInappIds failedTargetingInappIds: Set<String>) {
+    func collectTargetingFailures(forFailedTargetingInappIds failedTargetingInappIds: Set<String>, tagsByInappId: [String: [String: String]?]) {
         defer {
             pendingTargetingFailureDetails.removeAll()
         }
@@ -82,12 +82,12 @@ class InAppConfigurationDataFacade: InAppConfigurationDataFacadeProtocol {
         pendingTargetingFailureDetails.forEach { reason, details in
             let inappIds = inappIds(for: reason)
             failedTargetingInappIds.intersection(inappIds).forEach {
-                failureManager.addFailure(inappId: $0, reason: reason, details: details)
+                failureManager.addFailure(inappId: $0, reason: reason, details: details, tags: tagsByInappId[$0] ?? nil)
             }
         }
     }
 
-    func downloadImage(withUrl url: String, inappId: String, completion: @escaping (Result<UIImage, MindboxError>) -> Void) {
+    func downloadImage(withUrl url: String, inappId: String, tags: [String: String]?, completion: @escaping (Result<UIImage, MindboxError>) -> Void) {
         imageService.downloadImage(withUrl: url) { result in
             if case .failure(let error) = result {
                 switch error {
@@ -96,7 +96,8 @@ class InAppConfigurationDataFacade: InAppConfigurationDataFacadeProtocol {
                     self.failureManager.addFailure(
                         inappId: inappId,
                         reason: .imageDownloadFailed,
-                        details: details
+                        details: details,
+                        tags: tags
                     )
                 default:
                     break
@@ -106,10 +107,10 @@ class InAppConfigurationDataFacade: InAppConfigurationDataFacadeProtocol {
         }
     }
 
-    func trackTargeting(id: String?) {
+    func trackTargeting(id: String?, tags: [String: String]?) {
         if let id = id {
             do {
-                try self.tracker.trackTargeting(id: id)
+                try self.tracker.trackTargeting(id: id, tags: tags)
                 Logger.common(message: "Track InApp.Targeting. Id \(id)", level: .info, category: .inAppMessages)
             } catch {
                 Logger.common(message: "Track InApp.Targeting failed with error: \(error)", level: .error, category: .inAppMessages)

--- a/Mindbox/InAppMessages/InAppMessagesTracker.swift
+++ b/Mindbox/InAppMessages/InAppMessagesTracker.swift
@@ -9,16 +9,16 @@
 import Foundation
 
 protocol InappTargetingTrackProtocol: AnyObject {
-    func trackTargeting(id: String) throws
+    func trackTargeting(id: String, tags: [String: String]?) throws
 }
 
 protocol InAppMessagesTrackerProtocol: AnyObject {
     func trackView(id: String, timeToDisplay: String?, tags: [String: String]?) throws
-    func trackClick(id: String) throws
+    func trackClick(id: String, tags: [String: String]?) throws
 }
 
 class InAppMessagesTracker: InAppMessagesTrackerProtocol, InappTargetingTrackProtocol {
-    
+
     struct InAppShowBody: Encodable {
         let inappId: String
         let timeToDisplay: String?
@@ -38,30 +38,48 @@ class InAppMessagesTracker: InAppMessagesTrackerProtocol, InappTargetingTrackPro
         }
     }
 
-    struct InAppBody: Codable {
+    struct InAppBody: Encodable {
         let inappId: String
+        let tags: [String: String]?
+
+        func encode(to encoder: Encoder) throws {
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            try container.encode(inappId, forKey: .inappId)
+            if let tags = tags, !tags.isEmpty {
+                try container.encode(tags, forKey: .tags)
+            }
+        }
+
+        private enum CodingKeys: String, CodingKey {
+            case inappId, tags
+        }
     }
 
     private let databaseRepository: DatabaseRepositoryProtocol
+    private let featureToggleManager: FeatureToggleManager
 
-    init(databaseRepository: DatabaseRepositoryProtocol) {
+    init(databaseRepository: DatabaseRepositoryProtocol, featureToggleManager: FeatureToggleManager) {
         self.databaseRepository = databaseRepository
+        self.featureToggleManager = featureToggleManager
     }
 
     func trackView(id: String, timeToDisplay: String?, tags: [String: String]?) throws {
-        let encodable = InAppShowBody(inappId: id, timeToDisplay: timeToDisplay, tags: tags)
+        let gatedTags = tags.gatedTags(isTagsFeatureEnabled: featureToggleManager.isFeatureEnabled(.shouldSendInAppTags))
+        let encodable = InAppShowBody(inappId: id, timeToDisplay: timeToDisplay, tags: gatedTags)
         let event = Event(type: .inAppViewEvent, body: BodyEncoder(encodable: encodable).body)
         try databaseRepository.create(event: event)
     }
 
-    func trackClick(id: String) throws {
-        let encodable = InAppBody(inappId: id)
+    func trackClick(id: String, tags: [String: String]?) throws {
+        let gatedTags = tags.gatedTags(isTagsFeatureEnabled: featureToggleManager.isFeatureEnabled(.shouldSendInAppTags))
+        let encodable = InAppBody(inappId: id, tags: gatedTags)
         let event = Event(type: .inAppClickEvent, body: BodyEncoder(encodable: encodable).body)
         try databaseRepository.create(event: event)
     }
 
-    func trackTargeting(id: String) throws {
-        let encodable = InAppBody(inappId: id)
+    func trackTargeting(id: String, tags: [String: String]?) throws {
+        let gatedTags = tags.gatedTags(isTagsFeatureEnabled: featureToggleManager.isFeatureEnabled(.shouldSendInAppTags))
+        let encodable = InAppBody(inappId: id, tags: gatedTags)
         let event = Event(type: .inAppTargetingEvent, body: BodyEncoder(encodable: encodable).body)
         try databaseRepository.create(event: event)
     }

--- a/Mindbox/InAppMessages/InAppMessagesTracker.swift
+++ b/Mindbox/InAppMessages/InAppMessagesTracker.swift
@@ -23,36 +23,11 @@ class InAppMessagesTracker: InAppMessagesTrackerProtocol, InappTargetingTrackPro
         let inappId: String
         let timeToDisplay: String?
         let tags: [String: String]?
-
-        func encode(to encoder: Encoder) throws {
-            var container = encoder.container(keyedBy: CodingKeys.self)
-            try container.encode(inappId, forKey: .inappId)
-            try container.encodeIfPresent(timeToDisplay, forKey: .timeToDisplay)
-            if let tags = tags, !tags.isEmpty {
-                try container.encode(tags, forKey: .tags)
-            }
-        }
-
-        private enum CodingKeys: String, CodingKey {
-            case inappId, timeToDisplay, tags
-        }
     }
 
     struct InAppBody: Encodable {
         let inappId: String
         let tags: [String: String]?
-
-        func encode(to encoder: Encoder) throws {
-            var container = encoder.container(keyedBy: CodingKeys.self)
-            try container.encode(inappId, forKey: .inappId)
-            if let tags = tags, !tags.isEmpty {
-                try container.encode(tags, forKey: .tags)
-            }
-        }
-
-        private enum CodingKeys: String, CodingKey {
-            case inappId, tags
-        }
     }
 
     private let databaseRepository: DatabaseRepositoryProtocol
@@ -64,23 +39,22 @@ class InAppMessagesTracker: InAppMessagesTrackerProtocol, InappTargetingTrackPro
     }
 
     func trackView(id: String, timeToDisplay: String?, tags: [String: String]?) throws {
-        let gatedTags = tags.gatedTags(isTagsFeatureEnabled: featureToggleManager.isFeatureEnabled(.shouldSendInAppTags))
-        let encodable = InAppShowBody(inappId: id, timeToDisplay: timeToDisplay, tags: gatedTags)
+        let encodable = InAppShowBody(inappId: id, timeToDisplay: timeToDisplay, tags: featureToggleManager.gatedTags(tags))
         let event = Event(type: .inAppViewEvent, body: BodyEncoder(encodable: encodable).body)
         try databaseRepository.create(event: event)
     }
 
     func trackClick(id: String, tags: [String: String]?) throws {
-        let gatedTags = tags.gatedTags(isTagsFeatureEnabled: featureToggleManager.isFeatureEnabled(.shouldSendInAppTags))
-        let encodable = InAppBody(inappId: id, tags: gatedTags)
-        let event = Event(type: .inAppClickEvent, body: BodyEncoder(encodable: encodable).body)
-        try databaseRepository.create(event: event)
+        try track(id: id, tags: tags, type: .inAppClickEvent)
     }
 
     func trackTargeting(id: String, tags: [String: String]?) throws {
-        let gatedTags = tags.gatedTags(isTagsFeatureEnabled: featureToggleManager.isFeatureEnabled(.shouldSendInAppTags))
-        let encodable = InAppBody(inappId: id, tags: gatedTags)
-        let event = Event(type: .inAppTargetingEvent, body: BodyEncoder(encodable: encodable).body)
+        try track(id: id, tags: tags, type: .inAppTargetingEvent)
+    }
+
+    private func track(id: String, tags: [String: String]?, type: Event.Operation) throws {
+        let encodable = InAppBody(inappId: id, tags: featureToggleManager.gatedTags(tags))
+        let event = Event(type: type, body: BodyEncoder(encodable: encodable).body)
         try databaseRepository.create(event: event)
     }
 }

--- a/Mindbox/InAppMessages/InappScheduleManager.swift
+++ b/Mindbox/InAppMessages/InappScheduleManager.swift
@@ -153,7 +153,8 @@ internal extension InappScheduleManager {
                 self.failureManager.addFailure(
                     inappId: inapp.inAppId,
                     reason: error.failureReason,
-                    details: error.failureDetails
+                    details: error.failureDetails,
+                    tags: inapp.tags
                 )
                 self.failureManager.sendFailures()
             }

--- a/Mindbox/InAppMessages/InappShowFailureManager.swift
+++ b/Mindbox/InAppMessages/InappShowFailureManager.swift
@@ -40,7 +40,7 @@ final class InappShowFailureManager: InappShowFailureManagerProtocol {
             return
         }
 
-        let gatedTags = tags.gatedTags(isTagsFeatureEnabled: featureToggleManager.isFeatureEnabled(.shouldSendInAppTags))
+        let gatedTags = featureToggleManager.gatedTags(tags)
 
         let truncatedDetails = details.map { original -> String in
             let truncated = original.truncated(toUTF8ByteLimit: Self.errorDetailsLimit)

--- a/Mindbox/InAppMessages/InappShowFailureManager.swift
+++ b/Mindbox/InAppMessages/InappShowFailureManager.swift
@@ -10,7 +10,7 @@ import Foundation
 import MindboxLogger
 
 protocol InappShowFailureManagerProtocol {
-    func addFailure(inappId: String, reason: InAppShowFailureReason, details: String?)
+    func addFailure(inappId: String, reason: InAppShowFailureReason, details: String?, tags: [String: String]?)
     func clearFailures()
     func sendFailures()
 }
@@ -34,11 +34,13 @@ final class InappShowFailureManager: InappShowFailureManagerProtocol {
         self.featureToggleManager = featureToggleManager
     }
     
-    func addFailure(inappId: String, reason: InAppShowFailureReason, details: String?) {
+    func addFailure(inappId: String, reason: InAppShowFailureReason, details: String?, tags: [String: String]?) {
         guard featureToggleManager.isFeatureEnabled(.shouldSendInAppShowError) else {
             Logger.common(message: "[InappShowFailureManager] addFailure ignored, feature is disabled", category: .inAppMessages)
             return
         }
+
+        let gatedTags = tags.gatedTags(isTagsFeatureEnabled: featureToggleManager.isFeatureEnabled(.shouldSendInAppTags))
 
         let truncatedDetails = details.map { original -> String in
             let truncated = original.truncated(toUTF8ByteLimit: Self.errorDetailsLimit)
@@ -63,13 +65,13 @@ final class InappShowFailureManager: InappShowFailureManagerProtocol {
                     )
                     return
                 }
-                failures[existingIndex] = makeFailure(inappId: inappId, reason: reason, details: truncatedDetails)
+                failures[existingIndex] = makeFailure(inappId: inappId, reason: reason, details: truncatedDetails, tags: gatedTags)
                 Logger.common(message: "[InappShowFailureManager] Failure reason updated. inappId=\(inappId), reason=\(reason.rawValue)",
                               category: .inAppMessages)
                 return
             }
 
-            failures.append(makeFailure(inappId: inappId, reason: reason, details: truncatedDetails))
+            failures.append(makeFailure(inappId: inappId, reason: reason, details: truncatedDetails, tags: gatedTags))
         }
     }
     
@@ -111,12 +113,13 @@ final class InappShowFailureManager: InappShowFailureManagerProtocol {
         }
     }
     
-    private func makeFailure(inappId: String, reason: InAppShowFailureReason, details: String?) -> InAppShowFailure {
+    private func makeFailure(inappId: String, reason: InAppShowFailureReason, details: String?, tags: [String: String]?) -> InAppShowFailure {
         InAppShowFailure(
             inappId: inappId,
             failureReason: reason,
             errorDetails: details,
-            dateTimeUtc: Date().toString(withFormat: .utc)
+            dateTimeUtc: Date().toString(withFormat: .utc),
+            tags: tags
         )
     }
 

--- a/Mindbox/InAppMessages/Models/Config/FeatureTogglesModel.swift
+++ b/Mindbox/InAppMessages/Models/Config/FeatureTogglesModel.swift
@@ -11,9 +11,11 @@ import Foundation
 extension Settings {
     struct FeatureToggles: Decodable, Equatable {
         let shouldSendInAppShowError: Bool?
+        let shouldSendInAppTags: Bool?
 
         enum CodingKeys: String, CodingKey {
             case shouldSendInAppShowError = "MobileSdkShouldSendInAppShowError"
+            case shouldSendInAppTags = "MobileSdkShouldSendInAppTags"
         }
     }
 }
@@ -22,5 +24,6 @@ extension Settings.FeatureToggles {
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         self.shouldSendInAppShowError = try? container.decodeIfPresent(Bool.self, forKey: .shouldSendInAppShowError)
+        self.shouldSendInAppTags = try? container.decodeIfPresent(Bool.self, forKey: .shouldSendInAppTags)
     }
 }

--- a/Mindbox/InAppMessages/Models/InAppShowFailure.swift
+++ b/Mindbox/InAppMessages/Models/InAppShowFailure.swift
@@ -24,4 +24,5 @@ struct InAppShowFailure: Codable {
     let failureReason: InAppShowFailureReason
     let errorDetails: String?
     let dateTimeUtc: String
+    let tags: [String: String]?
 }

--- a/Mindbox/InAppMessages/Presentation/Manager/UseCases/PresentationActionUseCase/PresentationClickTracker.swift
+++ b/Mindbox/InAppMessages/Presentation/Manager/UseCases/PresentationActionUseCase/PresentationClickTracker.swift
@@ -20,15 +20,15 @@ class PresentationClickTracker {
         self.tracker = tracker
     }
 
-    func trackClick(id: String) {
+    func trackClick(id: String, tags: [String: String]?) {
         if SessionTemporaryStorage.shared.lastInappClickedID == id {
             return
         }
-        
+
         SessionTemporaryStorage.shared.lastInappClickedID = id
-        
+
         do {
-            try tracker.trackClick(id: id)
+            try tracker.trackClick(id: id, tags: tags)
             Logger.common(message: "Track InApp.Click. Id \(id)", level: .info, category: .notification)
         } catch {
             Logger.common(message: "Track InApp.Click failed with error: \(error)", level: .error, category: .notification)

--- a/Mindbox/InAppMessages/Presentation/Manager/UseCases/PresentationDisplayUseCase/PresentationDisplayUseCase.swift
+++ b/Mindbox/InAppMessages/Presentation/Manager/UseCases/PresentationDisplayUseCase/PresentationDisplayUseCase.swift
@@ -77,7 +77,7 @@ final class PresentationDisplayUseCase: PresentationDisplayUseCaseProtocol {
             wrappedTapAction = onTapAction
         } else {
             wrappedTapAction = { [weak self] url, payload in
-                self?.clickTracker.trackClick(id: model.inAppId)
+                self?.clickTracker.trackClick(id: model.inAppId, tags: model.tags)
                 onTapAction(url, payload)
             }
         }

--- a/Mindbox/InAppMessages/Presentation/Manager/UseCases/PresentationDisplayUseCase/PresentationDisplayUseCase.swift
+++ b/Mindbox/InAppMessages/Presentation/Manager/UseCases/PresentationDisplayUseCase/PresentationDisplayUseCase.swift
@@ -90,7 +90,8 @@ final class PresentationDisplayUseCase: PresentationDisplayUseCaseProtocol {
                                                onTapAction: wrappedTapAction,
                                                onClose: onClose,
                                                onError: onError,
-                                               operation: model.operation)
+                                               operation: model.operation,
+                                               tags: model.tags)
 
         guard let viewController = factory.create(with: parameters) else {
             onError(.failed("[PresentationDisplayUseCase] Failed to create in-app view controller."))

--- a/Mindbox/InAppMessages/Presentation/Views/ViewFactory/ViewFactoryProtocol.swift
+++ b/Mindbox/InAppMessages/Presentation/Views/ViewFactory/ViewFactoryProtocol.swift
@@ -19,6 +19,7 @@ struct ViewFactoryParameters {
     let onClose: () -> Void
     let onError: (InAppPresentationError) -> Void
     let operation: (name: String, body: String)?
+    let tags: [String: String]?
 }
 
 protocol ViewFactoryProtocol {

--- a/Mindbox/InAppMessages/Presentation/Views/ViewFactory/WebViewFactory.swift
+++ b/Mindbox/InAppMessages/Presentation/Views/ViewFactory/WebViewFactory.swift
@@ -20,7 +20,8 @@ class WebViewFactory: ViewFactoryProtocol {
                                                      onTapAction: params.onTapAction,
                                                      onCloseInApp: params.onClose,
                                                      onError: params.onError,
-                                                     operation: params.operation)
+                                                     operation: params.operation,
+                                                     tags: params.tags)
             myViewController = viewController
             return viewController
         }

--- a/Mindbox/InAppMessages/Presentation/Views/WebView/Bridge/BridgeMessage.swift
+++ b/Mindbox/InAppMessages/Presentation/Views/WebView/Bridge/BridgeMessage.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+import MindboxLogger
 
 @_spi(Internal)
 public enum JSONValue: Codable, Equatable {
@@ -148,12 +149,22 @@ public enum JSONValue: Codable, Equatable {
         case .none, .some(.null):
             dict["tags"] = .object(tags.mapValues { .string($0) })
         case .some(.object(var existingTags)):
-            for (key, value) in tags where existingTags[key] == nil {
+            for (key, value) in tags {
+                if existingTags[key] != nil {
+                    Logger.common(
+                        message: "[WebView] Tags merge: key '\(key)' already present in operation body, keeping client value",
+                        category: .inAppMessages
+                    )
+                    continue
+                }
                 existingTags[key] = .string(value)
             }
             dict["tags"] = .object(existingTags)
         default:
-            break
+            Logger.common(
+                message: "[WebView] Tags merge: 'tags' in operation body is not an object, keeping client value",
+                category: .inAppMessages
+            )
         }
 
         return .object(dict)

--- a/Mindbox/InAppMessages/Presentation/Views/WebView/Bridge/BridgeMessage.swift
+++ b/Mindbox/InAppMessages/Presentation/Views/WebView/Bridge/BridgeMessage.swift
@@ -134,6 +134,30 @@ public enum JSONValue: Codable, Equatable {
     private var containerValue: Any {
         anyValue ?? NSNull()
     }
+
+    /// Merges in-app tags into the root of a custom operation `body`.
+    ///
+    /// - No `tags` key (or `null`) in `body` → sets it to the tags object.
+    /// - `tags` already an object → adds only missing keys; existing client keys win.
+    /// - `tags` present but not an object (string/array/etc.) → left untouched.
+    static func mergingInAppTags(_ tags: [String: String]?, into body: JSONValue) -> JSONValue {
+        guard let tags, !tags.isEmpty else { return body }
+        guard case .object(var dict) = body else { return body }
+
+        switch dict["tags"] {
+        case .none, .some(.null):
+            dict["tags"] = .object(tags.mapValues { .string($0) })
+        case .some(.object(var existingTags)):
+            for (key, value) in tags where existingTags[key] == nil {
+                existingTags[key] = .string(value)
+            }
+            dict["tags"] = .object(existingTags)
+        default:
+            break
+        }
+
+        return .object(dict)
+    }
 }
 
 @_spi(Internal)

--- a/Mindbox/InAppMessages/Presentation/Views/WebView/TransparentView.swift
+++ b/Mindbox/InAppMessages/Presentation/Views/WebView/TransparentView.swift
@@ -16,7 +16,7 @@ final class TransparentView: UIView {
     weak var delegate: WebVCDelegate?
     weak var webViewAction: WebViewAction?
 
-    private var facade: InappWebViewFacadeProtocol?
+    var facade: InappWebViewFacadeProtocol?
     private var quizInitTimeoutWorkItem: DispatchWorkItem?
     private var params: [String: JSONValue]?
     private var operation: (name: String, body: String)?
@@ -28,7 +28,9 @@ final class TransparentView: UIView {
     private lazy var localStateStorage: WebViewLocalStateStorageProtocol = DI.injectOrFail(WebViewLocalStateStorageProtocol.self)
     private lazy var permissionHandlerRegistry = DI.injectOrFail(PermissionHandlerRegistryProtocol.self)
     private lazy var hapticService: HapticServiceProtocol = DI.injectOrFail(HapticServiceProtocol.self)
-    private lazy var featureToggleManager: FeatureToggleManager = DI.injectOrFail(FeatureToggleManager.self)
+    lazy var featureToggleManager: FeatureToggleManager = DI.injectOrFail(FeatureToggleManager.self)
+    lazy var databaseRepository: DatabaseRepositoryProtocol = DI.injectOrFail(DatabaseRepositoryProtocol.self)
+    lazy var eventRepository: EventRepository = DI.injectOrFail(EventRepository.self)
     private var isMotionServiceInitialized = false
     private lazy var motionService: MotionServiceProtocol = {
         isMotionServiceInitialized = true
@@ -375,7 +377,6 @@ extension TransparentView {
         let customEvent = CustomEvent(name: params.name, payload: bodyString)
         let event = Event(type: .customEvent, body: BodyEncoder(encodable: customEvent).body)
 
-        let databaseRepository = DI.injectOrFail(DatabaseRepositoryProtocol.self)
         do {
             try databaseRepository.create(event: event)
             Logger.common(message: "[WebView] asyncOperation '\(params.name)' queued", level: .info, category: .webViewInAppMessages)
@@ -397,7 +398,6 @@ extension TransparentView {
 
         let customEvent = CustomEvent(name: params.name, payload: bodyString)
         let event = Event(type: .syncEvent, body: BodyEncoder(encodable: customEvent).body)
-        let eventRepository = DI.injectOrFail(EventRepository.self)
 
         Logger.common(message: "[WebView] syncOperation '\(params.name)' sending", level: .info, category: .webViewInAppMessages)
 

--- a/Mindbox/InAppMessages/Presentation/Views/WebView/TransparentView.swift
+++ b/Mindbox/InAppMessages/Presentation/Views/WebView/TransparentView.swift
@@ -22,11 +22,13 @@ final class TransparentView: UIView {
     private var operation: (name: String, body: String)?
     private let userAgent: String
     private let inAppId: String
+    private let tags: [String: String]?
     private var lastReadyCheckedUrl: String?
     private var isReadyCheckInFlight = false
     private lazy var localStateStorage: WebViewLocalStateStorageProtocol = DI.injectOrFail(WebViewLocalStateStorageProtocol.self)
     private lazy var permissionHandlerRegistry = DI.injectOrFail(PermissionHandlerRegistryProtocol.self)
     private lazy var hapticService: HapticServiceProtocol = DI.injectOrFail(HapticServiceProtocol.self)
+    private lazy var featureToggleManager: FeatureToggleManager = DI.injectOrFail(FeatureToggleManager.self)
     private var isMotionServiceInitialized = false
     private lazy var motionService: MotionServiceProtocol = {
         isMotionServiceInitialized = true
@@ -37,11 +39,12 @@ final class TransparentView: UIView {
         return service
     }()
 
-    init(frame: CGRect, params: [String: JSONValue], userAgent: String, operation: (name: String, body: String)?, inAppId: String) {
+    init(frame: CGRect, params: [String: JSONValue], userAgent: String, operation: (name: String, body: String)?, inAppId: String, tags: [String: String]? = nil) {
         self.params = params
         self.operation = operation
         self.userAgent = userAgent
         self.inAppId = inAppId
+        self.tags = tags
         super.init(frame: frame)
         commonInit()
     }
@@ -51,6 +54,7 @@ final class TransparentView: UIView {
         self.operation = nil
         self.userAgent = ""
         self.inAppId = ""
+        self.tags = nil
         super.init(frame: frame)
         commonInit()
     }
@@ -60,6 +64,7 @@ final class TransparentView: UIView {
         self.operation = nil
         self.userAgent = ""
         self.inAppId = ""
+        self.tags = nil
         super.init(coder: coder)
         commonInit()
     }
@@ -322,18 +327,27 @@ extension TransparentView: WebBridgeNavigationDelegate {
 
 extension TransparentView {
 
-    private func extractOperationParams(from message: BridgeMessage) -> (name: String, body: String)? {
+    private func extractOperationParams(from message: BridgeMessage) -> (name: String, body: JSONValue)? {
         guard case .string(let str) = message.payload,
               let data = str.data(using: .utf8),
               let dict = try? JSONDecoder().decode([String: JSONValue].self, from: data),
               case .string(let operation) = dict["operation"],
-              let body = dict["body"],
-              let bodyData = try? JSONEncoder().encode(body),
-              let bodyString = String(data: bodyData, encoding: .utf8) else {
+              let body = dict["body"] else {
             return nil
         }
 
-        return (operation, bodyString)
+        return (operation, body)
+    }
+
+    private func mergedOperationBodyString(_ body: JSONValue) -> String? {
+        let isTagsFeatureEnabled = featureToggleManager.isFeatureEnabled(.shouldSendInAppTags)
+        let gatedTags = tags.gatedTags(isTagsFeatureEnabled: isTagsFeatureEnabled)
+        let mergedBody = JSONValue.mergingInAppTags(gatedTags, into: body)
+
+        guard let bodyData = try? JSONEncoder().encode(mergedBody) else {
+            return nil
+        }
+        return String(data: bodyData, encoding: .utf8)
     }
 
     private func sendBridgeSuccess(action: String, id: UUID) {
@@ -353,12 +367,13 @@ extension TransparentView {
     }
 
     private func handleAsyncOperation(message: BridgeMessage) {
-        guard let params = extractOperationParams(from: message) else {
+        guard let params = extractOperationParams(from: message),
+              let bodyString = mergedOperationBodyString(params.body) else {
             sendBridgeError("Invalid payload: missing or empty operation", action: message.action, id: message.id)
             return
         }
 
-        let customEvent = CustomEvent(name: params.name, payload: params.body)
+        let customEvent = CustomEvent(name: params.name, payload: bodyString)
         let event = Event(type: .customEvent, body: BodyEncoder(encodable: customEvent).body)
 
         let databaseRepository = DI.injectOrFail(DatabaseRepositoryProtocol.self)
@@ -375,12 +390,13 @@ extension TransparentView {
     }
 
     private func handleSyncOperation(message: BridgeMessage) {
-        guard let params = extractOperationParams(from: message) else {
+        guard let params = extractOperationParams(from: message),
+              let bodyString = mergedOperationBodyString(params.body) else {
             sendBridgeError("Invalid payload: missing or empty operation", action: message.action, id: message.id)
             return
         }
 
-        let customEvent = CustomEvent(name: params.name, payload: params.body)
+        let customEvent = CustomEvent(name: params.name, payload: bodyString)
         let event = Event(type: .syncEvent, body: BodyEncoder(encodable: customEvent).body)
         let eventRepository = DI.injectOrFail(EventRepository.self)
 

--- a/Mindbox/InAppMessages/Presentation/Views/WebView/TransparentView.swift
+++ b/Mindbox/InAppMessages/Presentation/Views/WebView/TransparentView.swift
@@ -41,7 +41,7 @@ final class TransparentView: UIView {
         return service
     }()
 
-    init(frame: CGRect, params: [String: JSONValue], userAgent: String, operation: (name: String, body: String)?, inAppId: String, tags: [String: String]? = nil) {
+    init(frame: CGRect, params: [String: JSONValue], userAgent: String, operation: (name: String, body: String)?, inAppId: String, tags: [String: String]?) {
         self.params = params
         self.operation = operation
         self.userAgent = userAgent

--- a/Mindbox/InAppMessages/Presentation/Views/WebView/TransparentView.swift
+++ b/Mindbox/InAppMessages/Presentation/Views/WebView/TransparentView.swift
@@ -340,8 +340,7 @@ extension TransparentView {
     }
 
     private func mergedOperationBodyString(_ body: JSONValue) -> String? {
-        let isTagsFeatureEnabled = featureToggleManager.isFeatureEnabled(.shouldSendInAppTags)
-        let gatedTags = tags.gatedTags(isTagsFeatureEnabled: isTagsFeatureEnabled)
+        let gatedTags = featureToggleManager.gatedTags(tags)
         let mergedBody = JSONValue.mergingInAppTags(gatedTags, into: body)
 
         guard let bodyData = try? JSONEncoder().encode(mergedBody) else {

--- a/Mindbox/InAppMessages/Presentation/Views/WebView/TransparentView.swift
+++ b/Mindbox/InAppMessages/Presentation/Views/WebView/TransparentView.swift
@@ -334,6 +334,7 @@ extension TransparentView {
               let data = str.data(using: .utf8),
               let dict = try? JSONDecoder().decode([String: JSONValue].self, from: data),
               case .string(let operation) = dict["operation"],
+              !operation.isEmpty,
               let body = dict["body"] else {
             return nil
         }

--- a/Mindbox/InAppMessages/Presentation/Views/WebView/TransparentView.swift
+++ b/Mindbox/InAppMessages/Presentation/Views/WebView/TransparentView.swift
@@ -371,7 +371,7 @@ extension TransparentView {
     private func handleAsyncOperation(message: BridgeMessage) {
         guard let params = extractOperationParams(from: message),
               let bodyString = mergedOperationBodyString(params.body) else {
-            sendBridgeError("Invalid payload: missing or empty operation", action: message.action, id: message.id)
+            sendBridgeError("Invalid payload: could not parse operation/body or encode the operation body", action: message.action, id: message.id)
             return
         }
 
@@ -393,7 +393,7 @@ extension TransparentView {
     private func handleSyncOperation(message: BridgeMessage) {
         guard let params = extractOperationParams(from: message),
               let bodyString = mergedOperationBodyString(params.body) else {
-            sendBridgeError("Invalid payload: missing or empty operation", action: message.action, id: message.id)
+            sendBridgeError("Invalid payload: could not parse operation/body or encode the operation body", action: message.action, id: message.id)
             return
         }
 

--- a/Mindbox/InAppMessages/Presentation/Views/WebView/WebViewController.swift
+++ b/Mindbox/InAppMessages/Presentation/Views/WebView/WebViewController.swift
@@ -64,7 +64,7 @@ final class WebViewController: UIViewController, InappViewControllerProtocol {
         onError: @escaping (InAppPresentationError) -> Void,
         windowProvider: @escaping () -> UIWindow? = WebViewController.defaultWindowProvider,
         operation: (name: String, body: String)?,
-        tags: [String: String]? = nil
+        tags: [String: String]?
     ) {
         self.model = model
         self.id = id

--- a/Mindbox/InAppMessages/Presentation/Views/WebView/WebViewController.swift
+++ b/Mindbox/InAppMessages/Presentation/Views/WebView/WebViewController.swift
@@ -35,6 +35,7 @@ final class WebViewController: UIViewController, InappViewControllerProtocol {
     private let id: String
     private let imagesDict: [String: UIImage]
     private let operation: (name: String, body: String)?
+    private let tags: [String: String]?
 
     private let onPresented: () -> Void
     private let onCloseInApp: () -> Void
@@ -62,12 +63,14 @@ final class WebViewController: UIViewController, InappViewControllerProtocol {
         onCloseInApp: @escaping () -> Void,
         onError: @escaping (InAppPresentationError) -> Void,
         windowProvider: @escaping () -> UIWindow? = WebViewController.defaultWindowProvider,
-        operation: (name: String, body: String)?
+        operation: (name: String, body: String)?,
+        tags: [String: String]? = nil
     ) {
         self.model = model
         self.id = id
         self.imagesDict = imagesDict
         self.operation = operation
+        self.tags = tags
         self.onPresented = onPresented
         self.onCloseInApp = onCloseInApp
         self.onError = onError
@@ -96,7 +99,7 @@ final class WebViewController: UIViewController, InappViewControllerProtocol {
 
         switch layer {
         case .webview(let webviewLayer):
-            let webView = TransparentView(frame: .zero, params: webviewLayer.params, userAgent: createUserAgent(), operation: operation, inAppId: id)
+            let webView = TransparentView(frame: .zero, params: webviewLayer.params, userAgent: createUserAgent(), operation: operation, inAppId: id, tags: tags)
             view.addSubview(webView)
 
             setupConstraints(for: webView, in: view)

--- a/MindboxTests/ConfigParsing/Settings/FeatureTogglesConfigParsingTests.swift
+++ b/MindboxTests/ConfigParsing/Settings/FeatureTogglesConfigParsingTests.swift
@@ -39,7 +39,7 @@ final class FeatureTogglesConfigParsingTests: XCTestCase {
         XCTAssertNotNil(config.featureToggles, "FeatureToggles must be successfully parsed")
         XCTAssertEqual(config.featureToggles?.shouldSendInAppShowError, true, "shouldSendInAppShowError must be true")
 
-        let featureToggleManager = DI.injectOrFail(FeatureToggleManager.self)
+        let featureToggleManager = FeatureToggleManager()
         featureToggleManager.applyFeatureToggles(config.featureToggles)
         XCTAssertTrue(featureToggleManager.isFeatureEnabled(.shouldSendInAppShowError))
     }
@@ -51,7 +51,7 @@ final class FeatureTogglesConfigParsingTests: XCTestCase {
         XCTAssertNotNil(config.featureToggles, "FeatureToggles must be successfully parsed")
         XCTAssertEqual(config.featureToggles?.shouldSendInAppShowError, false, "shouldSendInAppShowError must be false")
 
-        let featureToggleManager = DI.injectOrFail(FeatureToggleManager.self)
+        let featureToggleManager = FeatureToggleManager()
         featureToggleManager.applyFeatureToggles(config.featureToggles)
         XCTAssertFalse(featureToggleManager.isFeatureEnabled(.shouldSendInAppShowError))
     }
@@ -62,7 +62,7 @@ final class FeatureTogglesConfigParsingTests: XCTestCase {
 
         XCTAssertNil(config.featureToggles, "FeatureToggles must be `nil` if the key `featureToggles` is not found")
         
-        let featureToggleManager = DI.injectOrFail(FeatureToggleManager.self)
+        let featureToggleManager = FeatureToggleManager()
         featureToggleManager.applyFeatureToggles(config.featureToggles)
         XCTAssertTrue(featureToggleManager.isFeatureEnabled(.shouldSendInAppShowError))
     }
@@ -73,7 +73,7 @@ final class FeatureTogglesConfigParsingTests: XCTestCase {
 
         XCTAssertNil(config.featureToggles, "FeatureToggles must be `nil` if the type of `featureToggles` is not a `Settings.FeatureToggles`")
         
-        let featureToggleManager = DI.injectOrFail(FeatureToggleManager.self)
+        let featureToggleManager = FeatureToggleManager()
         featureToggleManager.applyFeatureToggles(config.featureToggles)
         XCTAssertTrue(featureToggleManager.isFeatureEnabled(.shouldSendInAppShowError))
     }
@@ -84,7 +84,7 @@ final class FeatureTogglesConfigParsingTests: XCTestCase {
 
         XCTAssertNotNil(config.featureToggles, "FeatureToggles must be successfully parsed")
         
-        let featureToggleManager = DI.injectOrFail(FeatureToggleManager.self)
+        let featureToggleManager = FeatureToggleManager()
         featureToggleManager.applyFeatureToggles(config.featureToggles)
         XCTAssertTrue(featureToggleManager.isFeatureEnabled(.shouldSendInAppShowError))
     }
@@ -95,7 +95,7 @@ final class FeatureTogglesConfigParsingTests: XCTestCase {
 
         XCTAssertNotNil(config.featureToggles, "FeatureToggles must be successfully parsed")
 
-        let featureToggleManager = DI.injectOrFail(FeatureToggleManager.self)
+        let featureToggleManager = FeatureToggleManager()
         featureToggleManager.applyFeatureToggles(config.featureToggles)
         XCTAssertTrue(featureToggleManager.isFeatureEnabled(.shouldSendInAppShowError))
     }
@@ -109,7 +109,7 @@ final class FeatureTogglesConfigParsingTests: XCTestCase {
         XCTAssertNotNil(config.featureToggles, "FeatureToggles must be successfully parsed")
         XCTAssertEqual(config.featureToggles?.shouldSendInAppTags, true, "shouldSendInAppTags must be true")
 
-        let featureToggleManager = DI.injectOrFail(FeatureToggleManager.self)
+        let featureToggleManager = FeatureToggleManager()
         featureToggleManager.applyFeatureToggles(config.featureToggles)
         XCTAssertTrue(featureToggleManager.isFeatureEnabled(.shouldSendInAppTags))
     }
@@ -121,7 +121,7 @@ final class FeatureTogglesConfigParsingTests: XCTestCase {
         XCTAssertNotNil(config.featureToggles, "FeatureToggles must be successfully parsed")
         XCTAssertEqual(config.featureToggles?.shouldSendInAppTags, false, "shouldSendInAppTags must be false")
 
-        let featureToggleManager = DI.injectOrFail(FeatureToggleManager.self)
+        let featureToggleManager = FeatureToggleManager()
         featureToggleManager.applyFeatureToggles(config.featureToggles)
         XCTAssertFalse(featureToggleManager.isFeatureEnabled(.shouldSendInAppTags))
     }
@@ -132,7 +132,7 @@ final class FeatureTogglesConfigParsingTests: XCTestCase {
 
         XCTAssertNotNil(config.featureToggles, "FeatureToggles must be successfully parsed")
 
-        let featureToggleManager = DI.injectOrFail(FeatureToggleManager.self)
+        let featureToggleManager = FeatureToggleManager()
         featureToggleManager.applyFeatureToggles(config.featureToggles)
         XCTAssertTrue(featureToggleManager.isFeatureEnabled(.shouldSendInAppTags))
     }
@@ -143,7 +143,7 @@ final class FeatureTogglesConfigParsingTests: XCTestCase {
 
         XCTAssertNotNil(config.featureToggles, "FeatureToggles must be successfully parsed")
 
-        let featureToggleManager = DI.injectOrFail(FeatureToggleManager.self)
+        let featureToggleManager = FeatureToggleManager()
         featureToggleManager.applyFeatureToggles(config.featureToggles)
         XCTAssertTrue(featureToggleManager.isFeatureEnabled(.shouldSendInAppTags))
     }

--- a/MindboxTests/ConfigParsing/Settings/FeatureTogglesConfigParsingTests.swift
+++ b/MindboxTests/ConfigParsing/Settings/FeatureTogglesConfigParsingTests.swift
@@ -23,6 +23,9 @@ fileprivate enum FeatureTogglesConfig: String, Configurable {
     case settingsFeatureTogglesShouldSendInAppShowErrorMissing = "SettingsFeatureTogglesShouldSendInAppShowErrorMissing" // Missing `shouldSendInAppShowError`
     case settingsFeatureTogglesShouldSendInAppShowErrorTypeError = "SettingsFeatureTogglesShouldSendInAppShowErrorTypeError" // Type of `shouldSendInAppShowError` is String instead of Bool
     case settingsFeatureTogglesShouldSendInAppShowErrorFalse = "SettingsFeatureTogglesShouldSendInAppShowErrorFalse" // `shouldSendInAppShowError` is false
+
+    case settingsFeatureTogglesShouldSendInAppTagsFalse = "SettingsFeatureTogglesShouldSendInAppTagsFalse" // `shouldSendInAppTags` is false
+    case settingsFeatureTogglesShouldSendInAppTagsTypeError = "SettingsFeatureTogglesShouldSendInAppTagsTypeError" // Type of `shouldSendInAppTags` is String instead of Bool
 }
 
 final class FeatureTogglesConfigParsingTests: XCTestCase {
@@ -91,9 +94,56 @@ final class FeatureTogglesConfigParsingTests: XCTestCase {
         let config = try! FeatureTogglesConfig.settingsFeatureTogglesShouldSendInAppShowErrorTypeError.getConfig()
 
         XCTAssertNotNil(config.featureToggles, "FeatureToggles must be successfully parsed")
-        
+
         let featureToggleManager = DI.injectOrFail(FeatureToggleManager.self)
         featureToggleManager.applyFeatureToggles(config.featureToggles)
         XCTAssertTrue(featureToggleManager.isFeatureEnabled(.shouldSendInAppShowError))
+    }
+
+    // MARK: - FeatureToggles: MobileSdkShouldSendInAppTags
+
+    func test_SettingsConfig_withFeatureTogglesTagsTrue_shouldParseSuccessfully() {
+        // `shouldSendInAppTags` is true
+        let config = try! FeatureTogglesConfig.configWithSettings.getConfig()
+
+        XCTAssertNotNil(config.featureToggles, "FeatureToggles must be successfully parsed")
+
+        let featureToggleManager = DI.injectOrFail(FeatureToggleManager.self)
+        featureToggleManager.applyFeatureToggles(config.featureToggles)
+        XCTAssertTrue(featureToggleManager.isFeatureEnabled(.shouldSendInAppTags))
+    }
+
+    func test_SettingsConfig_withFeatureTogglesTagsFalse_shouldParseSuccessfully() {
+        // `shouldSendInAppTags` is false
+        let config = try! FeatureTogglesConfig.settingsFeatureTogglesShouldSendInAppTagsFalse.getConfig()
+
+        XCTAssertNotNil(config.featureToggles, "FeatureToggles must be successfully parsed")
+        XCTAssertEqual(config.featureToggles?.shouldSendInAppTags, false, "shouldSendInAppTags must be false")
+
+        let featureToggleManager = DI.injectOrFail(FeatureToggleManager.self)
+        featureToggleManager.applyFeatureToggles(config.featureToggles)
+        XCTAssertFalse(featureToggleManager.isFeatureEnabled(.shouldSendInAppTags))
+    }
+
+    func test_SettingsConfig_withFeatureTogglesMissingShouldSendInAppTags_shouldDefaultToTrue() {
+        // Missing `shouldSendInAppTags`
+        let config = try! FeatureTogglesConfig.settingsFeatureTogglesShouldSendInAppShowErrorMissing.getConfig()
+
+        XCTAssertNotNil(config.featureToggles, "FeatureToggles must be successfully parsed")
+
+        let featureToggleManager = DI.injectOrFail(FeatureToggleManager.self)
+        featureToggleManager.applyFeatureToggles(config.featureToggles)
+        XCTAssertTrue(featureToggleManager.isFeatureEnabled(.shouldSendInAppTags))
+    }
+
+    func test_SettingsConfig_withFeatureTogglesShouldSendInAppTagsTypeError_shouldDefaultToTrue() {
+        // Type of `shouldSendInAppTags` is String instead of Bool
+        let config = try! FeatureTogglesConfig.settingsFeatureTogglesShouldSendInAppTagsTypeError.getConfig()
+
+        XCTAssertNotNil(config.featureToggles, "FeatureToggles must be successfully parsed")
+
+        let featureToggleManager = DI.injectOrFail(FeatureToggleManager.self)
+        featureToggleManager.applyFeatureToggles(config.featureToggles)
+        XCTAssertTrue(featureToggleManager.isFeatureEnabled(.shouldSendInAppTags))
     }
 }

--- a/MindboxTests/ConfigParsing/Settings/FeatureTogglesConfigParsingTests.swift
+++ b/MindboxTests/ConfigParsing/Settings/FeatureTogglesConfigParsingTests.swift
@@ -107,6 +107,7 @@ final class FeatureTogglesConfigParsingTests: XCTestCase {
         let config = try! FeatureTogglesConfig.configWithSettings.getConfig()
 
         XCTAssertNotNil(config.featureToggles, "FeatureToggles must be successfully parsed")
+        XCTAssertEqual(config.featureToggles?.shouldSendInAppTags, true, "shouldSendInAppTags must be true")
 
         let featureToggleManager = DI.injectOrFail(FeatureToggleManager.self)
         featureToggleManager.applyFeatureToggles(config.featureToggles)

--- a/MindboxTests/ConfigParsing/stubs/Settings/SettingsJsonStubs/FeatureTogglesError/SettingsFeatureTogglesShouldSendInAppTagsFalse.json
+++ b/MindboxTests/ConfigParsing/stubs/Settings/SettingsJsonStubs/FeatureTogglesError/SettingsFeatureTogglesShouldSendInAppTagsFalse.json
@@ -1,0 +1,28 @@
+{
+  "operations": {
+    "viewProduct": {
+      "systemName": "ProductView"
+    },
+    "viewCategory": {
+      "systemName": "CategoryView"
+    },
+    "setCart": {
+      "systemName": "SetCart"
+    }
+  },
+  "ttl": {
+    "inapps": "0.00:00:10"
+  },
+  "slidingExpiration": {
+    "config": "0.00:00:10",
+    "pushTokenKeepalive": "0.00:00:10"
+  },
+  "inapp": {
+    "maxInappsPerSession": 1,
+    "maxInappsPerDay": 1,
+    "minIntervalBetweenShows": "0.00:00:10"
+  },
+  "featureToggles": {
+    "MobileSdkShouldSendInAppTags": false
+  }
+}

--- a/MindboxTests/ConfigParsing/stubs/Settings/SettingsJsonStubs/FeatureTogglesError/SettingsFeatureTogglesShouldSendInAppTagsTypeError.json
+++ b/MindboxTests/ConfigParsing/stubs/Settings/SettingsJsonStubs/FeatureTogglesError/SettingsFeatureTogglesShouldSendInAppTagsTypeError.json
@@ -1,0 +1,28 @@
+{
+  "operations": {
+    "viewProduct": {
+      "systemName": "ProductView"
+    },
+    "viewCategory": {
+      "systemName": "CategoryView"
+    },
+    "setCart": {
+      "systemName": "SetCart"
+    }
+  },
+  "ttl": {
+    "inapps": "0.00:00:10"
+  },
+  "slidingExpiration": {
+    "config": "0.00:00:10",
+    "pushTokenKeepalive": "0.00:00:10"
+  },
+  "inapp": {
+    "maxInappsPerSession": 1,
+    "maxInappsPerDay": 1,
+    "minIntervalBetweenShows": "0.00:00:10"
+  },
+  "featureToggles": {
+    "MobileSdkShouldSendInAppTags": "yes"
+  }
+}

--- a/MindboxTests/ConfigParsing/stubs/Settings/SettingsJsonStubs/SettingsConfig.json
+++ b/MindboxTests/ConfigParsing/stubs/Settings/SettingsJsonStubs/SettingsConfig.json
@@ -23,7 +23,8 @@
     "minIntervalBetweenShows": "0.00:00:10"
   },
   "featureToggles": {
-    "MobileSdkShouldSendInAppShowError": true
+    "MobileSdkShouldSendInAppShowError": true,
+    "MobileSdkShouldSendInAppTags": true
   },
   "baseAddresses": {
     "operations": "anonymizer-demo-api-regular.mindbox.ru"

--- a/MindboxTests/Extensions/Tag+Extensions.swift
+++ b/MindboxTests/Extensions/Tag+Extensions.swift
@@ -27,4 +27,5 @@ extension Tag {
     @Tag static var trackVisit: Self
     @Tag static var operationsRouting: Self
     @Tag static var mbConfiguration: Self
+    @Tag static var inAppTags: Self
 }

--- a/MindboxTests/InApp/Tests/InAppConfigResponseTests/ConfigJsonStubs/ConfigTargetings/Tags-FailedTargeting.json
+++ b/MindboxTests/InApp/Tests/InAppConfigResponseTests/ConfigJsonStubs/ConfigTargetings/Tags-FailedTargeting.json
@@ -1,0 +1,197 @@
+{
+  "settings": {
+    "operations": {
+      "viewProduct": {
+        "systemName": "viewProduct"
+      }
+    }
+  },
+  "inapps": [
+    {
+      "id": "1",
+      "sdkVersion": {
+        "min": 8,
+        "max": null
+      },
+      "targeting": {
+        "nodes": [
+          {
+            "kind": "positive",
+            "segmentationInternalId": "42",
+            "segmentationExternalId": "79ff415d-5bcf-45c8-ba78-bbf559083b5b",
+            "segmentExternalId": "79ff415d-5bcf-45c8-ba78-bbf559083b5b",
+            "$type": "segment"
+          }
+        ],
+        "$type": "and"
+      },
+      "form": {
+        "variants": [
+          {
+            "content": {
+              "background": {
+                "layers": [
+                  {
+                    "action": {
+                      "intentPayload": "",
+                      "value": "",
+                      "$type": "redirectUrl"
+                    },
+                    "source": {
+                      "value": "https://personalization-web-stable.mindbox.ru/user-media/29836/e17b389b8fcd5819c15933de78398dcb65769ae44483d4ac6807781e2bf7781d.png",
+                      "$type": "url"
+                    },
+                    "$type": "image"
+                  }
+                ]
+              },
+              "position": {
+                "margin": {
+                  "kind": "dp",
+                  "top": 0.0,
+                  "right": 20.0,
+                  "left": 20.0,
+                  "bottom": 0.0
+                },
+                "gravity": {
+                  "horizontal": "center",
+                  "vertical": "top"
+                }
+              },
+              "elements": []
+            },
+            "imageUrl": "",
+            "redirectUrl": "",
+            "intentPayload": "",
+            "$type": "snackbar"
+          }
+        ]
+      },
+      "tags": {
+        "templateType": "Popup",
+        "abTestVariant": "control"
+      }
+    },
+    {
+      "id": "2",
+      "sdkVersion": {
+        "min": 8,
+        "max": null
+      },
+      "targeting": {
+        "nodes": [
+          {
+            "$type": "true"
+          }
+        ],
+        "$type": "and"
+      },
+      "form": {
+        "variants": [
+          {
+            "content": {
+              "background": {
+                "layers": [
+                  {
+                    "action": {
+                      "intentPayload": "",
+                      "value": "",
+                      "$type": "redirectUrl"
+                    },
+                    "source": {
+                      "value": "https://personalization-web-stable.mindbox.ru/user-media/29836/e17b389b8fcd5819c15933de78398dcb65769ae44483d4ac6807781e2bf7781d.png",
+                      "$type": "url"
+                    },
+                    "$type": "image"
+                  }
+                ]
+              },
+              "position": {
+                "margin": {
+                  "kind": "dp",
+                  "top": 0.0,
+                  "right": 20.0,
+                  "left": 20.0,
+                  "bottom": 0.0
+                },
+                "gravity": {
+                  "horizontal": "center",
+                  "vertical": "top"
+                }
+              },
+              "elements": []
+            },
+            "imageUrl": "",
+            "redirectUrl": "",
+            "intentPayload": "",
+            "$type": "snackbar"
+          }
+        ]
+      },
+      "tags": {
+        "templateType": "Snackbar"
+      }
+    },
+    {
+      "id": "3",
+      "sdkVersion": {
+        "min": 8,
+        "max": null
+      },
+      "targeting": {
+        "nodes": [
+          {
+            "kind": "positive",
+            "segmentationInternalId": "42",
+            "segmentationExternalId": "79ff415d-5bcf-45c8-ba78-bbf559083b5b",
+            "segmentExternalId": "79ff415d-5bcf-45c8-ba78-bbf559083b5b",
+            "$type": "segment"
+          }
+        ],
+        "$type": "and"
+      },
+      "form": {
+        "variants": [
+          {
+            "content": {
+              "background": {
+                "layers": [
+                  {
+                    "action": {
+                      "intentPayload": "",
+                      "value": "",
+                      "$type": "redirectUrl"
+                    },
+                    "source": {
+                      "value": "https://personalization-web-stable.mindbox.ru/user-media/29836/e17b389b8fcd5819c15933de78398dcb65769ae44483d4ac6807781e2bf7781d.png",
+                      "$type": "url"
+                    },
+                    "$type": "image"
+                  }
+                ]
+              },
+              "position": {
+                "margin": {
+                  "kind": "dp",
+                  "top": 0.0,
+                  "right": 20.0,
+                  "left": 20.0,
+                  "bottom": 0.0
+                },
+                "gravity": {
+                  "horizontal": "center",
+                  "vertical": "top"
+                }
+              },
+              "elements": []
+            },
+            "imageUrl": "",
+            "redirectUrl": "",
+            "intentPayload": "",
+            "$type": "snackbar"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/MindboxTests/InApp/Tests/InAppConfigResponseTests/InappMapperTests.swift
+++ b/MindboxTests/InApp/Tests/InAppConfigResponseTests/InappMapperTests.swift
@@ -26,6 +26,7 @@ fileprivate enum InappTargetingConfig: String, Configurable {
     case fortyFourTargeting            = "44-Targeting"
     case fortyFiveTargeting            = "45-Targeting"
     case fortySixTargeting             = "46-Targeting"
+    case tagsFailedTargeting           = "Tags-FailedTargeting"
 }
 
 // MARK: - Suite
@@ -58,6 +59,7 @@ struct InappRemainingTargetingTests {
         self.mockDataFacade = mock
         self.mockDataFacade.cleanTargetingArray()
         self.mockDataFacade.cleanImageDownloadFailures()
+        self.mockDataFacade.cleanCollectedTargetingFailureIds()
 
         self.mapper = DI.injectOrFail(InappMapperProtocol.self)
         self.persistenceStorage = DI.injectOrFail(PersistenceStorage.self)
@@ -154,6 +156,31 @@ struct InappRemainingTargetingTests {
         assertTargetingEquals(ids: ["1", "2"])
     }
     
+    @Test("Failed targeting collects tags only for failed in-apps that have them", .tags(.remainingTargeting, .inAppTags))
+    func failedTargeting_collectsTagsOnlyForFailedInappsWithTags() async throws {
+        let config = try InappTargetingConfig.tagsFailedTargeting.getConfig()
+
+        await handleInapps(event: nil, config: config)
+
+        // In-apps "1" (with tags) and "3" (without tags) fail segment targeting, "2" passes.
+        #expect(mockDataFacade.collectedTargetingFailureIds == [Set(["1", "3"])])
+        #expect(mockDataFacade.collectedTagsByInappId == [
+            ["1": ["templateType": "Popup", "abTestVariant": "control"]]
+        ])
+    }
+
+    @Test("Shown in-app propagates its tags into trackTargeting and downloadImage", .tags(.remainingTargeting, .inAppTags))
+    func shownInapp_propagatesTagsToTrackTargetingAndDownloadImage() async throws {
+        let config = try InappTargetingConfig.tagsFailedTargeting.getConfig()
+
+        await handleInapps(event: nil, config: config)
+
+        assertTargetingShows(id: "2")
+        let trackedTags = mockDataFacade.trackTargetingCalls.first(where: { $0.id == "2" })?.tags
+        #expect(trackedTags == ["templateType": "Snackbar"])
+        #expect(mockDataFacade.downloadImageTags["2"] == ["templateType": "Snackbar"])
+    }
+
     @Test("Image download error adds in-app show failure", .tags(.remainingTargeting))
     func imageDownloadError_addsFailure() async throws {
         let config = try InappTargetingConfig.oneTargeting.getConfig()

--- a/MindboxTests/InApp/Tests/InAppMessagesTrackerTests.swift
+++ b/MindboxTests/InApp/Tests/InAppMessagesTrackerTests.swift
@@ -72,16 +72,9 @@ final class InAppMessagesTrackerTests {
     }
 
     private func applyTagsToggle(enabled: Bool) {
-        let settingsJSON = """
-        {
-          "featureToggles": {
-            "MobileSdkShouldSendInAppTags": \(enabled ? "true" : "false")
-          }
-        }
-        """
-        let settingsData = settingsJSON.data(using: .utf8) ?? Data()
-        let settings = try? JSONDecoder().decode(Settings.self, from: settingsData)
-        featureToggleManager.applyFeatureToggles(settings?.featureToggles)
+        featureToggleManager.applyFeatureToggles(
+            Settings.FeatureToggles(shouldSendInAppShowError: nil, shouldSendInAppTags: enabled)
+        )
     }
 }
 

--- a/MindboxTests/InApp/Tests/InAppMessagesTrackerTests.swift
+++ b/MindboxTests/InApp/Tests/InAppMessagesTrackerTests.swift
@@ -26,6 +26,17 @@ final class InAppMessagesTrackerTests {
         return BodyDecoder<DecodedBody>(decodable: event.body)?.body
     }
 
+    /// Returns the top-level keys of the encoded event body. Used to assert that the
+    /// `tags` key is entirely absent (not merely `null`), which is what the contract requires.
+    private func bodyKeys() -> Set<String>? {
+        guard let event = databaseRepository.createdEvents.first,
+              let data = event.body.data(using: .utf8),
+              let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            return nil
+        }
+        return Set(object.keys)
+    }
+
     @Test("trackView includes tags when the feature is enabled", .tags(.inAppTags))
     func trackViewIncludesTagsWhenEnabled() throws {
         try tracker.trackView(id: "inapp-1", timeToDisplay: "150", tags: ["templateType": "Popup"])
@@ -36,7 +47,7 @@ final class InAppMessagesTrackerTests {
     func trackViewOmitsTagsWhenDisabled() throws {
         applyTagsToggle(enabled: false)
         try tracker.trackView(id: "inapp-1", timeToDisplay: "150", tags: ["templateType": "Popup"])
-        #expect(decodedBody()?.tags == nil)
+        #expect(bodyKeys()?.contains("tags") == false)
     }
 
     @Test("trackClick includes tags when the feature is enabled", .tags(.inAppTags))
@@ -49,7 +60,7 @@ final class InAppMessagesTrackerTests {
     func trackClickOmitsTagsWhenDisabled() throws {
         applyTagsToggle(enabled: false)
         try tracker.trackClick(id: "inapp-2", tags: ["templateType": "Snackbar"])
-        #expect(decodedBody()?.tags == nil)
+        #expect(bodyKeys()?.contains("tags") == false)
     }
 
     @Test("trackTargeting includes tags when the feature is enabled", .tags(.inAppTags))
@@ -62,13 +73,13 @@ final class InAppMessagesTrackerTests {
     func trackTargetingOmitsTagsWhenDisabled() throws {
         applyTagsToggle(enabled: false)
         try tracker.trackTargeting(id: "inapp-3", tags: ["templateType": "Modal"])
-        #expect(decodedBody()?.tags == nil)
+        #expect(bodyKeys()?.contains("tags") == false)
     }
 
     @Test("trackClick omits tags when nil tags are passed", .tags(.inAppTags))
     func trackClickOmitsNilTags() throws {
         try tracker.trackClick(id: "inapp-4", tags: nil)
-        #expect(decodedBody()?.tags == nil)
+        #expect(bodyKeys()?.contains("tags") == false)
     }
 
     private func applyTagsToggle(enabled: Bool) {

--- a/MindboxTests/InApp/Tests/InAppMessagesTrackerTests.swift
+++ b/MindboxTests/InApp/Tests/InAppMessagesTrackerTests.swift
@@ -1,0 +1,110 @@
+//
+//  InAppMessagesTrackerTests.swift
+//  MindboxTests
+//
+//  Created by Akylbek Utekeshev on 01.07.2026.
+//  Copyright © 2026 Mindbox. All rights reserved.
+//
+
+import Testing
+@testable import Mindbox
+
+@Suite("InAppMessagesTracker tags gating tests")
+final class InAppMessagesTrackerTests {
+    private struct DecodedBody: Decodable {
+        let inappId: String
+        let timeToDisplay: String?
+        let tags: [String: String]?
+    }
+
+    private let databaseRepository = InAppMessagesTrackerDatabaseRepositoryMock()
+    private let featureToggleManager = FeatureToggleManager()
+    private lazy var tracker = InAppMessagesTracker(databaseRepository: databaseRepository, featureToggleManager: featureToggleManager)
+
+    private func decodedBody() -> DecodedBody? {
+        guard let event = databaseRepository.createdEvents.first else { return nil }
+        return BodyDecoder<DecodedBody>(decodable: event.body)?.body
+    }
+
+    @Test("trackView includes tags when the feature is enabled", .tags(.inAppTags))
+    func trackViewIncludesTagsWhenEnabled() throws {
+        try tracker.trackView(id: "inapp-1", timeToDisplay: "150", tags: ["templateType": "Popup"])
+        #expect(decodedBody()?.tags == ["templateType": "Popup"])
+    }
+
+    @Test("trackView omits tags when the feature is disabled", .tags(.inAppTags))
+    func trackViewOmitsTagsWhenDisabled() throws {
+        applyTagsToggle(enabled: false)
+        try tracker.trackView(id: "inapp-1", timeToDisplay: "150", tags: ["templateType": "Popup"])
+        #expect(decodedBody()?.tags == nil)
+    }
+
+    @Test("trackClick includes tags when the feature is enabled", .tags(.inAppTags))
+    func trackClickIncludesTagsWhenEnabled() throws {
+        try tracker.trackClick(id: "inapp-2", tags: ["templateType": "Snackbar"])
+        #expect(decodedBody()?.tags == ["templateType": "Snackbar"])
+    }
+
+    @Test("trackClick omits tags when the feature is disabled", .tags(.inAppTags))
+    func trackClickOmitsTagsWhenDisabled() throws {
+        applyTagsToggle(enabled: false)
+        try tracker.trackClick(id: "inapp-2", tags: ["templateType": "Snackbar"])
+        #expect(decodedBody()?.tags == nil)
+    }
+
+    @Test("trackTargeting includes tags when the feature is enabled", .tags(.inAppTags))
+    func trackTargetingIncludesTagsWhenEnabled() throws {
+        try tracker.trackTargeting(id: "inapp-3", tags: ["templateType": "Modal"])
+        #expect(decodedBody()?.tags == ["templateType": "Modal"])
+    }
+
+    @Test("trackTargeting omits tags when the feature is disabled", .tags(.inAppTags))
+    func trackTargetingOmitsTagsWhenDisabled() throws {
+        applyTagsToggle(enabled: false)
+        try tracker.trackTargeting(id: "inapp-3", tags: ["templateType": "Modal"])
+        #expect(decodedBody()?.tags == nil)
+    }
+
+    @Test("trackClick omits tags when nil tags are passed", .tags(.inAppTags))
+    func trackClickOmitsNilTags() throws {
+        try tracker.trackClick(id: "inapp-4", tags: nil)
+        #expect(decodedBody()?.tags == nil)
+    }
+
+    private func applyTagsToggle(enabled: Bool) {
+        let settingsJSON = """
+        {
+          "featureToggles": {
+            "MobileSdkShouldSendInAppTags": \(enabled ? "true" : "false")
+          }
+        }
+        """
+        let settingsData = settingsJSON.data(using: .utf8) ?? Data()
+        let settings = try? JSONDecoder().decode(Settings.self, from: settingsData)
+        featureToggleManager.applyFeatureToggles(settings?.featureToggles)
+    }
+}
+
+private final class InAppMessagesTrackerDatabaseRepositoryMock: DatabaseRepositoryProtocol {
+    var limit: Int = 0
+    var lifeLimitDate: Date?
+    var deprecatedLimit: Int = 0
+    var onObjectsDidChange: (() -> Void)?
+    private(set) var createdEvents: [Event] = []
+
+    func create(event: Event) throws {
+        createdEvents.append(event)
+    }
+
+    func readEvent(by transactionId: String) throws -> Event? {
+        createdEvents.first(where: { $0.transactionId == transactionId })
+    }
+
+    func update(event: Event) throws {}
+    func delete(event: Event) throws {}
+    func query(fetchLimit: Int, retryDeadline: TimeInterval) throws -> [Event] { [] }
+    func removeDeprecatedEventsIfNeeded() throws {}
+    func countDeprecatedEvents() throws -> Int { 0 }
+    func erase() throws { createdEvents.removeAll() }
+    func countEvents() throws -> Int { createdEvents.count }
+}

--- a/MindboxTests/InApp/Tests/InAppTagsGatingTests.swift
+++ b/MindboxTests/InApp/Tests/InAppTagsGatingTests.swift
@@ -1,0 +1,39 @@
+//
+//  InAppTagsGatingTests.swift
+//  MindboxTests
+//
+//  Created by Akylbek Utekeshev on 01.07.2026.
+//  Copyright © 2026 Mindbox. All rights reserved.
+//
+
+import Testing
+@testable import Mindbox
+
+@Suite("gatedTags pure function tests")
+struct InAppTagsGatingTests {
+
+    @Test("Returns tags unchanged when feature is enabled and tags are non-empty", .tags(.inAppTags))
+    func returnsTagsWhenEnabled() {
+        let tags: [String: String]? = ["templateType": "Popup"]
+        #expect(tags.gatedTags(isTagsFeatureEnabled: true) == tags)
+    }
+
+    @Test("Returns nil when feature is disabled, even with non-empty tags", .tags(.inAppTags))
+    func returnsNilWhenDisabled() {
+        let tags: [String: String]? = ["templateType": "Popup"]
+        #expect(tags.gatedTags(isTagsFeatureEnabled: false) == nil)
+    }
+
+    @Test("Returns nil when tags are nil, regardless of feature state", .tags(.inAppTags))
+    func returnsNilWhenTagsNil() {
+        let tags: [String: String]? = nil
+        #expect(tags.gatedTags(isTagsFeatureEnabled: true) == nil)
+        #expect(tags.gatedTags(isTagsFeatureEnabled: false) == nil)
+    }
+
+    @Test("Returns nil when tags are empty, even when feature is enabled", .tags(.inAppTags))
+    func returnsNilWhenTagsEmpty() {
+        let tags: [String: String]? = [:]
+        #expect(tags.gatedTags(isTagsFeatureEnabled: true) == nil)
+    }
+}

--- a/MindboxTests/InApp/Tests/InAppTagsGatingTests.swift
+++ b/MindboxTests/InApp/Tests/InAppTagsGatingTests.swift
@@ -15,25 +15,25 @@ struct InAppTagsGatingTests {
     @Test("Returns tags unchanged when feature is enabled and tags are non-empty", .tags(.inAppTags))
     func returnsTagsWhenEnabled() {
         let tags: [String: String]? = ["templateType": "Popup"]
-        #expect(tags.gatedTags(isTagsFeatureEnabled: true) == tags)
+        #expect(FeatureToggleManager.gatedTags(tags, isEnabled: true) == tags)
     }
 
     @Test("Returns nil when feature is disabled, even with non-empty tags", .tags(.inAppTags))
     func returnsNilWhenDisabled() {
         let tags: [String: String]? = ["templateType": "Popup"]
-        #expect(tags.gatedTags(isTagsFeatureEnabled: false) == nil)
+        #expect(FeatureToggleManager.gatedTags(tags, isEnabled: false) == nil)
     }
 
     @Test("Returns nil when tags are nil, regardless of feature state", .tags(.inAppTags))
     func returnsNilWhenTagsNil() {
         let tags: [String: String]? = nil
-        #expect(tags.gatedTags(isTagsFeatureEnabled: true) == nil)
-        #expect(tags.gatedTags(isTagsFeatureEnabled: false) == nil)
+        #expect(FeatureToggleManager.gatedTags(tags, isEnabled: true) == nil)
+        #expect(FeatureToggleManager.gatedTags(tags, isEnabled: false) == nil)
     }
 
     @Test("Returns nil when tags are empty, even when feature is enabled", .tags(.inAppTags))
     func returnsNilWhenTagsEmpty() {
         let tags: [String: String]? = [:]
-        #expect(tags.gatedTags(isTagsFeatureEnabled: true) == nil)
+        #expect(FeatureToggleManager.gatedTags(tags, isEnabled: true) == nil)
     }
 }

--- a/MindboxTests/InApp/Tests/InappConfigurationDataFacade/InappConfigurationDataFacadeTests.swift
+++ b/MindboxTests/InApp/Tests/InappConfigurationDataFacade/InappConfigurationDataFacadeTests.swift
@@ -43,10 +43,10 @@ final class MockSegmentationService: SegmentationServiceProtocol {
 }
 
 final class MockInappShowFailureManager: InappShowFailureManagerProtocol {
-    private(set) var failures: [(inappId: String, reason: InAppShowFailureReason, details: String?)] = []
+    private(set) var failures: [(inappId: String, reason: InAppShowFailureReason, details: String?, tags: [String: String]?)] = []
 
-    func addFailure(inappId: String, reason: InAppShowFailureReason, details: String?) {
-        failures.append((inappId: inappId, reason: reason, details: details))
+    func addFailure(inappId: String, reason: InAppShowFailureReason, details: String?, tags: [String: String]?) {
+        failures.append((inappId: inappId, reason: reason, details: details, tags: tags))
     }
 
     func clearFailures() {
@@ -193,11 +193,32 @@ final class InAppConfigurationDataFacadeTests: XCTestCase {
         mockSegmentation.stubError = .serverError(.init(status: .internalServerError, errorMessage: "Internal Server error", httpStatusCode: 500))
 
         dataFacade.fetchProductSegmentationIfNeeded(products: products)
-        dataFacade.collectTargetingFailures(forFailedTargetingInappIds: ["inapp-2", "inapp-other"])
+        dataFacade.collectTargetingFailures(forFailedTargetingInappIds: ["inapp-2", "inapp-other"], tagsByInappId: [:])
 
         XCTAssertEqual(mockFailureManager.failures.count, 1)
         XCTAssertEqual(Set(mockFailureManager.failures.map { $0.inappId }), Set(["inapp-2"]))
         XCTAssertTrue(mockFailureManager.failures.allSatisfy { $0.reason == .productSegmentRequestFailed })
+    }
+
+    func test_collectTargetingFailures_propagatesTagsByInappId() {
+        SessionTemporaryStorage.shared.viewProductOperation = "App.ViewProduct".lowercased()
+        let model = decodeInAppOperationJSONModel(from: """
+            { "viewProduct": { "product": { "ids": { "website": "100" } } } }
+        """
+        )
+        let products = model!.viewProduct!.product
+        dataFacade.targetingChecker.event = ApplicationEvent(name: "App.ViewProduct", model: model)
+        dataFacade.targetingChecker.context.productSegmentInapps = ["inapp-tagged"]
+        mockSegmentation.stubError = .serverError(.init(status: .internalServerError, errorMessage: "Internal Server error", httpStatusCode: 500))
+
+        dataFacade.fetchProductSegmentationIfNeeded(products: products)
+        dataFacade.collectTargetingFailures(
+            forFailedTargetingInappIds: ["inapp-tagged"],
+            tagsByInappId: ["inapp-tagged": ["templateType": "Popup"]]
+        )
+
+        XCTAssertEqual(mockFailureManager.failures.count, 1)
+        XCTAssertEqual(mockFailureManager.failures.first?.tags, ["templateType": "Popup"])
     }
 
     func test_doNotAddFailure_whenProductSegmentationReturnsNonServerError() {
@@ -212,7 +233,7 @@ final class InAppConfigurationDataFacadeTests: XCTestCase {
         mockSegmentation.stubError = .protocolError(.init(status: .protocolError, errorMessage: "Bad request", httpStatusCode: 400))
 
         dataFacade.fetchProductSegmentationIfNeeded(products: products)
-        dataFacade.collectTargetingFailures(forFailedTargetingInappIds: ["inapp-1"])
+        dataFacade.collectTargetingFailures(forFailedTargetingInappIds: ["inapp-1"], tagsByInappId: [:])
 
         XCTAssertTrue(mockFailureManager.failures.isEmpty)
     }
@@ -228,7 +249,7 @@ final class InAppConfigurationDataFacadeTests: XCTestCase {
         }
 
         waitForExpectations(timeout: 1)
-        dataFacade.collectTargetingFailures(forFailedTargetingInappIds: ["inapp-segment-2", "inapp-other"])
+        dataFacade.collectTargetingFailures(forFailedTargetingInappIds: ["inapp-segment-2", "inapp-other"], tagsByInappId: [:])
 
         XCTAssertEqual(mockFailureManager.failures.count, 1)
         XCTAssertEqual(Set(mockFailureManager.failures.map { $0.inappId }), Set(["inapp-segment-2"]))
@@ -282,7 +303,7 @@ final class InAppConfigurationDataFacadeTests: XCTestCase {
             firstExpectation.fulfill()
         }
         waitForExpectations(timeout: 1)
-        facade.collectTargetingFailures(forFailedTargetingInappIds: ["inapp-segment"])
+        facade.collectTargetingFailures(forFailedTargetingInappIds: ["inapp-segment"], tagsByInappId: [:])
 
         shouldReturnFailure = false
         let secondExpectation = expectation(description: "second fetch dependencies")
@@ -290,7 +311,7 @@ final class InAppConfigurationDataFacadeTests: XCTestCase {
             secondExpectation.fulfill()
         }
         waitForExpectations(timeout: 1)
-        facade.collectTargetingFailures(forFailedTargetingInappIds: ["inapp-segment"])
+        facade.collectTargetingFailures(forFailedTargetingInappIds: ["inapp-segment"], tagsByInappId: [:])
 
         XCTAssertEqual(requestCallCount, 1)
         XCTAssertEqual(localFailureManager.failures.count, 2)
@@ -309,7 +330,7 @@ final class InAppConfigurationDataFacadeTests: XCTestCase {
         }
 
         waitForExpectations(timeout: 1)
-        dataFacade.collectTargetingFailures(forFailedTargetingInappIds: ["inapp-segment"])
+        dataFacade.collectTargetingFailures(forFailedTargetingInappIds: ["inapp-segment"], tagsByInappId: [:])
 
         XCTAssertTrue(mockFailureManager.failures.isEmpty)
     }
@@ -326,7 +347,7 @@ final class InAppConfigurationDataFacadeTests: XCTestCase {
         }
 
         waitForExpectations(timeout: 1)
-        dataFacade.collectTargetingFailures(forFailedTargetingInappIds: ["inapp-geo", "inapp-other"])
+        dataFacade.collectTargetingFailures(forFailedTargetingInappIds: ["inapp-geo", "inapp-other"], tagsByInappId: [:])
 
         XCTAssertEqual(mockFailureManager.failures.count, 1)
         XCTAssertEqual(mockFailureManager.failures.first?.inappId, "inapp-geo")
@@ -344,7 +365,7 @@ final class InAppConfigurationDataFacadeTests: XCTestCase {
             firstExpectation.fulfill()
         }
         waitForExpectations(timeout: 1)
-        dataFacade.collectTargetingFailures(forFailedTargetingInappIds: ["inapp-geo"])
+        dataFacade.collectTargetingFailures(forFailedTargetingInappIds: ["inapp-geo"], tagsByInappId: [:])
 
         networkFetcher?.error = nil
         let secondExpectation = expectation(description: "second fetch dependencies")
@@ -352,7 +373,7 @@ final class InAppConfigurationDataFacadeTests: XCTestCase {
             secondExpectation.fulfill()
         }
         waitForExpectations(timeout: 1)
-        dataFacade.collectTargetingFailures(forFailedTargetingInappIds: ["inapp-geo"])
+        dataFacade.collectTargetingFailures(forFailedTargetingInappIds: ["inapp-geo"], tagsByInappId: [:])
 
         XCTAssertEqual(mockFailureManager.failures.count, 2)
         XCTAssertTrue(mockFailureManager.failures.allSatisfy { $0.reason == .geoRequestFailed })

--- a/MindboxTests/InApp/Tests/InappScheduleManagerTests.swift
+++ b/MindboxTests/InApp/Tests/InappScheduleManagerTests.swift
@@ -461,6 +461,7 @@ final class InappShowFailureManagerMock: InappShowFailureManagerProtocol {
         let inappId: String
         let reason: InAppShowFailureReason
         let details: String?
+        let tags: [String: String]?
     }
 
     private(set) var addFailureCallCount = 0
@@ -468,9 +469,9 @@ final class InappShowFailureManagerMock: InappShowFailureManagerProtocol {
     private(set) var sendFailuresCallCount = 0
     private(set) var addFailureCalls: [AddFailureCall] = []
 
-    func addFailure(inappId: String, reason: InAppShowFailureReason, details: String?) {
+    func addFailure(inappId: String, reason: InAppShowFailureReason, details: String?, tags: [String: String]?) {
         addFailureCallCount += 1
-        addFailureCalls.append(AddFailureCall(inappId: inappId, reason: reason, details: details))
+        addFailureCalls.append(AddFailureCall(inappId: inappId, reason: reason, details: details, tags: tags))
     }
 
     func clearFailures() {

--- a/MindboxTests/InApp/Tests/InappScheduleManagerTests.swift
+++ b/MindboxTests/InApp/Tests/InappScheduleManagerTests.swift
@@ -364,6 +364,17 @@ struct InappScheduleManagerTests {
         #expect(failureManagerMock.sendFailuresCallCount == 1)
     }
 
+    @Test("In-app error callback propagates the in-app tags into the show failure", .tags(.inAppSchedule, .inAppTags))
+    func presentInapp_onError_propagatesTags() {
+        let tags = ["templateType": "Modal"]
+        let inapp = createInAppFormData(id: "error-tags-id", isPriority: false, delayTime: nil, tags: tags)
+
+        scheduleManager.presentInapp(inapp, stopwatch: ForegroundStopwatch())
+        presentationManagerMock.receivedOnError?(.failedToLoadWindow)
+
+        #expect(failureManagerMock.addFailureCalls.first?.tags == tags)
+    }
+
     @Test("In-app error callback maps error to show failure payload", .tags(.inAppSchedule))
     func presentInapp_onError_mapsToFailureReasonAndDetails() {
         let cases: [(InAppPresentationError, InAppShowFailureReason, String)] = [
@@ -418,7 +429,7 @@ struct InappScheduleManagerTests {
 
     // MARK: - Helpers
 
-    private func createInAppFormData(id: String, isPriority: Bool, delayTime: String?) -> InAppFormData {
+    private func createInAppFormData(id: String, isPriority: Bool, delayTime: String?, tags: [String: String]? = nil) -> InAppFormData {
         let modalVariant = ModalFormVariant(content: createMockContent())
         let content: MindboxFormVariant = .modal(modalVariant)
         let onceFrequency = OnceFrequency(kind: .session)
@@ -431,7 +442,8 @@ struct InappScheduleManagerTests {
             imagesDict: [:],
             firstImageValue: "",
             content: content,
-            frequency: frequency
+            frequency: frequency,
+            tags: tags
         )
     }
 

--- a/MindboxTests/InApp/Tests/InappShowFailureManagerTests.swift
+++ b/MindboxTests/InApp/Tests/InappShowFailureManagerTests.swift
@@ -788,7 +788,8 @@ final class WebViewControllerWindowProviderTests: XCTestCase {
             onCloseInApp: {},
             onError: { _ in },
             windowProvider: { window },
-            operation: nil
+            operation: nil,
+            tags: nil
         )
 
         sut.onInit()

--- a/MindboxTests/InApp/Tests/InappShowFailureManagerTests.swift
+++ b/MindboxTests/InApp/Tests/InappShowFailureManagerTests.swift
@@ -37,7 +37,8 @@ final class InappShowFailureManagerTests: XCTestCase {
         manager.addFailure(
             inappId: "inapp-1",
             reason: .presentationFailed,
-            details: "No window available"
+            details: "No window available",
+            tags: nil
         )
 
         manager.sendFailures()
@@ -57,7 +58,8 @@ final class InappShowFailureManagerTests: XCTestCase {
         manager.addFailure(
             inappId: "inapp-2",
             reason: .unknownError,
-            details: nil
+            details: nil,
+            tags: nil
         )
 
         manager.sendFailures()
@@ -82,12 +84,14 @@ final class InappShowFailureManagerTests: XCTestCase {
         manager.addFailure(
             inappId: "inapp-duplicate",
             reason: .imageDownloadFailed,
-            details: "first"
+            details: "first",
+            tags: nil
         )
         manager.addFailure(
             inappId: "inapp-duplicate",
             reason: .unknownError,
-            details: "second"
+            details: "second",
+            tags: nil
         )
 
         manager.sendFailures()
@@ -104,17 +108,20 @@ final class InappShowFailureManagerTests: XCTestCase {
         manager.addFailure(
             inappId: "inapp-priority",
             reason: .productSegmentRequestFailed,
-            details: "product"
+            details: "product",
+            tags: nil
         )
         manager.addFailure(
             inappId: "inapp-priority",
             reason: .geoRequestFailed,
-            details: "geo"
+            details: "geo",
+            tags: nil
         )
         manager.addFailure(
             inappId: "inapp-priority",
             reason: .customerSegmentRequestFailed,
-            details: "segment"
+            details: "segment",
+            tags: nil
         )
 
         manager.sendFailures()
@@ -131,17 +138,20 @@ final class InappShowFailureManagerTests: XCTestCase {
         manager.addFailure(
             inappId: "inapp-priority-no-downgrade",
             reason: .customerSegmentRequestFailed,
-            details: "segment"
+            details: "segment",
+            tags: nil
         )
         manager.addFailure(
             inappId: "inapp-priority-no-downgrade",
             reason: .geoRequestFailed,
-            details: "geo"
+            details: "geo",
+            tags: nil
         )
         manager.addFailure(
             inappId: "inapp-priority-no-downgrade",
             reason: .productSegmentRequestFailed,
-            details: "product"
+            details: "product",
+            tags: nil
         )
 
         manager.sendFailures()
@@ -158,7 +168,8 @@ final class InappShowFailureManagerTests: XCTestCase {
         manager.addFailure(
             inappId: "inapp-clear",
             reason: .presentationFailed,
-            details: "clear me"
+            details: "clear me",
+            tags: nil
         )
         manager.clearFailures()
         manager.sendFailures()
@@ -170,7 +181,8 @@ final class InappShowFailureManagerTests: XCTestCase {
         manager.addFailure(
             inappId: "inapp-send-success",
             reason: .presentationFailed,
-            details: nil
+            details: nil,
+            tags: nil
         )
 
         manager.sendFailures()
@@ -183,7 +195,8 @@ final class InappShowFailureManagerTests: XCTestCase {
         manager.addFailure(
             inappId: "inapp-retry",
             reason: .unknownError,
-            details: "will retry"
+            details: "will retry",
+            tags: nil
         )
         databaseRepository.createError = InappShowFailureRepositoryError.createFailed
 
@@ -201,7 +214,8 @@ final class InappShowFailureManagerTests: XCTestCase {
         manager.addFailure(
             inappId: "inapp-add-disabled",
             reason: .presentationFailed,
-            details: "should be ignored"
+            details: "should be ignored",
+            tags: nil
         )
         
         applyFeatureToggle(shouldSendInAppShowError: true)
@@ -213,7 +227,7 @@ final class InappShowFailureManagerTests: XCTestCase {
     func testAddFailure_errorDetailsBelowLimit_isNotTruncated() throws {
         let details = String(repeating: "a", count: InappShowFailureManager.errorDetailsLimit - 1)
 
-        manager.addFailure(inappId: "inapp-below-limit", reason: .unknownError, details: details)
+        manager.addFailure(inappId: "inapp-below-limit", reason: .unknownError, details: details, tags: nil)
         manager.sendFailures()
 
         assertCreatedEventsCountEventually(1)
@@ -226,7 +240,7 @@ final class InappShowFailureManagerTests: XCTestCase {
     func testAddFailure_errorDetailsAtLimit_isNotTruncated() throws {
         let details = String(repeating: "b", count: InappShowFailureManager.errorDetailsLimit)
 
-        manager.addFailure(inappId: "inapp-at-limit", reason: .unknownError, details: details)
+        manager.addFailure(inappId: "inapp-at-limit", reason: .unknownError, details: details, tags: nil)
         manager.sendFailures()
 
         assertCreatedEventsCountEventually(1)
@@ -240,7 +254,7 @@ final class InappShowFailureManagerTests: XCTestCase {
         let limit = InappShowFailureManager.errorDetailsLimit
         let details = String(repeating: "c", count: limit + 500)
 
-        manager.addFailure(inappId: "inapp-above-limit", reason: .unknownError, details: details)
+        manager.addFailure(inappId: "inapp-above-limit", reason: .unknownError, details: details, tags: nil)
         manager.sendFailures()
 
         assertCreatedEventsCountEventually(1)
@@ -251,7 +265,7 @@ final class InappShowFailureManagerTests: XCTestCase {
     }
 
     func testAddFailure_errorDetailsNil_remainsNil() throws {
-        manager.addFailure(inappId: "inapp-nil-details", reason: .unknownError, details: nil)
+        manager.addFailure(inappId: "inapp-nil-details", reason: .unknownError, details: nil, tags: nil)
         manager.sendFailures()
 
         assertCreatedEventsCountEventually(1)
@@ -261,7 +275,7 @@ final class InappShowFailureManagerTests: XCTestCase {
     }
 
     func testAddFailure_errorDetailsEmpty_remainsEmpty() throws {
-        manager.addFailure(inappId: "inapp-empty-details", reason: .unknownError, details: "")
+        manager.addFailure(inappId: "inapp-empty-details", reason: .unknownError, details: "", tags: nil)
         manager.sendFailures()
 
         assertCreatedEventsCountEventually(1)
@@ -275,7 +289,7 @@ final class InappShowFailureManagerTests: XCTestCase {
         // Cyrillic 'а' is 2 bytes in UTF-8: total = 2 * limit bytes.
         let details = String(repeating: "а", count: limit)
 
-        manager.addFailure(inappId: "inapp-multibyte", reason: .unknownError, details: details)
+        manager.addFailure(inappId: "inapp-multibyte", reason: .unknownError, details: details, tags: nil)
         manager.sendFailures()
 
         assertCreatedEventsCountEventually(1)
@@ -293,7 +307,7 @@ final class InappShowFailureManagerTests: XCTestCase {
         // Cyrillic 'ё' is 2 bytes — appending it would overflow by 1 byte.
         let details = asciiPrefix + "ё"
 
-        manager.addFailure(inappId: "inapp-no-split", reason: .unknownError, details: details)
+        manager.addFailure(inappId: "inapp-no-split", reason: .unknownError, details: details, tags: nil)
         manager.sendFailures()
 
         assertCreatedEventsCountEventually(1)
@@ -311,7 +325,7 @@ final class InappShowFailureManagerTests: XCTestCase {
         let asciiPrefix = String(repeating: "y", count: limit - 2)
         let details = asciiPrefix + "🙂"
 
-        manager.addFailure(inappId: "inapp-emoji", reason: .unknownError, details: details)
+        manager.addFailure(inappId: "inapp-emoji", reason: .unknownError, details: details, tags: nil)
         manager.sendFailures()
 
         assertCreatedEventsCountEventually(1)
@@ -327,8 +341,8 @@ final class InappShowFailureManagerTests: XCTestCase {
         let limit = InappShowFailureManager.errorDetailsLimit
         let longDetails = String(repeating: "d", count: limit + 200)
 
-        manager.addFailure(inappId: "inapp-priority-truncate", reason: .productSegmentRequestFailed, details: "short")
-        manager.addFailure(inappId: "inapp-priority-truncate", reason: .customerSegmentRequestFailed, details: longDetails)
+        manager.addFailure(inappId: "inapp-priority-truncate", reason: .productSegmentRequestFailed, details: "short", tags: nil)
+        manager.addFailure(inappId: "inapp-priority-truncate", reason: .customerSegmentRequestFailed, details: longDetails, tags: nil)
         manager.sendFailures()
 
         assertCreatedEventsCountEventually(1)
@@ -343,7 +357,8 @@ final class InappShowFailureManagerTests: XCTestCase {
         manager.addFailure(
             inappId: "inapp-toggle-disabled",
             reason: .presentationFailed,
-            details: "disabled"
+            details: "disabled",
+            tags: nil
         )
         applyFeatureToggle(shouldSendInAppShowError: false)
 
@@ -357,6 +372,60 @@ final class InappShowFailureManagerTests: XCTestCase {
         let event = try XCTUnwrap(databaseRepository.createdEvents.first)
         let failure = try XCTUnwrap(decodeFailures(from: event)?.first)
         XCTAssertEqual(failure.inappId, "inapp-toggle-disabled")
+    }
+
+    func testAddFailure_includesTags_whenTagsFeatureEnabled() throws {
+        manager.addFailure(
+            inappId: "inapp-tags-enabled",
+            reason: .presentationFailed,
+            details: nil,
+            tags: ["templateType": "Popup"]
+        )
+        manager.sendFailures()
+
+        assertCreatedEventsCountEventually(1)
+        let event = try XCTUnwrap(databaseRepository.createdEvents.first)
+        let failure = try XCTUnwrap(decodeFailures(from: event)?.first)
+        XCTAssertEqual(failure.tags, ["templateType": "Popup"])
+    }
+
+    func testAddFailure_omitsTags_whenTagsFeatureDisabled() throws {
+        applyTagsFeatureToggle(shouldSendInAppTags: false)
+
+        manager.addFailure(
+            inappId: "inapp-tags-disabled",
+            reason: .presentationFailed,
+            details: nil,
+            tags: ["templateType": "Popup"]
+        )
+        manager.sendFailures()
+
+        assertCreatedEventsCountEventually(1)
+        let event = try XCTUnwrap(databaseRepository.createdEvents.first)
+        let failure = try XCTUnwrap(decodeFailures(from: event)?.first)
+        XCTAssertNil(failure.tags)
+    }
+
+    func testAddFailure_priorityReplacement_alsoReplacesTags() throws {
+        manager.addFailure(
+            inappId: "inapp-priority-tags",
+            reason: .productSegmentRequestFailed,
+            details: "product",
+            tags: ["templateType": "First"]
+        )
+        manager.addFailure(
+            inappId: "inapp-priority-tags",
+            reason: .customerSegmentRequestFailed,
+            details: "segment",
+            tags: ["templateType": "Second"]
+        )
+        manager.sendFailures()
+
+        assertCreatedEventsCountEventually(1)
+        let event = try XCTUnwrap(databaseRepository.createdEvents.first)
+        let failure = try XCTUnwrap(decodeFailures(from: event)?.first)
+        XCTAssertEqual(failure.failureReason, .customerSegmentRequestFailed)
+        XCTAssertEqual(failure.tags, ["templateType": "Second"])
     }
 }
 
@@ -374,6 +443,19 @@ private extension InappShowFailureManagerTests {
         {
           "featureToggles": {
             "MobileSdkShouldSendInAppShowError": \(shouldSendInAppShowError ? "true" : "false")
+          }
+        }
+        """
+        let settingsData = settingsJSON.data(using: .utf8) ?? Data()
+        let settings = try? JSONDecoder().decode(Settings.self, from: settingsData)
+        featureToggleManager.applyFeatureToggles(settings?.featureToggles)
+    }
+
+    func applyTagsFeatureToggle(shouldSendInAppTags: Bool) {
+        let settingsJSON = """
+        {
+          "featureToggles": {
+            "MobileSdkShouldSendInAppTags": \(shouldSendInAppTags ? "true" : "false")
           }
         }
         """
@@ -734,7 +816,7 @@ final class WebViewControllerWindowProviderTests: XCTestCase {
 
 private final class InAppMessagesTrackerMock: InAppMessagesTrackerProtocol {
     func trackView(id: String, timeToDisplay: String?, tags: [String: String]?) throws {}
-    func trackClick(id: String) throws {}
+    func trackClick(id: String, tags: [String: String]?) throws {}
 }
 
 private final class PresentationStrategyMock: PresentationStrategyProtocol {

--- a/MindboxTests/InApp/Tests/InappShowFailureManagerTests.swift
+++ b/MindboxTests/InApp/Tests/InappShowFailureManagerTests.swift
@@ -452,16 +452,9 @@ private extension InappShowFailureManagerTests {
     }
 
     func applyTagsFeatureToggle(shouldSendInAppTags: Bool) {
-        let settingsJSON = """
-        {
-          "featureToggles": {
-            "MobileSdkShouldSendInAppTags": \(shouldSendInAppTags ? "true" : "false")
-          }
-        }
-        """
-        let settingsData = settingsJSON.data(using: .utf8) ?? Data()
-        let settings = try? JSONDecoder().decode(Settings.self, from: settingsData)
-        featureToggleManager.applyFeatureToggles(settings?.featureToggles)
+        featureToggleManager.applyFeatureToggles(
+            Settings.FeatureToggles(shouldSendInAppShowError: nil, shouldSendInAppTags: shouldSendInAppTags)
+        )
     }
 
     func assertCreatedEventsCountEventually(

--- a/MindboxTests/InApp/Tests/TimeToDisplayBackgroundTests.swift
+++ b/MindboxTests/InApp/Tests/TimeToDisplayBackgroundTests.swift
@@ -150,5 +150,5 @@ final class InAppMessagesTrackerSpyMock: InAppMessagesTrackerProtocol {
         lastTimeToDisplay = timeToDisplay
     }
 
-    func trackClick(id: String) throws {}
+    func trackClick(id: String, tags: [String: String]?) throws {}
 }

--- a/MindboxTests/InApp/Tests/WebView/JSONValueTagsMergeTests.swift
+++ b/MindboxTests/InApp/Tests/WebView/JSONValueTagsMergeTests.swift
@@ -1,0 +1,93 @@
+//
+//  JSONValueTagsMergeTests.swift
+//  MindboxTests
+//
+//  Created by Akylbek Utekeshev on 01.07.2026.
+//  Copyright © 2026 Mindbox. All rights reserved.
+//
+
+import Testing
+@_spi(Internal) @testable import Mindbox
+
+@Suite("JSONValue.mergingInAppTags tests")
+struct JSONValueTagsMergeTests {
+
+    @Test("Sets tags directly when body has no tags key", .tags(.inAppTags, .webView))
+    func setsTagsWhenAbsent() {
+        let body: JSONValue = .object(["viewProduct": .string("value")])
+        let merged = JSONValue.mergingInAppTags(["templateType": "Popup"], into: body)
+
+        guard case .object(let dict) = merged else {
+            Issue.record("Expected merged body to be an object")
+            return
+        }
+        #expect(dict["tags"] == .object(["templateType": .string("Popup")]))
+        #expect(dict["viewProduct"] == .string("value"))
+    }
+
+    @Test("Sets tags directly when existing tags value is null", .tags(.inAppTags, .webView))
+    func setsTagsWhenNull() {
+        let body: JSONValue = .object(["tags": .null])
+        let merged = JSONValue.mergingInAppTags(["templateType": "Popup"], into: body)
+
+        guard case .object(let dict) = merged else {
+            Issue.record("Expected merged body to be an object")
+            return
+        }
+        #expect(dict["tags"] == .object(["templateType": .string("Popup")]))
+    }
+
+    @Test("Adds only missing keys when tags already an object, client keys win", .tags(.inAppTags, .webView))
+    func mergesMissingKeysOnly() {
+        let body: JSONValue = .object(["tags": .object(["campaign": .string("client-campaign")])])
+        let merged = JSONValue.mergingInAppTags(["templateType": "Popup", "campaign": "server-campaign"], into: body)
+
+        guard case .object(let dict) = merged,
+              case .object(let tags) = dict["tags"] else {
+            Issue.record("Expected merged body's tags to be an object")
+            return
+        }
+        #expect(tags["campaign"] == .string("client-campaign"))
+        #expect(tags["templateType"] == .string("Popup"))
+    }
+
+    @Test("Leaves body untouched when existing tags value is not an object", .tags(.inAppTags, .webView))
+    func leavesNonObjectTagsUntouched() {
+        let body: JSONValue = .object(["tags": .string("client-string")])
+        let merged = JSONValue.mergingInAppTags(["templateType": "Popup"], into: body)
+
+        #expect(merged == body)
+    }
+
+    @Test("Leaves array-valued tags untouched", .tags(.inAppTags, .webView))
+    func leavesArrayTagsUntouched() {
+        let body: JSONValue = .object(["tags": .array([.string("a")])])
+        let merged = JSONValue.mergingInAppTags(["templateType": "Popup"], into: body)
+
+        #expect(merged == body)
+    }
+
+    @Test("Returns body unchanged when tags are nil", .tags(.inAppTags, .webView))
+    func returnsBodyUnchangedWhenTagsNil() {
+        let body: JSONValue = .object(["viewProduct": .string("value")])
+        let merged = JSONValue.mergingInAppTags(nil, into: body)
+
+        #expect(merged == body)
+    }
+
+    @Test("Returns body unchanged when tags are empty", .tags(.inAppTags, .webView))
+    func returnsBodyUnchangedWhenTagsEmpty() {
+        let body: JSONValue = .object(["viewProduct": .string("value")])
+        let merged = JSONValue.mergingInAppTags([:], into: body)
+
+        #expect(merged == body)
+    }
+
+    @Test("Returns body unchanged when body root is not an object", .tags(.inAppTags, .webView))
+    func returnsBodyUnchangedWhenRootIsNotObject() {
+        let body: JSONValue = .array([.string("a")])
+        let merged = JSONValue.mergingInAppTags(["templateType": "Popup"], into: body)
+
+        #expect(merged == body)
+    }
+}

--- a/MindboxTests/InApp/Tests/WebView/TransparentViewJSBridgeTests.swift
+++ b/MindboxTests/InApp/Tests/WebView/TransparentViewJSBridgeTests.swift
@@ -205,4 +205,6 @@ private final class EventRepositorySpy: EventRepository {
         sentRawEvents.append(event)
         completion(.success(Data(#"{"status":"Success"}"#.utf8)))
     }
+
+    func cancelAllRequests() {}
 }

--- a/MindboxTests/InApp/Tests/WebView/TransparentViewJSBridgeTests.swift
+++ b/MindboxTests/InApp/Tests/WebView/TransparentViewJSBridgeTests.swift
@@ -1,0 +1,199 @@
+//
+//  TransparentViewJSBridgeTests.swift
+//  MindboxTests
+//
+//  Created by Akylbek Utekeshev on 08.07.2026.
+//  Copyright © 2026 Mindbox. All rights reserved.
+//
+
+import Testing
+import UIKit
+import WebKit
+@_spi(Internal) @testable import Mindbox
+
+@MainActor
+@Suite("TransparentView JS-bridge operation tags tests")
+final class TransparentViewJSBridgeTests {
+
+    private let featureToggleManager = FeatureToggleManager()
+    private let databaseRepository = DatabaseRepositorySpy()
+    private let eventRepository = EventRepositorySpy()
+    private let facade = WebViewFacadeSpy()
+
+    init() {
+        TestConfiguration.configure()
+    }
+
+    // MARK: - asyncOperation
+
+    @Test("asyncOperation merges in-app tags into the operation body when the feature is enabled", .tags(.inAppTags, .webView))
+    func asyncOperationMergesTagsWhenEnabled() throws {
+        let view = makeView(tags: ["templateType": "Popup"])
+        send(.asyncOperation, payload: #"{"operation":"Test.Operation","body":{"field":"value"}}"#, to: view)
+
+        let customEvent = try #require(queuedCustomEvent())
+        #expect(customEvent.name == "Test.Operation")
+
+        let body = try #require(decodedPayload(of: customEvent))
+        #expect(body["field"] == .string("value"))
+        #expect(body["tags"] == .object(["templateType": .string("Popup")]))
+        #expect(facade.sentMessages.last?.type == .response)
+    }
+
+    @Test("asyncOperation omits tags from the operation body when the feature is disabled", .tags(.inAppTags, .webView))
+    func asyncOperationOmitsTagsWhenDisabled() throws {
+        applyTagsToggle(enabled: false)
+        let view = makeView(tags: ["templateType": "Popup"])
+        send(.asyncOperation, payload: #"{"operation":"Test.Operation","body":{"field":"value"}}"#, to: view)
+
+        let customEvent = try #require(queuedCustomEvent())
+        let body = try #require(decodedPayload(of: customEvent))
+        #expect(body["field"] == .string("value"))
+        #expect(body.keys.contains("tags") == false)
+    }
+
+    @Test("asyncOperation keeps client-provided tag values on key collision", .tags(.inAppTags, .webView))
+    func asyncOperationKeepsClientTagsOnCollision() throws {
+        let view = makeView(tags: ["templateType": "Popup", "source": "server"])
+        send(.asyncOperation, payload: #"{"operation":"Test.Operation","body":{"tags":{"templateType":"client"}}}"#, to: view)
+
+        let customEvent = try #require(queuedCustomEvent())
+        let body = try #require(decodedPayload(of: customEvent))
+        #expect(body["tags"] == .object([
+            "templateType": .string("client"),
+            "source": .string("server")
+        ]))
+    }
+
+    @Test("asyncOperation without a body responds with a bridge error and queues nothing", .tags(.inAppTags, .webView))
+    func asyncOperationWithoutBodySendsBridgeError() throws {
+        let view = makeView(tags: ["templateType": "Popup"])
+        send(.asyncOperation, payload: #"{"operation":"Test.Operation"}"#, to: view)
+
+        #expect(databaseRepository.createdEvents.isEmpty)
+        #expect(facade.sentMessages.last?.type == .error)
+    }
+
+    // MARK: - syncOperation
+
+    @Test("syncOperation merges in-app tags into the operation body when the feature is enabled", .tags(.inAppTags, .webView))
+    func syncOperationMergesTagsWhenEnabled() throws {
+        let view = makeView(tags: ["templateType": "Snackbar"])
+        send(.syncOperation, payload: #"{"operation":"Test.Sync","body":{"field":"value"}}"#, to: view)
+
+        let event = try #require(eventRepository.sentRawEvents.first)
+        let customEvent = try #require(BodyDecoder<CustomEvent>(decodable: event.body)?.body)
+        #expect(customEvent.name == "Test.Sync")
+
+        let body = try #require(decodedPayload(of: customEvent))
+        #expect(body["field"] == .string("value"))
+        #expect(body["tags"] == .object(["templateType": .string("Snackbar")]))
+    }
+
+    @Test("syncOperation omits tags from the operation body when the feature is disabled", .tags(.inAppTags, .webView))
+    func syncOperationOmitsTagsWhenDisabled() throws {
+        applyTagsToggle(enabled: false)
+        let view = makeView(tags: ["templateType": "Snackbar"])
+        send(.syncOperation, payload: #"{"operation":"Test.Sync","body":{"field":"value"}}"#, to: view)
+
+        let event = try #require(eventRepository.sentRawEvents.first)
+        let customEvent = try #require(BodyDecoder<CustomEvent>(decodable: event.body)?.body)
+        let body = try #require(decodedPayload(of: customEvent))
+        #expect(body.keys.contains("tags") == false)
+    }
+
+    // MARK: - Helpers
+
+    private func makeView(tags: [String: String]?) -> TransparentView {
+        let view = TransparentView(
+            frame: .zero,
+            params: [:],
+            userAgent: "",
+            operation: nil,
+            inAppId: "inapp-1",
+            tags: tags
+        )
+        view.facade = facade
+        view.featureToggleManager = featureToggleManager
+        view.databaseRepository = databaseRepository
+        view.eventRepository = eventRepository
+        return view
+    }
+
+    private func send(_ action: BridgeMessage.Action, payload: String, to view: TransparentView) {
+        let bridge = MindboxWebBridge(webView: WKWebView())
+        let message = BridgeMessage(type: .request, action: action, payload: .string(payload))
+        view.webBridge(bridge, didReceiveBridgeMessage: message)
+    }
+
+    private func queuedCustomEvent() -> CustomEvent? {
+        guard let event = databaseRepository.createdEvents.first else { return nil }
+        return BodyDecoder<CustomEvent>(decodable: event.body)?.body
+    }
+
+    private func decodedPayload(of customEvent: CustomEvent) -> [String: JSONValue]? {
+        guard let data = customEvent.payload.data(using: .utf8) else { return nil }
+        return try? JSONDecoder().decode([String: JSONValue].self, from: data)
+    }
+
+    private func applyTagsToggle(enabled: Bool) {
+        featureToggleManager.applyFeatureToggles(
+            Settings.FeatureToggles(shouldSendInAppShowError: nil, shouldSendInAppTags: enabled)
+        )
+    }
+}
+
+// MARK: - Spies
+
+private final class WebViewFacadeSpy: InappWebViewFacadeProtocol {
+    private(set) var sentMessages: [BridgeMessage] = []
+
+    func makeView() -> UIView { UIView() }
+    func loadHTML(baseUrl: String, contentUrl: String, onFailure: @escaping () -> Void) {}
+    func applyViewSettings(scrollViewDelegate: UIScrollViewDelegate?) {}
+    func cleanWebView() {}
+    func sendReadyEvent(id: UUID) {}
+    func sendToJS(_ message: BridgeMessage) { sentMessages.append(message) }
+    func evaluateJavaScript(_ script: String, completion: @escaping (Result<Any?, Error>) -> Void) {}
+    func setBridgeMessageDelegate(_ delegate: WebBridgeMessageDelegate?) {}
+    func setNavigationDelegate(_ delegate: WebBridgeNavigationDelegate?) {}
+}
+
+private final class DatabaseRepositorySpy: DatabaseRepositoryProtocol {
+    var limit: Int = 0
+    var lifeLimitDate: Date?
+    var deprecatedLimit: Int = 0
+    var onObjectsDidChange: (() -> Void)?
+    private(set) var createdEvents: [Event] = []
+
+    func create(event: Event) throws {
+        createdEvents.append(event)
+    }
+
+    func readEvent(by transactionId: String) throws -> Event? {
+        createdEvents.first(where: { $0.transactionId == transactionId })
+    }
+
+    func update(event: Event) throws {}
+    func delete(event: Event) throws {}
+    func query(fetchLimit: Int, retryDeadline: TimeInterval) throws -> [Event] { [] }
+    func removeDeprecatedEventsIfNeeded() throws {}
+    func countDeprecatedEvents() throws -> Int { 0 }
+    func erase() throws { createdEvents.removeAll() }
+    func countEvents() throws -> Int { createdEvents.count }
+}
+
+private final class EventRepositorySpy: EventRepository {
+    private(set) var sentRawEvents: [Event] = []
+
+    func send(event: Event, completion: @escaping (Result<Void, MindboxError>) -> Void) {
+        completion(.success(()))
+    }
+
+    func send<T>(type: T.Type, event: Event, completion: @escaping (Result<T, MindboxError>) -> Void) where T: Decodable {}
+
+    func sendRaw(event: Event, completion: @escaping (Result<Data, MindboxError>) -> Void) {
+        sentRawEvents.append(event)
+        completion(.success(Data(#"{"status":"Success"}"#.utf8)))
+    }
+}

--- a/MindboxTests/InApp/Tests/WebView/TransparentViewJSBridgeTests.swift
+++ b/MindboxTests/InApp/Tests/WebView/TransparentViewJSBridgeTests.swift
@@ -74,6 +74,15 @@ final class TransparentViewJSBridgeTests {
         #expect(facade.sentMessages.last?.type == .error)
     }
 
+    @Test("asyncOperation with an empty operation name responds with a bridge error and queues nothing", .tags(.inAppTags, .webView))
+    func asyncOperationWithEmptyNameSendsBridgeError() throws {
+        let view = makeView(tags: ["templateType": "Popup"])
+        send(.asyncOperation, payload: #"{"operation":"","body":{"field":"value"}}"#, to: view)
+
+        #expect(databaseRepository.createdEvents.isEmpty)
+        #expect(facade.sentMessages.last?.type == .error)
+    }
+
     // MARK: - syncOperation
 
     @Test("syncOperation merges in-app tags into the operation body when the feature is enabled", .tags(.inAppTags, .webView))

--- a/MindboxTests/Mock/MockInAppConfigurationDataFacade.swift
+++ b/MindboxTests/Mock/MockInAppConfigurationDataFacade.swift
@@ -62,7 +62,7 @@ class MockInAppConfigurationDataFacade: InAppConfigurationDataFacadeProtocol {
         }
     }
 
-    func collectTargetingFailures(forFailedTargetingInappIds failedTargetingInappIds: Set<String>, tagsByInappId: [String: [String: String]?]) {
+    func collectTargetingFailures(forFailedTargetingInappIds failedTargetingInappIds: Set<String>, tagsByInappId: [String: [String: String]]) {
         collectedTargetingFailureIds.append(failedTargetingInappIds)
     }
 

--- a/MindboxTests/Mock/MockInAppConfigurationDataFacade.swift
+++ b/MindboxTests/Mock/MockInAppConfigurationDataFacade.swift
@@ -42,7 +42,7 @@ class MockInAppConfigurationDataFacade: InAppConfigurationDataFacadeProtocol {
         completion()
     }
 
-    func downloadImage(withUrl url: String, inappId: String, completion: @escaping (Result<UIImage, MindboxError>) -> Void) {
+    func downloadImage(withUrl url: String, inappId: String, tags: [String: String]?, completion: @escaping (Result<UIImage, MindboxError>) -> Void) {
         if let downloadImageError {
             switch downloadImageError {
             case .serverError, .protocolError, .unknown:
@@ -62,11 +62,11 @@ class MockInAppConfigurationDataFacade: InAppConfigurationDataFacadeProtocol {
         }
     }
 
-    func collectTargetingFailures(forFailedTargetingInappIds failedTargetingInappIds: Set<String>) {
+    func collectTargetingFailures(forFailedTargetingInappIds failedTargetingInappIds: Set<String>, tagsByInappId: [String: [String: String]?]) {
         collectedTargetingFailureIds.append(failedTargetingInappIds)
     }
-    
-    func trackTargeting(id: String?) {
+
+    func trackTargeting(id: String?, tags: [String: String]?) {
         if let id = id {
             if showArray.isEmpty {
                 showArray.append(id)

--- a/MindboxTests/Mock/MockInAppConfigurationDataFacade.swift
+++ b/MindboxTests/Mock/MockInAppConfigurationDataFacade.swift
@@ -20,9 +20,12 @@ class MockInAppConfigurationDataFacade: InAppConfigurationDataFacadeProtocol {
 
     public var showArray: [String] = []
     public var targetingArray: [String] = []
+    public var trackTargetingCalls: [(id: String?, tags: [String: String]?)] = []
     public var downloadImageError: MindboxError?
     public var imageDownloadFailures: [(inappId: String, details: String?)] = []
+    public var downloadImageTags: [String: [String: String]?] = [:]
     public var collectedTargetingFailureIds: [Set<String>] = []
+    public var collectedTagsByInappId: [[String: [String: String]]] = []
 
     init(segmentationService: SegmentationServiceProtocol,
          targetingChecker: InAppTargetingCheckerProtocol,
@@ -43,6 +46,7 @@ class MockInAppConfigurationDataFacade: InAppConfigurationDataFacadeProtocol {
     }
 
     func downloadImage(withUrl url: String, inappId: String, tags: [String: String]?, completion: @escaping (Result<UIImage, MindboxError>) -> Void) {
+        downloadImageTags[inappId] = tags
         if let downloadImageError {
             switch downloadImageError {
             case .serverError, .protocolError, .unknown:
@@ -64,9 +68,11 @@ class MockInAppConfigurationDataFacade: InAppConfigurationDataFacadeProtocol {
 
     func collectTargetingFailures(forFailedTargetingInappIds failedTargetingInappIds: Set<String>, tagsByInappId: [String: [String: String]]) {
         collectedTargetingFailureIds.append(failedTargetingInappIds)
+        collectedTagsByInappId.append(tagsByInappId)
     }
 
     func trackTargeting(id: String?, tags: [String: String]?) {
+        trackTargetingCalls.append((id: id, tags: tags))
         if let id = id {
             if showArray.isEmpty {
                 showArray.append(id)
@@ -78,13 +84,16 @@ class MockInAppConfigurationDataFacade: InAppConfigurationDataFacadeProtocol {
 
     func cleanTargetingArray() {
         targetingArray = []
+        trackTargetingCalls = []
     }
-    
+
     func cleanImageDownloadFailures() {
         imageDownloadFailures = []
+        downloadImageTags = [:]
     }
 
     func cleanCollectedTargetingFailureIds() {
         collectedTargetingFailureIds = []
+        collectedTagsByInappId = []
     }
 }


### PR DESCRIPTION
## Description

Adds support for sending in-app `tags` (delivered in the in-app config from the backend) in SDK events, gated by a new `MobileSdkShouldSendInAppTags` feature toggle (enabled by default, can be disabled via backend config).

- New `MobileSdkShouldSendInAppTags` feature toggle and `gatedTags` helper: tags are sent only when the toggle is enabled and the dictionary is non-empty.
- Tags are included in `Inapp.Show`, `Inapp.Click`, `Inapp.Targeting` and `Inapp.ShowFailure` event bodies.
- Tags are merged into the root of WebView JS-bridge operation bodies (sync and async); client-provided tag keys always win, non-object `tags` values in the client body are left untouched.
- `FeatureToggleManager` storage is now guarded by a lock (toggles are written on the config-fetch queue and read from the main thread by the JS bridge and trackers).

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Test Procedure

- 27 new unit tests: toggle parsing (explicit true/false, missing key, type error), `gatedTags` gating rules, tags in Show/Click/Targeting event bodies, tags in ShowFailure (including priority replacement and targeting-failure propagation), JS-bridge body merge rules.
- Full test suite: 1138 tests passed, 0 failures (iPhone 16 Pro, iOS 18.5).