### PR TITLE
MOBILE-268: Shared WebView cache + feature toggles

### DIFF
--- a/Mindbox.xcodeproj/project.pbxproj
+++ b/Mindbox.xcodeproj/project.pbxproj
@@ -7,6 +7,10 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		16311BEB069E4B3983FAF594 /* InAppWebViewCacheTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 895F8C05EA8B4716B2A2941A /* InAppWebViewCacheTests.swift */; };
+		28375259024D42658E146900 /* InAppWebViewFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD1627DAC8D54E448C6D7BF0 /* InAppWebViewFactory.swift */; };
+		B58D5207F49F4531AA1C516B /* InAppWebViewHTMLFetcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = A85CCBEB1D874078954BB771 /* InAppWebViewHTMLFetcher.swift */; };
+		2DBF19F24FEA48AAA39C33E6 /* InAppWebViewDataStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D096F433EBB44C8B3490CF6 /* InAppWebViewDataStore.swift */; };
 		B9025268DDC24820B95ADE10 /* WebViewTimeoutErrorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11E54FE3B51649DCBD5ABE33 /* WebViewTimeoutErrorTests.swift */; };
 		CB91323FAD66404B9422B6E0 /* WebViewReadyCheckerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D716044131845AEA04A9858 /* WebViewReadyCheckerTests.swift */; };
 		C830BF4C287849CE95BB4ED9 /* WebViewReadyChecker.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2DAFC2435264F15B8033CCE /* WebViewReadyChecker.swift */; };
@@ -737,6 +741,10 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		895F8C05EA8B4716B2A2941A /* InAppWebViewCacheTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = InAppWebViewCacheTests.swift; sourceTree = "<group>"; };
+		FD1627DAC8D54E448C6D7BF0 /* InAppWebViewFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InAppWebViewFactory.swift; sourceTree = "<group>"; };
+		A85CCBEB1D874078954BB771 /* InAppWebViewHTMLFetcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InAppWebViewHTMLFetcher.swift; sourceTree = "<group>"; };
+		6D096F433EBB44C8B3490CF6 /* InAppWebViewDataStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InAppWebViewDataStore.swift; sourceTree = "<group>"; };
 		11E54FE3B51649DCBD5ABE33 /* WebViewTimeoutErrorTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WebViewTimeoutErrorTests.swift; sourceTree = "<group>"; };
 		4D716044131845AEA04A9858 /* WebViewReadyCheckerTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WebViewReadyCheckerTests.swift; sourceTree = "<group>"; };
 		F2DAFC2435264F15B8033CCE /* WebViewReadyChecker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebViewReadyChecker.swift; sourceTree = "<group>"; };
@@ -1511,6 +1519,7 @@
 		2B4C84F6EDD4B7D977F67A95 /* WebView */ = {
 			isa = PBXGroup;
 			children = (
+				895F8C05EA8B4716B2A2941A /* InAppWebViewCacheTests.swift */,
 				11E54FE3B51649DCBD5ABE33 /* WebViewTimeoutErrorTests.swift */,
 				4D716044131845AEA04A9858 /* WebViewReadyCheckerTests.swift */,
 				0CFCC82B8014DE7276C217CD /* WebViewLocalStateStorageTests.swift */,
@@ -3027,6 +3036,9 @@
 		B4E4386F2D8AFA5700603F3A /* WebView */ = {
 			isa = PBXGroup;
 			children = (
+				FD1627DAC8D54E448C6D7BF0 /* InAppWebViewFactory.swift */,
+				A85CCBEB1D874078954BB771 /* InAppWebViewHTMLFetcher.swift */,
+				6D096F433EBB44C8B3490CF6 /* InAppWebViewDataStore.swift */,
 				F2DAFC2435264F15B8033CCE /* WebViewReadyChecker.swift */,
 				47B1B6A92F6174E0000A4B67 /* LocalState */,
 				F3BD9F802F273BC800647BAF /* Bridge */,
@@ -4273,6 +4285,9 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				28375259024D42658E146900 /* InAppWebViewFactory.swift in Sources */,
+				B58D5207F49F4531AA1C516B /* InAppWebViewHTMLFetcher.swift in Sources */,
+				2DBF19F24FEA48AAA39C33E6 /* InAppWebViewDataStore.swift in Sources */,
 				C830BF4C287849CE95BB4ED9 /* WebViewReadyChecker.swift in Sources */,
 				46E95250B5904CC18E079C54 /* SDKUserAgent.swift in Sources */,
 				47EFBB2F2CB92B240023A4B9 /* SegmentationCheckResponse.swift in Sources */,
@@ -4651,6 +4666,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				16311BEB069E4B3983FAF594 /* InAppWebViewCacheTests.swift in Sources */,
 				B9025268DDC24820B95ADE10 /* WebViewTimeoutErrorTests.swift in Sources */,
 				CB91323FAD66404B9422B6E0 /* WebViewReadyCheckerTests.swift in Sources */,
 				F349753A2DEE2CB700BEC667 /* ShownInAppsDictionaryMigrationTests.swift in Sources */,

--- a/Mindbox.xcodeproj/project.pbxproj
+++ b/Mindbox.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		AE190755CA97473B83E1568D /* MBContainerConcurrencyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B4F5CEE405E4BE29F97E43B /* MBContainerConcurrencyTests.swift */; };
+		3FDBA6E4D39A49369A335CF4 /* SDKUserAgentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E45E06561604E6185C33366 /* SDKUserAgentTests.swift */; };
 		16311BEB069E4B3983FAF594 /* InAppWebViewCacheTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 895F8C05EA8B4716B2A2941A /* InAppWebViewCacheTests.swift */; };
 		28375259024D42658E146900 /* InAppWebViewFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD1627DAC8D54E448C6D7BF0 /* InAppWebViewFactory.swift */; };
 		B58D5207F49F4531AA1C516B /* InAppWebViewHTMLFetcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = A85CCBEB1D874078954BB771 /* InAppWebViewHTMLFetcher.swift */; };
