### PR TITLE
MOBILE-268: WebView in-app show robustness

### DIFF
--- a/Mindbox.xcodeproj/project.pbxproj
+++ b/Mindbox.xcodeproj/project.pbxproj
@@ -7,6 +7,10 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		B9025268DDC24820B95ADE10 /* WebViewTimeoutErrorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11E54FE3B51649DCBD5ABE33 /* WebViewTimeoutErrorTests.swift */; };
+		CB91323FAD66404B9422B6E0 /* WebViewReadyCheckerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D716044131845AEA04A9858 /* WebViewReadyCheckerTests.swift */; };
+		C830BF4C287849CE95BB4ED9 /* WebViewReadyChecker.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2DAFC2435264F15B8033CCE /* WebViewReadyChecker.swift */; };
+		46E95250B5904CC18E079C54 /* SDKUserAgent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68184C936B4243C28CC10829 /* SDKUserAgent.swift */; };
 		0A3D045A2BC6803E00E1FC52 /* ImageFormat.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A3D04592BC6803E00E1FC52 /* ImageFormat.swift */; };
 		0E7A224A082FA2DA35706CC7 /* MotionServiceResolvePositionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C8192B8B7043EF74D05B36B /* MotionServiceResolvePositionTests.swift */; };
 		0E7A224A082FA2DA35706CC8 /* MotionServiceShakeToEditTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C8192B8B7043EF74D05B36C /* MotionServiceShakeToEditTests.swift */; };