@@ -741,6 +743,8 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		4B4F5CEE405E4BE29F97E43B /* MBContainerConcurrencyTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MBContainerConcurrencyTests.swift; sourceTree = "<group>"; };
+		4E45E06561604E6185C33366 /* SDKUserAgentTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SDKUserAgentTests.swift; sourceTree = "<group>"; };
 		895F8C05EA8B4716B2A2941A /* InAppWebViewCacheTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = InAppWebViewCacheTests.swift; sourceTree = "<group>"; };
 		FD1627DAC8D54E448C6D7BF0 /* InAppWebViewFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InAppWebViewFactory.swift; sourceTree = "<group>"; };
 		A85CCBEB1D874078954BB771 /* InAppWebViewHTMLFetcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InAppWebViewHTMLFetcher.swift; sourceTree = "<group>"; };
@@ -2259,6 +2263,7 @@
 		64FD3F7576619DCF106D10B6 /* Network */ = {
 			isa = PBXGroup;
 			children = (
+				4E45E06561604E6185C33366 /* SDKUserAgentTests.swift */,
 				97FEDDEB5F71A67F1C4C675F /* MBNetworkFetcherResponseHandlingTests.swift */,
 				F3BA5E000130A000C0000006 /* OperationsURLRoutingTests.swift */,
 				F3CD202C2F600A800065392A /* HostNormalizerTests.swift */,
@@ -2447,6 +2452,7 @@
 		84B625F525C98EE000AB6228 /* DI */ = {
 			isa = PBXGroup;
 			children = (
+				4B4F5CEE405E4BE29F97E43B /* MBContainerConcurrencyTests.swift */,
 				F3FEEAA72C25CC8F000E9D0F /* Injections */,
 				F3FEEA9E2C25AF39000E9D0F /* StubContainer.swift */,
 				F32E536E2C3F2B05002C7CA0 /* DITests.swift */,
@@ -4666,6 +4672,8 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				AE190755CA97473B83E1568D /* MBContainerConcurrencyTests.swift in Sources */,
+				3FDBA6E4D39A49369A335CF4 /* SDKUserAgentTests.swift in Sources */,
 				16311BEB069E4B3983FAF594 /* InAppWebViewCacheTests.swift in Sources */,
 				B9025268DDC24820B95ADE10 /* WebViewTimeoutErrorTests.swift in Sources */,
 				CB91323FAD66404B9422B6E0 /* WebViewReadyCheckerTests.swift in Sources */,

--- a/Mindbox/InAppMessages/Configuration/InAppConfigurationRepository.swift
+++ b/Mindbox/InAppMessages/Configuration/InAppConfigurationRepository.swift
@@ -27,6 +27,14 @@ class InAppConfigurationRepository {
         }
     }
 
+    /// The single home of the lenient cached-config decode for launch-time readers (the
+    /// prewarm stages, the WebView cache toggle). The config manager keeps its own richer
+    /// variant with per-outcome logging.
+    func fetchDecodedConfigFromCache() -> ConfigResponse? {
+        guard let data = fetchConfigFromCache() else { return nil }
+        return try? JSONDecoder().decode(ConfigResponse.self, from: data)
+    }
+
     func saveConfigToCache(_ data: Data) {
         do {
             // Atomic (write-then-rename): the init-time prewarm reads this file from a

--- a/Mindbox/InAppMessages/FeatureToggleManager/FeatureToggleManager.swift
+++ b/Mindbox/InAppMessages/FeatureToggleManager/FeatureToggleManager.swift
@@ -11,15 +11,22 @@ import MindboxLogger
 
 enum FeatureFlag {
     case shouldSendInAppShowError
+    case shouldPrewarmInAppWebView
+    case shouldCacheInAppWebView
 
     var defaultValue: Bool {
         switch self {
-        case .shouldSendInAppShowError:
+        case .shouldSendInAppShowError, .shouldPrewarmInAppWebView, .shouldCacheInAppWebView:
             return true
         }
     }
 }
 
+/// Holds the toggles applied from a freshly downloaded config. The WebView flags
+/// (`shouldPrewarmInAppWebView`, `shouldCacheInAppWebView`) are deliberately read
+/// config-scoped by their consumers instead (each prewarm stage reads the config it works
+/// with; the data store latches from the config cache) — those reads happen before any
+/// fresh config can be applied here.
 final class FeatureToggleManager {
 
     private var featureToggles: Settings.FeatureToggles?
@@ -27,7 +34,9 @@ final class FeatureToggleManager {
     func applyFeatureToggles(_ featureToggles: Settings.FeatureToggles?) {
         self.featureToggles = featureToggles
         let flags: [String] = [
-            featureToggles?.shouldSendInAppShowError.map { "MobileSdkShouldSendInAppShowError=\($0)" }
+            featureToggles?.shouldSendInAppShowError.map { "MobileSdkShouldSendInAppShowError=\($0)" },
+            featureToggles?.shouldPrewarmInAppWebView.map { "MobileSdkShouldPrewarmInAppWebView=\($0)" },
+            featureToggles?.shouldCacheInAppWebView.map { "MobileSdkShouldCacheInAppWebView=\($0)" }
         ].compactMap { $0 }
         Logger.common(
             message: "[FeatureToggles] \(flags)",
@@ -40,6 +49,10 @@ final class FeatureToggleManager {
         switch feature {
         case .shouldSendInAppShowError:
             return featureToggles?.shouldSendInAppShowError ?? feature.defaultValue
+        case .shouldPrewarmInAppWebView:
+            return featureToggles?.shouldPrewarmInAppWebView ?? feature.defaultValue
+        case .shouldCacheInAppWebView:
+            return featureToggles?.shouldCacheInAppWebView ?? feature.defaultValue
         }
     }
 }

--- a/Mindbox/InAppMessages/Models/Config/FeatureTogglesModel.swift
+++ b/Mindbox/InAppMessages/Models/Config/FeatureTogglesModel.swift
@@ -11,9 +11,13 @@ import Foundation
 extension Settings {
     struct FeatureToggles: Decodable, Equatable {
         let shouldSendInAppShowError: Bool?
+        let shouldPrewarmInAppWebView: Bool?
+        let shouldCacheInAppWebView: Bool?
 
         enum CodingKeys: String, CodingKey {
             case shouldSendInAppShowError = "MobileSdkShouldSendInAppShowError"
+            case shouldPrewarmInAppWebView = "MobileSdkShouldPrewarmInAppWebView"
+            case shouldCacheInAppWebView = "MobileSdkShouldCacheInAppWebView"
         }
     }
 }
@@ -22,5 +26,7 @@ extension Settings.FeatureToggles {
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         self.shouldSendInAppShowError = try? container.decodeIfPresent(Bool.self, forKey: .shouldSendInAppShowError)
+        self.shouldPrewarmInAppWebView = try? container.decodeIfPresent(Bool.self, forKey: .shouldPrewarmInAppWebView)
+        self.shouldCacheInAppWebView = try? container.decodeIfPresent(Bool.self, forKey: .shouldCacheInAppWebView)
     }
 }

--- a/Mindbox/InAppMessages/Presentation/Views/WebView/Debug/MindboxWebViewFacade.swift
+++ b/Mindbox/InAppMessages/Presentation/Views/WebView/Debug/MindboxWebViewFacade.swift
@@ -87,18 +87,7 @@ public final class MindboxWebViewFacade: MindboxInternalWebViewFacadeProtocol {
                 inAppId: String = "",
                 log: @escaping WebViewLog = { _ in },
                 logError: @escaping WebViewLogError = { _ in }) {
-        let config = WKWebViewConfiguration()
-        config.websiteDataStore = .nonPersistent()
-        config.applicationNameForUserAgent = userAgent
-        config.allowsInlineMediaPlayback = true
-        config.mediaTypesRequiringUserActionForPlayback = []
-
-        let webView = WKWebView(frame: .zero, configuration: config)
-        #if DEBUG
-        if #available(iOS 16.4, *) {
-            webView.isInspectable = true
-        }
-        #endif
+        let webView = InAppWebViewFactory.make(userAgent: userAgent)
         let bridge = MindboxWebBridge(webView: webView)
 
         self.webView = webView
@@ -313,15 +302,11 @@ extension MindboxWebViewFacade {
             return
         }
         
-        let config = URLSessionConfiguration.ephemeral
-        config.requestCachePolicy = .reloadIgnoringLocalAndRemoteCacheData
-        config.urlCache = nil
-        
-        let session = URLSession(configuration: config)
-        
+        let (session, request) = InAppWebViewHTMLFetcher.sessionAndRequest(for: url)
+
         log("Fetching HTML from \(url.absoluteString)")
-        
-        let task = session.dataTask(with: url) { [weak self] data, response, error in
+
+        let task = session.dataTask(with: request) { [weak self] data, response, error in
             if let error {
                 self?.logError("Error fetching HTML: \(error.localizedDescription)")
                 completion(nil)

--- a/Mindbox/InAppMessages/Presentation/Views/WebView/InAppWebViewDataStore.swift
+++ b/Mindbox/InAppMessages/Presentation/Views/WebView/InAppWebViewDataStore.swift
@@ -1,0 +1,63 @@
+//
+//  InAppWebViewDataStore.swift
+//  Mindbox
+//
+//  Created by Sergei Semko on 06.07.2026.
+//  Copyright © 2026 Mindbox. All rights reserved.
+//
+
+import WebKit
+
+/// The single `WKWebsiteDataStore` used by every Mindbox WebView (prewarm and shows alike).
+///
+/// Persistence is what lets WebKit's header-driven HTTP cache survive relaunches. The disk
+/// cache is keyed per data store, so the prewarm and the shows MUST share this instance for
+/// prewarmed entries to be visible to shows.
+///
+/// On iOS 17+ the store is isolated from the host app's `.default()` store so Mindbox web
+/// content never shares cookies/storage with the host's own WebViews. Earlier systems fall
+/// back to `.default()` — a deliberate product decision: some disk cache beats none, and
+/// sharing the host's store is accepted there. The cache kill switch still restores the
+/// pre-feature `.nonPersistent()` isolation on every OS.
+enum InAppWebViewDataStore {
+    // Stable identifier for the isolated store; changing it orphans the previous store.
+    // UUIDv5 (SHA-1, RFC 4122 DNS namespace) of "cloud.Mindbox.InAppWebViewDataStore":
+    // python3 -c 'import uuid; print(uuid.uuid5(uuid.NAMESPACE_DNS, "cloud.Mindbox.InAppWebViewDataStore"))'
+    // swiftlint:disable:next force_unwrapping
+    private static let identifier = UUID(uuidString: "9E350642-BB9F-5D4C-9981-94FFD93C2B57")!
+
+    /// The cache half of the WebView feature toggles. Latched at first WebView creation for
+    /// the rest of the launch: flipping stores mid-session would split the cache between
+    /// partitions. Read from the config cache, which holds the freshest config the SDK has
+    /// seen — a freshly downloaded config is saved there before any show or stage-2 prewarm
+    /// can run.
+    static let isCacheFeatureEnabled: Bool =
+        isCacheEnabled(in: InAppConfigurationRepository().fetchDecodedConfigFromCache())
+
+    /// Absent key, absent section, absent/unreadable config all mean "enabled" — the toggle
+    /// is a kill switch, not an opt-in.
+    static func isCacheEnabled(in config: ConfigResponse?) -> Bool {
+        config?.settings?.featureToggles?.shouldCacheInAppWebView
+            ?? FeatureFlag.shouldCacheInAppWebView.defaultValue
+    }
+
+    // One live store object per process: a single instance also guarantees prewarm and
+    // shows share the same in-memory session (connection pool, memory cache).
+    private static let instance: WKWebsiteDataStore = {
+        if #available(iOS 17.0, *) {
+            return WKWebsiteDataStore(forIdentifier: identifier)
+        } else {
+            // Product decision: no isolated named stores before iOS 17, and some disk
+            // cache beats none — Mindbox web content shares the host app's default store
+            // (cookies/storage included) on old systems. Toggle off → .nonPersistent().
+            return WKWebsiteDataStore.default()
+        }
+    }()
+
+    static func shared() -> WKWebsiteDataStore {
+        // Toggle off restores the pre-feature behavior exactly: every WebView gets its
+        // own fresh in-memory store, nothing is shared and nothing persists.
+        guard isCacheFeatureEnabled else { return WKWebsiteDataStore.nonPersistent() }
+        return instance
+    }
+}

--- a/Mindbox/InAppMessages/Presentation/Views/WebView/InAppWebViewFactory.swift
+++ b/Mindbox/InAppMessages/Presentation/Views/WebView/InAppWebViewFactory.swift
@@ -1,0 +1,30 @@
+//
+//  InAppWebViewFactory.swift
+//  Mindbox
+//
+//  Created by Sergei Semko on 07.07.2026.
+//  Copyright © 2026 Mindbox. All rights reserved.
+//
+
+import WebKit
+
+/// The single place a Mindbox in-app WKWebView is configured. A borrowed prewarmed
+/// instance and a cold-created one must be indistinguishable — a knob added here
+/// reaches both.
+enum InAppWebViewFactory {
+
+    static func make(userAgent: String = SDKUserAgent.build()) -> WKWebView {
+        let config = WKWebViewConfiguration()
+        config.websiteDataStore = InAppWebViewDataStore.shared()
+        config.applicationNameForUserAgent = userAgent
+        config.allowsInlineMediaPlayback = true
+        config.mediaTypesRequiringUserActionForPlayback = []
+        let webView = WKWebView(frame: .zero, configuration: config)
+        #if DEBUG
+        if #available(iOS 16.4, *) {
+            webView.isInspectable = true
+        }
+        #endif
+        return webView
+    }
+}

--- a/Mindbox/InAppMessages/Presentation/Views/WebView/InAppWebViewHTMLFetcher.swift
+++ b/Mindbox/InAppMessages/Presentation/Views/WebView/InAppWebViewHTMLFetcher.swift
@@ -1,0 +1,53 @@
+//
+//  InAppWebViewHTMLFetcher.swift
+//  Mindbox
+//
+//  Created by Sergei Semko on 07.07.2026.
+//  Copyright © 2026 Mindbox. All rights reserved.
+//
+
+import Foundation
+
+/// The single home of the in-app HTML fetch transport: the prewarm and the shows MUST use
+/// identical cache semantics, or the prewarm fills a cache the shows never read.
+enum InAppWebViewHTMLFetcher {
+
+    /// Caching path: revalidates with the server on every fetch (ETag match → a ~0-byte 304
+    /// and the cache supplies the stored body). A dedicated cookie-less session keeps the
+    /// SDK out of the host app's shared cookie jar and URLCache — the pre-feature fetch
+    /// carried no cookies either.
+    private static let cachingSession: URLSession = {
+        let config = URLSessionConfiguration.default
+        config.httpShouldSetCookies = false
+        config.httpCookieAcceptPolicy = .never
+        config.httpCookieStorage = nil
+        if #available(iOS 13.0, *) {
+            // Holds ONLY the in-app index HTML (a few small entries per endpoint) — page
+            // resources live in WebKit's own cache. Sized accordingly.
+            let directory = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first?
+                .appendingPathComponent("cloud.Mindbox.InAppWebViewHTML", isDirectory: true)
+            config.urlCache = URLCache(memoryCapacity: 512 * 1024,
+                                       diskCapacity: 4 * 1024 * 1024,
+                                       directory: directory)
+        }
+        return URLSession(configuration: config)
+    }()
+
+    /// Cache-less path — the exact pre-feature transport.
+    private static let ephemeralSession: URLSession = {
+        let config = URLSessionConfiguration.ephemeral
+        config.requestCachePolicy = .reloadIgnoringLocalAndRemoteCacheData
+        config.urlCache = nil
+        return URLSession(configuration: config)
+    }()
+
+    static func sessionAndRequest(for url: URL) -> (session: URLSession, request: URLRequest) {
+        // Foundation implements .reloadRevalidatingCacheData starting with iOS 13; on
+        // iOS 12 it silently degrades to the protocol policy and could serve a stale
+        // index without a server round-trip — old systems keep the cache-less fetch.
+        guard #available(iOS 13.0, *), InAppWebViewDataStore.isCacheFeatureEnabled else {
+            return (ephemeralSession, URLRequest(url: url))
+        }
+        return (cachingSession, URLRequest(url: url, cachePolicy: .reloadRevalidatingCacheData))
+    }
+}

--- a/MindboxTests/DI/MBContainerConcurrencyTests.swift
+++ b/MindboxTests/DI/MBContainerConcurrencyTests.swift
@@ -1,0 +1,49 @@
+//
+//  MBContainerConcurrencyTests.swift
+//  MindboxTests
+//
+//  Created by Sergei Semko on 08.07.2026.
+//  Copyright © 2026 Mindbox. All rights reserved.
+//
+
+import Testing
+import Foundation
+@testable import Mindbox
+
+@Suite("MBContainer thread safety", .tags(.dependencyInjection))
+struct MBContainerConcurrencyTests {
+
+    private final class Service {}
+
+    /// A `.container`-scoped singleton must be minted exactly once even under concurrent
+    /// resolves — the recursive lock serializes the check-create-store. Without the lock,
+    /// racing resolves each see an empty cache and run the factory more than once.
+    @Test
+    func concurrentResolveMintsOneInstance() {
+        let container = MBContainer()
+        let counterLock = NSLock()
+        var factoryCalls = 0
+
+        container.register(Service.self, scope: .container) {
+            // Widen the check-create-store window so a missing lock reliably races.
+            Thread.sleep(forTimeInterval: 0.02)
+            counterLock.lock()
+            factoryCalls += 1
+            counterLock.unlock()
+            return Service()
+        }
+
+        let resultsLock = NSLock()
+        var identifiers = Set<ObjectIdentifier>()
+        DispatchQueue.concurrentPerform(iterations: 32) { _ in
+            if let service = container.resolve(Service.self) {
+                resultsLock.lock()
+                identifiers.insert(ObjectIdentifier(service))
+                resultsLock.unlock()
+            }
+        }
+
+        #expect(factoryCalls == 1)
+        #expect(identifiers.count == 1)
+    }
+}

--- a/MindboxTests/Extensions/Tag+Extensions.swift
+++ b/MindboxTests/Extensions/Tag+Extensions.swift
@@ -27,4 +27,6 @@ extension Tag {
     @Tag static var trackVisit: Self
     @Tag static var operationsRouting: Self
     @Tag static var mbConfiguration: Self
+    @Tag static var userAgent: Self
+    @Tag static var dependencyInjection: Self
 }

--- a/MindboxTests/InApp/Tests/WebView/InAppWebViewCacheTests.swift
+++ b/MindboxTests/InApp/Tests/WebView/InAppWebViewCacheTests.swift
@@ -1,0 +1,99 @@
+//
+//  InAppWebViewCacheTests.swift
+//  MindboxTests
+//
+//  Created by Sergei Semko on 06.07.2026.
+//  Copyright © 2026 Mindbox. All rights reserved.
+//
+
+import Foundation
+import Testing
+import WebKit
+@testable import Mindbox
+
+@Suite("InApp WebView data store", .tags(.webView))
+@MainActor
+struct InAppWebViewDataStoreTests {
+
+    /// Evaluates the lazily-initialized store here rather than first in a host app: a mangled
+    /// identifier literal traps in CI. The properties are the ones the cache design rests on —
+    /// one live instance (shared in-memory session), persistence (cache survives relaunch),
+    /// isolation from the host app's default store, and the exact identifier value: changing
+    /// it orphans every install's cached store, so it must never change unnoticed.
+    @Test
+    func sharedIsOneIsolatedPersistentStore() {
+        let store = InAppWebViewDataStore.shared()
+        #expect(store === InAppWebViewDataStore.shared())
+        // iOS 17+: isolated persistent store. Below 17 the store IS .default() by product
+        // decision (some disk cache beats none), so isolation is only asserted here.
+        if #available(iOS 17.0, *) {
+            #expect(store !== WKWebsiteDataStore.default())
+            #expect(store.isPersistent)
+            // UUIDv5 of "cloud.Mindbox.InAppWebViewDataStore" — see InAppWebViewDataStore.
+            #expect(store.identifier == UUID(uuidString: "9E350642-BB9F-5D4C-9981-94FFD93C2B57"))
+        }
+    }
+
+    /// Kill-switch semantics: only an explicit `false` disables; an absent key, absent
+    /// section, or missing/unreadable config (nil from the repository) means enabled.
+    @Test
+    func cacheToggleResolvesFromCachedConfig() throws {
+        func config(_ json: String) throws -> ConfigResponse {
+            try JSONDecoder().decode(ConfigResponse.self, from: Data(json.utf8))
+        }
+
+        #expect(InAppWebViewDataStore.isCacheEnabled(in: nil))
+        #expect(InAppWebViewDataStore.isCacheEnabled(in: try config(#"{"settings":{}}"#)))
+        #expect(InAppWebViewDataStore.isCacheEnabled(in: try config(#"{"settings":{"featureToggles":{}}}"#)))
+        #expect(InAppWebViewDataStore.isCacheEnabled(
+            in: try config(#"{"settings":{"featureToggles":{"MobileSdkShouldCacheInAppWebView":true}}}"#)
+        ))
+        #expect(!InAppWebViewDataStore.isCacheEnabled(
+            in: try config(#"{"settings":{"featureToggles":{"MobileSdkShouldCacheInAppWebView":false}}}"#)
+        ))
+    }
+
+    @Test
+    func webViewTogglesDecodeFromFeatureTogglesSection() throws {
+        let json = #"{"settings":{"featureToggles":{"MobileSdkShouldPrewarmInAppWebView":false,"MobileSdkShouldCacheInAppWebView":true}}}"#
+        let config = try JSONDecoder().decode(ConfigResponse.self, from: Data(json.utf8))
+
+        let toggles = try #require(config.settings?.featureToggles)
+        #expect(toggles.shouldPrewarmInAppWebView == false)
+        #expect(toggles.shouldCacheInAppWebView == true)
+    }
+}
+
+@Suite("InApp WebView HTML fetcher", .tags(.webView))
+struct InAppWebViewHTMLFetcherTests {
+
+    /// In the test process the cache toggle latches enabled (no cached config on disk),
+    /// so this pins the caching path: revalidation, no host cookie jar, one stable session.
+    @Test
+    func cachingPathIsCookieLessRevalidatingAndStable() throws {
+        let url = try #require(URL(string: "https://inapp.local/popup"))
+        let (session, request) = InAppWebViewHTMLFetcher.sessionAndRequest(for: url)
+
+        #expect(request.cachePolicy == .reloadRevalidatingCacheData)
+        #expect(session !== URLSession.shared)
+        #expect(session.configuration.httpShouldSetCookies == false)
+        #expect(session.configuration.httpCookieStorage == nil)
+        #expect(session.configuration.urlCache != nil)
+        #expect(session.configuration.urlCache !== URLCache.shared)
+        #expect(InAppWebViewHTMLFetcher.sessionAndRequest(for: url).session === session)
+    }
+}
+
+@Suite("InApp WebView factory", .tags(.webView))
+@MainActor
+struct InAppWebViewFactoryTests {
+
+    @Test
+    func factoryConfiguresTheSharedStoreAndUserAgent() {
+        let webView = InAppWebViewFactory.make(userAgent: "test-ua")
+        #expect(webView.configuration.websiteDataStore === InAppWebViewDataStore.shared())
+        #expect(webView.configuration.applicationNameForUserAgent == "test-ua")
+        #expect(webView.configuration.allowsInlineMediaPlayback)
+        #expect(InAppWebViewFactory.make().configuration.applicationNameForUserAgent == SDKUserAgent.build())
+    }
+}

--- a/MindboxTests/Network/SDKUserAgentTests.swift
+++ b/MindboxTests/Network/SDKUserAgentTests.swift
@@ -1,0 +1,49 @@
+//
+//  SDKUserAgentTests.swift
+//  MindboxTests
+//
+//  Created by Sergei Semko on 08.07.2026.
+//  Copyright © 2026 Mindbox. All rights reserved.
+//
+
+import Testing
+import Foundation
+@testable import Mindbox
+
+@Suite("SDK User-Agent builder", .tags(.userAgent))
+struct SDKUserAgentTests {
+
+    private struct StubUtilitiesFetcher: UtilitiesFetcher {
+        var sdkVersion: String?
+        var appVerson: String?
+        var hostApplicationName: String?
+        var applicationGroupIdentifier = "group.stub"
+        func getDeviceUUID(completion: @escaping (String) -> Void) { completion("") }
+    }
+
+    /// Pins the UA layout `mindbox.sdk/<sdk> (<os> <ver>; <model>) <app>/<appVer>` so a
+    /// refactor can't reorder the segments: the backend slices traffic by this string, and
+    /// the network layer and the WebView share this single builder.
+    @Test
+    func buildKeepsSegmentOrderAndFormat() {
+        let fetcher = StubUtilitiesFetcher(sdkVersion: "9.9.9", appVerson: "1.2.3", hostApplicationName: "com.test.app")
+        let ua = SDKUserAgent.build(utilitiesFetcher: fetcher)
+
+        // sdk token first, app/appVer last — a reordering breaks the prefix/suffix.
+        #expect(ua.hasPrefix("mindbox.sdk/9.9.9 ("))
+        #expect(ua.hasSuffix(") com.test.app/1.2.3"))
+        // The device segment "(os ver; model)" sits between them.
+        #expect(ua.contains("; "))
+    }
+
+    /// Missing bundle metadata falls back to "unknown" in every slot — not the legacy
+    /// "unknow" typo, and not an empty token.
+    @Test
+    func buildFallsBackToUnknown() {
+        let fetcher = StubUtilitiesFetcher(sdkVersion: nil, appVerson: nil, hostApplicationName: nil)
+        let ua = SDKUserAgent.build(utilitiesFetcher: fetcher)
+
+        #expect(ua.hasPrefix("mindbox.sdk/unknown ("))
+        #expect(ua.hasSuffix(") unknown/unknown"))
+    }
+}


### PR DESCRIPTION
Второй PR стека MOBILE-268 — в интеграционную ветку `feature/MOBILE-268` (поверх PR1). Вводит общий кэш ресурсов WebView in-app и два фиче-тогла. Прогрева ещё нет — он в PR3.

- **Общий `WKWebsiteDataStore`** (`InAppWebViewDataStore`): один инстанс на прогрев и показы, чтобы HTTP-кэш переживал перезапуск и был виден всем. iOS 17+ — изолированный persistent-стор под фиксированным UUIDv5 (не делит куки/хранилище с хостом); iOS<17 — `.default()` (продуктовое решение: хоть какой-то диск-кэш лучше, чем никакого). Кэш-kill-switch → `.nonPersistent()`.
- **`InAppWebViewHTMLFetcher`**: единый транспорт для index-HTML — cookie-less сессия со своим маленьким `URLCache` и ревалидацией, когда кэш включён; иначе ephemeral без кэша.
- **`InAppWebViewFactory`**: единственное место конфигурации WKWebView (общий стор, UA, inline-медиа).
- **Два фиче-тогла** `MobileSdkShouldCacheInAppWebView` / `MobileSdkShouldPrewarmInAppWebView`: отсутствие ключа ⇒ включено (kill switch, не opt-in). `fetchDecodedConfigFromCache` — единая точка щадящего декода конфига на старте.

**Зачем:** сейчас каждый показ WebView in-app тянет ресурсы заново; общий persistent-кэш даёт им переживать перезапуск, а тоглы дают бэку рубильник на случай проблем.

Тесты: `InAppWebViewCacheTests` — контракт стора (один изолированный persistent-инстанс, точный UUIDv5), kill-switch-семантика тогла, cookie-less ревалидирующая сессия, проводка фабрики. Полный `MindboxTests` зелёный (1122/0) на iOS 26.5.