@@ -733,6 +737,10 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		11E54FE3B51649DCBD5ABE33 /* WebViewTimeoutErrorTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WebViewTimeoutErrorTests.swift; sourceTree = "<group>"; };
+		4D716044131845AEA04A9858 /* WebViewReadyCheckerTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WebViewReadyCheckerTests.swift; sourceTree = "<group>"; };
+		F2DAFC2435264F15B8033CCE /* WebViewReadyChecker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebViewReadyChecker.swift; sourceTree = "<group>"; };
+		68184C936B4243C28CC10829 /* SDKUserAgent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SDKUserAgent.swift; sourceTree = "<group>"; };
 		0475E8755F63483597539A50 /* TrackVisitManagerTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TrackVisitManagerTests.swift; sourceTree = "<group>"; };
 		0A3D04592BC6803E00E1FC52 /* ImageFormat.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageFormat.swift; sourceTree = "<group>"; };
 		0CFCC82B8014DE7276C217CD /* WebViewLocalStateStorageTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WebViewLocalStateStorageTests.swift; sourceTree = "<group>"; };
@@ -1503,6 +1511,8 @@
 		2B4C84F6EDD4B7D977F67A95 /* WebView */ = {
 			isa = PBXGroup;
 			children = (
+				11E54FE3B51649DCBD5ABE33 /* WebViewTimeoutErrorTests.swift */,
+				4D716044131845AEA04A9858 /* WebViewReadyCheckerTests.swift */,
 				0CFCC82B8014DE7276C217CD /* WebViewLocalStateStorageTests.swift */,
 				A1B2C3D400000006E1010101 /* BridgeMessagePermissionTests.swift */,
 				BD1BE43AA9EAEA03F8ED400C /* HapticRequestParserTests.swift */,
@@ -1643,6 +1653,7 @@
 		31A20D4A25B6E09900AAA0A3 /* Utilities */ = {
 			isa = PBXGroup;
 			children = (
+				68184C936B4243C28CC10829 /* SDKUserAgent.swift */,
 				47CFDAB82F3A05430034F310 /* SystemInfo */,
 				F31909972E979D8200373E2F /* AppDelegateProxy */,
 				47BD5BF82C578AD700F965C0 /* Migrations */,
@@ -3016,6 +3027,7 @@
 		B4E4386F2D8AFA5700603F3A /* WebView */ = {
 			isa = PBXGroup;
 			children = (
+				F2DAFC2435264F15B8033CCE /* WebViewReadyChecker.swift */,
 				47B1B6A92F6174E0000A4B67 /* LocalState */,
 				F3BD9F802F273BC800647BAF /* Bridge */,
 				F30654B92F1A83430058808C /* Debug */,
@@ -4261,6 +4273,8 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				C830BF4C287849CE95BB4ED9 /* WebViewReadyChecker.swift in Sources */,
+				46E95250B5904CC18E079C54 /* SDKUserAgent.swift in Sources */,
 				47EFBB2F2CB92B240023A4B9 /* SegmentationCheckResponse.swift in Sources */,
 				F331DD062A83A56500222120 /* ModalViewController.swift in Sources */,
 				F331DCC12A80993600222120 /* ContentElement.swift in Sources */,
@@ -4637,6 +4651,8 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				B9025268DDC24820B95ADE10 /* WebViewTimeoutErrorTests.swift in Sources */,
+				CB91323FAD66404B9422B6E0 /* WebViewReadyCheckerTests.swift in Sources */,
 				F349753A2DEE2CB700BEC667 /* ShownInAppsDictionaryMigrationTests.swift in Sources */,
 				4766A8AE2C9325B0002D15A4 /* ABTestsConfigParsingTests.swift in Sources */,
 				F3FEEA9F2C25AF39000E9D0F /* StubContainer.swift in Sources */,

--- a/Mindbox/DI/MBContainer.swift
+++ b/Mindbox/DI/MBContainer.swift
@@ -16,15 +16,21 @@ enum ObjectScope {
 class MBContainer {
     private var factories: [String: (ObjectScope, () -> Any)] = [:]
     private var singletons: [String: Any] = [:]
+    // Recursive: factories resolve their own dependencies on the same thread.
+    private let lock = NSRecursiveLock()
 
     func register<T>(_ type: T.Type, scope: ObjectScope = .container, factory: @escaping () -> T) {
         let key = String(describing: type)
+        lock.lock()
+        defer { lock.unlock() }
         factories[key] = (scope, factory)
     }
 
     func resolve<T>(_ type: T.Type) -> T? {
         let key = String(describing: type)
 
+        lock.lock()
+        defer { lock.unlock() }
         if let (scope, factory) = factories[key] {
             switch scope {
             case .container:

--- a/Mindbox/InAppMessages/Configuration/InAppConfigurationRepository.swift
+++ b/Mindbox/InAppMessages/Configuration/InAppConfigurationRepository.swift
@@ -29,7 +29,10 @@ class InAppConfigurationRepository {
 
     func saveConfigToCache(_ data: Data) {
         do {
-            try data.write(to: inAppConfigFileUrl)
+            // Atomic (write-then-rename): the init-time prewarm reads this file from a
+            // background queue while the config download rewrites it — a concurrent
+            // reader must see the old or the new config, never a torn file.
+            try data.write(to: inAppConfigFileUrl, options: .atomic)
             Logger.common(message: "Successfuly saved config file on a disk.", level: .debug, category: .inAppMessages)
         } catch {
             Logger.common(message: "Failed to save config file on a disk. Error: \(error.localizedDescription)", level: .debug, category: .inAppMessages)

--- a/Mindbox/InAppMessages/Presentation/Views/WebView/TransparentView.swift
+++ b/Mindbox/InAppMessages/Presentation/Views/WebView/TransparentView.swift
@@ -23,7 +23,14 @@ final class TransparentView: UIView {
     private let userAgent: String
     private let inAppId: String
     private var lastReadyCheckedUrl: String?
-    private var isReadyCheckInFlight = false
+    private var readyChecker: WebViewReadyChecker?
+    /// True when the page finished loading but the JS bridge never appeared within the
+    /// ready-check budget — lets the init timeout report the accurate failure category.
+    private(set) var readyCheckDidGiveUp = false
+    /// True once the page has sent `init`. After that the init timeout is cancelled, so a
+    /// later ready-check give-up (a post-load navigation dropped the bridge) has no other
+    /// closing authority — it must close the show itself.
+    private var hasReceivedInit = false
     private lazy var localStateStorage: WebViewLocalStateStorageProtocol = DI.injectOrFail(WebViewLocalStateStorageProtocol.self)
     private lazy var permissionHandlerRegistry = DI.injectOrFail(PermissionHandlerRegistryProtocol.self)
     private lazy var hapticService: HapticServiceProtocol = DI.injectOrFail(HapticServiceProtocol.self)
@@ -65,6 +72,7 @@ final class TransparentView: UIView {
     }
 
     deinit {
+        readyChecker?.cancel()
         if isMotionServiceInitialized { motionService.stopMonitoring() }
         Logger.common(message: "[WebView] Deinit TransparentView", category: .webViewInAppMessages)
     }
@@ -174,6 +182,7 @@ extension TransparentView: WebBridgeMessageDelegate {
             if isMotionServiceInitialized { motionService.stopMonitoring() }
             webViewAction?.onClose()
         case .`init`:
+            hasReceivedInit = true
             quizInitTimeoutWorkItem?.cancel()
             hapticService.prepare()
             webViewAction?.onInit()
@@ -234,43 +243,49 @@ extension TransparentView: WebBridgeNavigationDelegate {
         Logger.common(message: "[WebView] WKNavigationDelegate: start loading URL \(url?.absoluteString ?? "unknown")", category: .webViewInAppMessages)
         // Reset per-navigation checks (e.g. redirects / re-loads).
         lastReadyCheckedUrl = nil
-        isReadyCheckInFlight = false
+        readyCheckDidGiveUp = false
+        readyChecker?.cancel()
+        readyChecker = nil
     }
-    
+
     func webBridge(_ bridge: MindboxWebBridge, didFinishNavigation url: URL?) {
         let urlString = url?.absoluteString ?? "unknown"
         Logger.common(message: "[WebView] WKNavigationDelegate: Upload completed \(urlString)", category: .webViewInAppMessages)
 
         // Avoid duplicate checks on multiple didFinish calls for the same URL.
-        guard !isReadyCheckInFlight else { return }
         guard lastReadyCheckedUrl != urlString else { return }
         lastReadyCheckedUrl = urlString
-        isReadyCheckInFlight = true
 
-        let script = Constants.WebViewBridgeJS.bridgeFunctionReadyCheck
-        facade?.evaluateJavaScript(script) { [weak self] result in
+        readyChecker?.cancel()
+        let checker = WebViewReadyChecker(evaluate: { [weak self] script, completion in
+            // Teardown: abandon the poll silently, exactly like cancel().
+            guard let facade = self?.facade else { return }
+            facade.evaluateJavaScript(script, completion: completion)
+        })
+        readyChecker = checker
+        checker.run(onReady: {
+            Logger.common(
+                message: "[WebView] JS ready check for URL \(urlString): true",
+                category: .webViewInAppMessages
+            )
+        }, onGiveUp: { [weak self] lastFailure in
             guard let self else { return }
-            self.isReadyCheckInFlight = false
-
-            switch result {
-            case .success(let anyValue):
-                let hasReady = (anyValue as? Bool) ?? false
-                Logger.common(
-                    message: "[WebView] JS ready check for URL \(urlString): \(hasReady)",
-                    category: .webViewInAppMessages
-                )
-                if !hasReady {
-                    self.delegate?.closeJSReadyMissingWebViewVC(reason: "window.bridgeMessagesHandlers.emit is missing for URL \(urlString)")
-                }
-
-            case .failure(let error):
-                Logger.common(
-                    message: "[WebView] JS ready check failed for URL \(urlString). Error: \(error.localizedDescription)",
-                    category: .webViewInAppMessages
-                )
-                self.delegate?.closeJSReadyMissingWebViewVC(reason: "evaluateJavaScript error for URL \(urlString): \(error.localizedDescription)")
+            self.readyCheckDidGiveUp = true
+            Logger.common(
+                message: "[WebView] JS ready check gave up for URL \(urlString): \(lastFailure)",
+                category: .webViewInAppMessages
+            )
+            // Before `init` the 7s timeout owns closing: its budget can expire while a slow
+            // page is still booting the bridge, and the window is invisible until `init`
+            // anyway; the flag above lets that timeout report the real category. After
+            // `init` the timeout is already cancelled, so a give-up here (a post-load
+            // navigation dropped the bridge) is the only signal left — close now, else the
+            // in-app stays up with a dead bridge. The give-up flag makes this report
+            // webview_presentation_failed, matching the pre-refactor behavior.
+            if self.hasReceivedInit {
+                self.delegate?.closeTimeoutWebViewVC()
             }
-        }
+        })
     }
     
     func webBridge(_ bridge: MindboxWebBridge, didFailProvisionalNavigation url: URL?, error: any Error) {

--- a/Mindbox/InAppMessages/Presentation/Views/WebView/WebViewController.swift
+++ b/Mindbox/InAppMessages/Presentation/Views/WebView/WebViewController.swift
@@ -12,7 +12,6 @@ protocol WebVCDelegate: AnyObject {
     func closeTapWebViewVC()
     func closeTimeoutWebViewVC()
     func closeLoadFailedWebViewVC(reason: String)
-    func closeJSReadyMissingWebViewVC(reason: String)
 }
 
 final class WebViewController: UIViewController, InappViewControllerProtocol {
@@ -198,13 +197,7 @@ final class WebViewController: UIViewController, InappViewControllerProtocol {
     }
 
     private func createUserAgent() -> String {
-        let utilitiesFetcher = DI.injectOrFail(UtilitiesFetcher.self)
-
-        let sdkVersion = utilitiesFetcher.sdkVersion ?? "unknown"
-        let appVersion = utilitiesFetcher.appVerson ?? "unknown"
-        let appName = utilitiesFetcher.hostApplicationName ?? "unknown"
-
-        return "mindbox.sdk/\(sdkVersion) (\(DeviceModelHelper.os) \(DeviceModelHelper.iOSVersion); \(DeviceModelHelper.model)) \(appName)/\(appVersion)"
+        SDKUserAgent.build()
     }
 }
 
@@ -217,24 +210,23 @@ extension WebViewController: WebVCDelegate {
     func closeTimeoutWebViewVC() {
         Logger.common(message: "[WebView] WebViewVC closeTimeoutOrErrorWebViewVC", category: .webViewInAppMessages)
         reportErrorAndClose(
-            .webviewLoadFailed("[WebView] WebView initialization timeout for in-app id \(id).")
+            Self.timeoutError(readyCheckGaveUp: transparentWebView?.readyCheckDidGiveUp == true, inAppId: id)
         )
+    }
+
+    /// The init timeout is the single closing authority, but monitoring must still tell
+    /// "the page loaded and its JS bridge never appeared" (a content defect) apart from
+    /// "the page never finished loading" (a load defect).
+    static func timeoutError(readyCheckGaveUp: Bool, inAppId: String) -> InAppPresentationError {
+        readyCheckGaveUp
+            ? .webviewPresentationFailed("[WebView] JS bridge missing after page load (init timeout) for in-app id \(inAppId).")
+            : .webviewLoadFailed("[WebView] WebView initialization timeout for in-app id \(inAppId).")
     }
 
     func closeLoadFailedWebViewVC(reason: String) {
         Logger.common(message: "[WebView] WebViewVC closeLoadFailedWebViewVC. Reason: \(reason)", category: .webViewInAppMessages)
         reportErrorAndClose(
             .webviewLoadFailed(reason)
-        )
-    }
-
-    func closeJSReadyMissingWebViewVC(reason: String) {
-        Logger.common(
-            message: "[WebView] WebViewVC closeJSReadyMissingWebViewVC. Reason: \(reason)",
-            category: .webViewInAppMessages
-        )
-        reportErrorAndClose(
-            .webviewPresentationFailed(reason)
         )
     }
 }

--- a/Mindbox/InAppMessages/Presentation/Views/WebView/WebViewReadyChecker.swift
+++ b/Mindbox/InAppMessages/Presentation/Views/WebView/WebViewReadyChecker.swift
@@ -1,0 +1,70 @@
+//
+//  WebViewReadyChecker.swift
+//  Mindbox
+//
+//  Created by Sergei Semko on 06.07.2026.
+//  Copyright © 2026 Mindbox. All rights reserved.
+//
+
+import Foundation
+
+/// Polls the page for the JS bridge instead of deciding on a single didFinish-time probe:
+/// module scripts can finish evaluating a beat after the navigation's load event (reused
+/// prewarmed WebView, slow devices), so one early `false` must not fail a healthy in-app.
+final class WebViewReadyChecker {
+    typealias Evaluate = (_ script: String, _ completion: @escaping (Result<Any?, Error>) -> Void) -> Void
+    typealias Schedule = (_ delay: TimeInterval, _ work: @escaping () -> Void) -> Void
+
+    static let maxAttempts = 8
+    static let retryDelay: TimeInterval = 0.15
+
+    private let evaluate: Evaluate
+    private let schedule: Schedule
+    private var isCancelled = false
+
+    init(evaluate: @escaping Evaluate,
+         schedule: @escaping Schedule = { delay, work in
+             DispatchQueue.main.asyncAfter(deadline: .now() + delay, execute: work)
+         }) {
+        self.evaluate = evaluate
+        self.schedule = schedule
+    }
+
+    func run(onReady: @escaping () -> Void, onGiveUp: @escaping (_ lastFailure: String) -> Void) {
+        attempt(1, onReady: onReady, onGiveUp: onGiveUp)
+    }
+
+    /// Abandons the poll without calling either completion — the caller's new navigation
+    /// (or teardown) owns readiness from here.
+    func cancel() {
+        isCancelled = true
+    }
+
+    private func attempt(_ number: Int, onReady: @escaping () -> Void, onGiveUp: @escaping (String) -> Void) {
+        guard !isCancelled else { return }
+        evaluate(Constants.WebViewBridgeJS.bridgeFunctionReadyCheck) { [weak self] result in
+            guard let self, !self.isCancelled else { return }
+
+            let failure: String
+            switch result {
+            case .success(let anyValue) where (anyValue as? Bool) == true:
+                onReady()
+                return
+            case .success:
+                failure = "window.bridgeMessagesHandlers.emit is missing"
+            case .failure(let error):
+                // Transient during navigation churn (a page mid-teardown rejects
+                // evaluation) — retried on the same budget as a plain `false`.
+                failure = "evaluateJavaScript error: \(error.localizedDescription)"
+            }
+
+            guard number < Self.maxAttempts else {
+                onGiveUp(failure)
+                return
+            }
+            self.schedule(Self.retryDelay) { [weak self] in
+                self?.attempt(number + 1, onReady: onReady, onGiveUp: onGiveUp)
+            }
+        }
+    }
+}

--- a/Mindbox/Network/MBNetworkFetcher.swift
+++ b/Mindbox/Network/MBNetworkFetcher.swift
@@ -27,10 +27,8 @@ class MBNetworkFetcher: NetworkFetcher {
 
     private static func makeSession(utilitiesFetcher: UtilitiesFetcher) -> URLSession {
         let sessionConfiguration: URLSessionConfiguration = .default
-        let sdkVersion = utilitiesFetcher.sdkVersion ?? "unknow"
-        let appVersion = utilitiesFetcher.appVerson ?? "unknow"
-        let appName = utilitiesFetcher.hostApplicationName ?? "unknow"
-        let userAgent: String = "mindbox.sdk/\(sdkVersion) (\(DeviceModelHelper.os) \(DeviceModelHelper.iOSVersion); \(DeviceModelHelper.model)) \(appName)/\(appVersion)"
+        let sdkVersion = utilitiesFetcher.sdkVersion ?? "unknown"
+        let userAgent = SDKUserAgent.build(utilitiesFetcher: utilitiesFetcher)
         sessionConfiguration.httpAdditionalHeaders = [
             "Mindbox-Integration": "iOS-SDK",
             "Mindbox-Integration-Version": sdkVersion,

--- a/Mindbox/Utilities/SDKUserAgent.swift
+++ b/Mindbox/Utilities/SDKUserAgent.swift
@@ -1,0 +1,23 @@
+//
+//  SDKUserAgent.swift
+//  Mindbox
+//
+//  Created by Sergei Semko on 06.07.2026.
+//  Copyright © 2026 Mindbox. All rights reserved.
+//
+
+import Foundation
+
+/// One User-Agent for every SDK surface — API requests and WebView `applicationName` alike.
+/// The backend slices traffic by this string, so transports must not drift apart. All
+/// inputs are static per app run, which also keeps a prewarmed WebView indistinguishable
+/// from a per-show one.
+enum SDKUserAgent {
+    static func build(utilitiesFetcher: UtilitiesFetcher = DI.injectOrFail(UtilitiesFetcher.self)) -> String {
+        let sdkVersion = utilitiesFetcher.sdkVersion ?? "unknown"
+        let appVersion = utilitiesFetcher.appVerson ?? "unknown"
+        let appName = utilitiesFetcher.hostApplicationName ?? "unknown"
+
+        return "mindbox.sdk/\(sdkVersion) (\(DeviceModelHelper.os) \(DeviceModelHelper.iOSVersion); \(DeviceModelHelper.model)) \(appName)/\(appVersion)"
+    }
+}

--- a/MindboxTests/InApp/Tests/WebView/WebViewReadyCheckerTests.swift
+++ b/MindboxTests/InApp/Tests/WebView/WebViewReadyCheckerTests.swift
@@ -1,0 +1,111 @@
+//
+//  WebViewReadyCheckerTests.swift
+//  MindboxTests
+//
+//  Created by Sergei Semko on 06.07.2026.
+//  Copyright © 2026 Mindbox. All rights reserved.
+//
+
+import Testing
+import Foundation
+@testable import Mindbox
+
+@Suite("WebView ready check retry", .tags(.webView))
+struct WebViewReadyCheckerTests {
+
+    /// Scripted evaluate answers + manual control over the retry schedule.
+    private final class Harness {
+        var answers: [Result<Any?, Error>]
+        private(set) var evaluateCount = 0
+        private(set) var pendingWork: [() -> Void] = []
+
+        init(answers: [Result<Any?, Error>]) {
+            self.answers = answers
+        }
+
+        func makeChecker() -> WebViewReadyChecker {
+            WebViewReadyChecker(
+                evaluate: { [self] _, completion in
+                    evaluateCount += 1
+                    completion(answers.removeFirst())
+                },
+                schedule: { [self] _, work in pendingWork.append(work) }
+            )
+        }
+
+        func runPending() {
+            let work = pendingWork
+            pendingWork = []
+            work.forEach { $0() }
+        }
+    }
+
+    @Test("An immediately ready page passes on the first attempt")
+    func readyFirstAttempt() {
+        let harness = Harness(answers: [.success(true)])
+        var readyCount = 0
+
+        harness.makeChecker().run(onReady: { readyCount += 1 }, onGiveUp: { _ in Issue.record("unexpected give-up") })
+
+        #expect(readyCount == 1)
+        #expect(harness.evaluateCount == 1)
+        #expect(harness.pendingWork.isEmpty)
+    }
+
+    @Test("A module evaluating after didFinish passes on a retry instead of failing the show")
+    func readyAfterRetries() {
+        let harness = Harness(answers: [.success(false), .success(false), .success(true)])
+        var readyCount = 0
+
+        let checker = harness.makeChecker()
+        checker.run(onReady: { readyCount += 1 }, onGiveUp: { _ in Issue.record("unexpected give-up") })
+        harness.runPending()
+        harness.runPending()
+
+        withExtendedLifetime(checker) {}
+        #expect(readyCount == 1)
+        #expect(harness.evaluateCount == 3)
+    }
+
+    @Test("Evaluation errors are retried like a plain false")
+    func evaluationErrorRetries() {
+        let error = NSError(domain: "test", code: 1)
+        let harness = Harness(answers: [.failure(error), .success(true)])
+        var readyCount = 0
+
+        let checker = harness.makeChecker()
+        checker.run(onReady: { readyCount += 1 }, onGiveUp: { _ in Issue.record("unexpected give-up") })
+        harness.runPending()
+
+        withExtendedLifetime(checker) {}
+        #expect(readyCount == 1)
+    }
+
+    @Test("A page that never boots gives up only after the full retry budget")
+    func givesUpAfterBudget() {
+        let harness = Harness(answers: Array(repeating: .success(false), count: WebViewReadyChecker.maxAttempts))
+        var giveUpFailure: String?
+
+        let checker = harness.makeChecker()
+        checker.run(onReady: { Issue.record("unexpected ready") }, onGiveUp: { giveUpFailure = $0 })
+        while !harness.pendingWork.isEmpty {
+            harness.runPending()
+        }
+
+        withExtendedLifetime(checker) {}
+        #expect(harness.evaluateCount == WebViewReadyChecker.maxAttempts)
+        #expect(giveUpFailure == "window.bridgeMessagesHandlers.emit is missing")
+    }
+
+    @Test("Cancel abandons the poll without ever resolving")
+    func cancelAbandonsSilently() {
+        let harness = Harness(answers: [.success(false), .success(true)])
+        let checker = harness.makeChecker()
+
+        checker.run(onReady: { Issue.record("resolved after cancel") }, onGiveUp: { _ in Issue.record("resolved after cancel") })
+        checker.cancel()
+        harness.runPending()
+
+        #expect(harness.evaluateCount == 1)
+    }
+}

--- a/MindboxTests/InApp/Tests/WebView/WebViewTimeoutErrorTests.swift
+++ b/MindboxTests/InApp/Tests/WebView/WebViewTimeoutErrorTests.swift
@@ -1,0 +1,28 @@
+//
+//  WebViewTimeoutErrorTests.swift
+//  MindboxTests
+//
+//  Created by Sergei Semko on 06.07.2026.
+//  Copyright © 2026 Mindbox. All rights reserved.
+//
+
+import Testing
+@testable import Mindbox
+
+@Suite("WebView timeout error category", .tags(.webView))
+struct WebViewTimeoutErrorTests {
+
+    /// The 7s init timeout stays the single closing authority, but monitoring must tell
+    /// "page loaded, JS bridge never appeared" apart from "page never finished loading".
+    @Test
+    func timeoutDistinguishesBridgeMissingFromLoadFailure() {
+        guard case .webviewPresentationFailed = WebViewController.timeoutError(readyCheckGaveUp: true, inAppId: "x") else {
+            Issue.record("expected webviewPresentationFailed when the ready check gave up")
+            return
+        }
+        guard case .webviewLoadFailed = WebViewController.timeoutError(readyCheckGaveUp: false, inAppId: "x") else {
+            Issue.record("expected webviewLoadFailed when the page never loaded")
+            return
+        }
+    }
+}


### PR DESCRIPTION
Первый PR стека MOBILE-268 — в интеграционную ветку `feature/MOBILE-268` (не в develop). Самодостаточные правки существующего показа WebView in-app, без кэша/прогрева.

- **Ready-check поллер** (`WebViewReadyChecker`) вместо одноразовой проверки моста: страница, чьи module-скрипты доезжают на такт позже `load`, больше не падает; give-up после `init` закрывает показ, потерявший мост, вместо зависшего экрана.
- **Категория ошибки init-таймаута**: `webview_presentation_failed` (мост не появился) vs `webview_load_failed` (страница не загрузилась) — `WebViewController.timeoutError`.
- **Единый `SDKUserAgent`** для сети и WebView (чинит опечатку `unknow`).
- **Потокобезопасность DI** `MBContainer` (рекурсивный лок, без дублей синглтонов).
- **Атомарная запись** кэша конфига.

Тесты: `WebViewReadyCheckerTests`, `WebViewTimeoutErrorTests`. Полный `MindboxTests` зелёный (1117/0) на iOS 26.5.