### PR TITLE
MOBILE-268: Bridge — filter a prior owner's callbacks on a reused WebView

### DIFF
--- a/Mindbox.xcodeproj/project.pbxproj
+++ b/Mindbox.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		23E4A509BFE94104BD01B61A /* MindboxWebBridgeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CC5ED4F76B046798978B4B9 /* MindboxWebBridgeTests.swift */; };
 		AE190755CA97473B83E1568D /* MBContainerConcurrencyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B4F5CEE405E4BE29F97E43B /* MBContainerConcurrencyTests.swift */; };
 		3FDBA6E4D39A49369A335CF4 /* SDKUserAgentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E45E06561604E6185C33366 /* SDKUserAgentTests.swift */; };
 		16311BEB069E4B3983FAF594 /* InAppWebViewCacheTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 895F8C05EA8B4716B2A2941A /* InAppWebViewCacheTests.swift */; };
@@ -743,6 +744,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		9CC5ED4F76B046798978B4B9 /* MindboxWebBridgeTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MindboxWebBridgeTests.swift; sourceTree = "<group>"; };
 		4B4F5CEE405E4BE29F97E43B /* MBContainerConcurrencyTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MBContainerConcurrencyTests.swift; sourceTree = "<group>"; };
 		4E45E06561604E6185C33366 /* SDKUserAgentTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SDKUserAgentTests.swift; sourceTree = "<group>"; };
 		895F8C05EA8B4716B2A2941A /* InAppWebViewCacheTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = InAppWebViewCacheTests.swift; sourceTree = "<group>"; };
@@ -1523,6 +1525,7 @@
 		2B4C84F6EDD4B7D977F67A95 /* WebView */ = {
 			isa = PBXGroup;
 			children = (
+				9CC5ED4F76B046798978B4B9 /* MindboxWebBridgeTests.swift */,
 				895F8C05EA8B4716B2A2941A /* InAppWebViewCacheTests.swift */,
 				11E54FE3B51649DCBD5ABE33 /* WebViewTimeoutErrorTests.swift */,
 				4D716044131845AEA04A9858 /* WebViewReadyCheckerTests.swift */,
@@ -4672,6 +4675,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				23E4A509BFE94104BD01B61A /* MindboxWebBridgeTests.swift in Sources */,
 				AE190755CA97473B83E1568D /* MBContainerConcurrencyTests.swift in Sources */,
 				3FDBA6E4D39A49369A335CF4 /* SDKUserAgentTests.swift in Sources */,
 				16311BEB069E4B3983FAF594 /* InAppWebViewCacheTests.swift in Sources */,

--- a/Mindbox/InAppMessages/Presentation/Views/WebView/Bridge/MindboxWebBridge.swift
+++ b/Mindbox/InAppMessages/Presentation/Views/WebView/Bridge/MindboxWebBridge.swift
@@ -45,19 +45,28 @@ public final class MindboxWebBridge: NSObject {
     private var pendingRequestIds = Set<UUID>()
     private var contentURL: URL?
 
+    // A reused (pre-warmed) WKWebView can deliver navigation callbacks and script messages
+    // that belong to a previous owner's load. Callbacks are filtered by navigation identity;
+    // messages are gated until the show's own document commits (the document-swap point —
+    // whoever posts before it is not this show's page). Main-thread only.
+    private var expectedNavigation: WKNavigation?
+    private var expectedNavigationFinished = false
+    private var expectedNavigationCommitted = false
+    private var contentLoadIssued = false
+
     init(webView: WKWebView) {
         self.webView = webView
         super.init()
 
         let controller = webView.configuration.userContentController
+        // Idempotent: a reused WebView may still carry a previous show's handler of this name.
+        controller.removeScriptMessageHandler(forName: Constants.WebViewBridgeJS.handlerName)
         controller.add(self, name: Constants.WebViewBridgeJS.handlerName)
         webView.navigationDelegate = self
     }
 
-    deinit {
-        webView?.configuration.userContentController.removeScriptMessageHandler(forName: Constants.WebViewBridgeJS.handlerName)
-        webView?.navigationDelegate = nil
-    }
+    // No deinit teardown needed: `navigationDelegate` is weak (zeroes automatically), and
+    // the successor's init does remove-then-add on the script handler.
 
     func send(_ message: BridgeMessage) {
         guard let json = message.jsonString() else {
@@ -132,6 +141,32 @@ public final class MindboxWebBridge: NSObject {
     func updateContentURL(_ url: URL?) {
         contentURL = url
     }
+
+    /// Registers the navigation issued by this show's own load (loadHTMLString/reload).
+    /// Until it finishes, callbacks for any other navigation are treated as stale leftovers.
+    func expectContentNavigation(_ navigation: WKNavigation?) {
+        contentLoadIssued = true
+        expectedNavigation = navigation
+        expectedNavigationFinished = false
+        expectedNavigationCommitted = false
+    }
+
+    private func isStaleNavigation(_ navigation: WKNavigation?) -> Bool {
+        if expectedNavigationFinished { return false }
+        guard contentLoadIssued else { return true }
+        // WebKit occasionally delivers a nil navigation (early provisional failures): it
+        // can't be proven to be a leftover — fail open, like the nil-expected case below.
+        guard let navigation else { return false }
+        guard let expected = expectedNavigation else { return false }
+        return navigation !== expected
+    }
+
+    private func logStaleNavigation(_ event: String) {
+        Logger.common(
+            message: "[WebView] Bridge: ignoring stale navigation \(event) (leftover load on reused WebView)",
+            category: .webViewInAppMessages
+        )
+    }
 }
 
 extension MindboxWebBridge: WKScriptMessageHandler {
@@ -140,6 +175,16 @@ extension MindboxWebBridge: WKScriptMessageHandler {
         guard message.name == Constants.WebViewBridgeJS.handlerName else {
             Logger.common(
                 message: "[WebView] Bridge: received message with wrong handler name: \(message.name)",
+                category: .webViewInAppMessages
+            )
+            return
+        }
+
+        // Mirror of the navigation staleness filter at message level: until the show's own
+        // document has committed, whoever is posting is not this show's page — drop it.
+        guard expectedNavigationCommitted else {
+            Logger.common(
+                message: "[WebView] Bridge: ignoring JS message before the show's document committed (leftover page on reused WebView)",
                 category: .webViewInAppMessages
             )
             return
@@ -183,22 +228,53 @@ extension MindboxWebBridge: WKScriptMessageHandler {
 
 extension MindboxWebBridge: WKNavigationDelegate {
     public func webView(_ webView: WKWebView, didStartProvisionalNavigation navigation: WKNavigation!) {
+        guard !isStaleNavigation(navigation) else {
+            logStaleNavigation("start")
+            return
+        }
         navigationDelegate?.webBridge(self, didStartProvisionalNavigation: webView.url)
     }
 
+    public func webView(_ webView: WKWebView, didCommit navigation: WKNavigation!) {
+        guard !isStaleNavigation(navigation) else {
+            logStaleNavigation("commit")
+            return
+        }
+        // The old document is gone from this point: script messages are now this show's.
+        expectedNavigationCommitted = true
+    }
+
     public func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
-        navigationDelegate?.webBridge(self, didFinishNavigation: contentURL ?? webView.url)
+        guard !isStaleNavigation(navigation) else {
+            logStaleNavigation("finish")
+            return
+        }
+        // Only the show's own load reports the content URL; a page-initiated navigation
+        // reports its real URL so upstream can tell the documents apart.
+        let isExpected = navigation === expectedNavigation
+        if isExpected {
+            expectedNavigationFinished = true
+        }
+        navigationDelegate?.webBridge(self, didFinishNavigation: isExpected ? (contentURL ?? webView.url) : webView.url)
     }
 
     public func webView(_ webView: WKWebView,
                         didFailProvisionalNavigation navigation: WKNavigation!,
                         withError error: Error) {
+        guard !isStaleNavigation(navigation) else {
+            logStaleNavigation("provisional failure: \(error.localizedDescription)")
+            return
+        }
         navigationDelegate?.webBridge(self, didFailProvisionalNavigation: webView.url, error: error)
     }
 
     public func webView(_ webView: WKWebView,
                         didFail navigation: WKNavigation!,
                         withError error: Error) {
+        guard !isStaleNavigation(navigation) else {
+            logStaleNavigation("failure: \(error.localizedDescription)")
+            return
+        }
         navigationDelegate?.webBridge(self, didFailProvisionalNavigation: webView.url, error: error)
     }
     

--- a/MindboxTests/InApp/Tests/WebView/MindboxWebBridgeTests.swift
+++ b/MindboxTests/InApp/Tests/WebView/MindboxWebBridgeTests.swift
@@ -1,0 +1,247 @@
+//
+//  MindboxWebBridgeTests.swift
+//  MindboxTests
+//
+//  Created by Sergei Semko on 06.07.2026.
+//  Copyright © 2026 Mindbox. All rights reserved.
+//
+
+import Testing
+import WebKit
+@_spi(Internal) @testable import Mindbox
+
+/// A reused (pre-warmed) WebView delivers navigation callbacks from previous owners'
+/// loads; leftovers must never reach the show's delegate.
+@Suite("MindboxWebBridge navigation staleness", .tags(.webView))
+@MainActor
+struct MindboxWebBridgeStalenessTests {
+
+    private final class DelegateSpy: WebBridgeNavigationDelegate {
+        private(set) var startCount = 0
+        private(set) var finishCount = 0
+        private(set) var failCount = 0
+        private(set) var finishURLs: [URL?] = []
+
+        func webBridge(_ bridge: MindboxWebBridge, didStartProvisionalNavigation url: URL?) { startCount += 1 }
+        func webBridge(_ bridge: MindboxWebBridge, didFinishNavigation url: URL?) {
+            finishCount += 1
+            finishURLs.append(url)
+        }
+        func webBridge(_ bridge: MindboxWebBridge, didFailProvisionalNavigation url: URL?, error: Error) { failCount += 1 }
+        func webBridge(_ bridge: MindboxWebBridge, decidePolicyFor url: URL?, navigationType: WKNavigationType,
+                       decisionHandler: @escaping (WKNavigationActionPolicy) -> Void) {
+            decisionHandler(.allow)
+        }
+    }
+
+    private let webView: WKWebView
+    private let bridge: MindboxWebBridge
+    private let spy: DelegateSpy
+    // Source of real, distinct WKNavigation objects; separate from `webView` so its async
+    // delegate callbacks can never reach the bridge under test.
+    private let navigationFactory = WKWebView(frame: .zero, configuration: WKWebViewConfiguration())
+
+    init() {
+        webView = WKWebView(frame: .zero, configuration: WKWebViewConfiguration())
+        bridge = MindboxWebBridge(webView: webView)
+        spy = DelegateSpy()
+        bridge.navigationDelegate = spy
+    }
+
+    private func makeNavigation() -> WKNavigation {
+        // swiftlint:disable:next force_unwrapping
+        navigationFactory.loadHTMLString("<html></html>", baseURL: nil)!
+    }
+
+    @Test("Before the show's own load every navigation callback is stale")
+    func everythingIsStaleBeforeContentLoad() {
+        bridge.webView(webView, didStartProvisionalNavigation: makeNavigation())
+        bridge.webView(webView, didFinish: makeNavigation())
+
+        #expect(spy.startCount == 0)
+        #expect(spy.finishCount == 0)
+    }
+
+    @Test("Only the expected navigation's callbacks reach the delegate")
+    func strangerNavigationsAreFiltered() {
+        let expected = makeNavigation()
+        bridge.expectContentNavigation(expected)
+
+        let stranger = makeNavigation()
+        bridge.webView(webView, didStartProvisionalNavigation: stranger)
+        bridge.webView(webView, didFinish: stranger)
+        #expect(spy.startCount == 0)
+        #expect(spy.finishCount == 0)
+
+        bridge.webView(webView, didStartProvisionalNavigation: expected)
+        bridge.webView(webView, didFinish: expected)
+        #expect(spy.startCount == 1)
+        #expect(spy.finishCount == 1)
+    }
+
+    @Test("After the expected navigation finished the filter opens for page-initiated navigations")
+    func filterOpensAfterExpectedFinish() {
+        let expected = makeNavigation()
+        bridge.expectContentNavigation(expected)
+        bridge.webView(webView, didFinish: expected)
+        #expect(spy.finishCount == 1)
+
+        bridge.webView(webView, didFinish: makeNavigation())
+        #expect(spy.finishCount == 2)
+    }
+
+    @Test("A nil expected navigation (loadHTMLString returned nil) fails open, not closed")
+    func nilExpectedNavigationFailsOpen() {
+        bridge.expectContentNavigation(nil)
+
+        bridge.webView(webView, didFinish: makeNavigation())
+
+        #expect(spy.finishCount == 1)
+    }
+
+    @Test("A nil callback navigation fails open, mirroring the nil-expected case")
+    func nilCallbackNavigationFailsOpen() {
+        bridge.expectContentNavigation(makeNavigation())
+
+        bridge.webView(webView, didFailProvisionalNavigation: nil, withError: NSError(domain: "test", code: 2))
+        #expect(spy.failCount == 1)
+
+        bridge.webView(webView, didFinish: nil)
+        #expect(spy.finishCount == 1)
+    }
+
+    @Test("Stale failure callbacks never close the show")
+    func staleFailuresAreFiltered() {
+        bridge.expectContentNavigation(makeNavigation())
+
+        bridge.webView(webView, didFailProvisionalNavigation: makeNavigation(),
+                       withError: NSError(domain: "test", code: 1))
+
+        #expect(spy.failCount == 0)
+    }
+
+    @Test("Only the show's own finish reports the content URL; page navigations report their real URL")
+    func finishReportsPerNavigationURL() {
+        let contentURL = URL(string: "https://content.mindbox.ru/index.html")
+        bridge.updateContentURL(contentURL)
+        let expected = makeNavigation()
+        bridge.expectContentNavigation(expected)
+
+        bridge.webView(webView, didFinish: expected)
+        // The unloaded test instance's real URL is nil — distinct from contentURL.
+        bridge.webView(webView, didFinish: makeNavigation())
+
+        #expect(spy.finishURLs.count == 2)
+        #expect(spy.finishURLs.first == contentURL)
+        #expect(spy.finishURLs.last == URL?.none)
+    }
+}
+
+/// Script messages have their own gate: until the show's own document commits, a reused
+/// WebView's previous document (e.g. a dying prewarm page) can still post to the freshly
+/// attached handler — answering it could present a page that must never be shown.
+@Suite("MindboxWebBridge message gate", .tags(.webView))
+@MainActor
+struct MindboxWebBridgeMessageGateTests {
+
+    private final class MessageSpy: WebBridgeMessageDelegate {
+        private(set) var received: [BridgeMessage] = []
+        func webBridge(_ bridge: MindboxWebBridge, didReceiveBridgeMessage message: BridgeMessage) {
+            received.append(message)
+        }
+    }
+
+    /// WKScriptMessage's real initializer is WebKit-internal; the bridge only reads
+    /// `name` and `body`.
+    private final class FakeScriptMessage: WKScriptMessage {
+        private let fakeName: String
+        private let fakeBody: Any
+
+        init(name: String, body: Any) {
+            self.fakeName = name
+            self.fakeBody = body
+            super.init()
+        }
+
+        override var name: String { fakeName }
+        override var body: Any { fakeBody }
+    }
+
+    private let webView: WKWebView
+    private let bridge: MindboxWebBridge
+    private let spy: MessageSpy
+    private let navigationFactory = WKWebView(frame: .zero, configuration: WKWebViewConfiguration())
+
+    init() {
+        webView = WKWebView(frame: .zero, configuration: WKWebViewConfiguration())
+        bridge = MindboxWebBridge(webView: webView)
+        spy = MessageSpy()
+        bridge.messageDelegate = spy
+    }
+
+    private func makeNavigation() -> WKNavigation {
+        // swiftlint:disable:next force_unwrapping
+        navigationFactory.loadHTMLString("<html></html>", baseURL: nil)!
+    }
+
+    private func postValidMessage() throws {
+        let message = try #require(BridgeMessage(type: .request, action: "log", payload: "hi"))
+        let body = try #require(message.jsonString())
+        bridge.userContentController(
+            webView.configuration.userContentController,
+            didReceive: FakeScriptMessage(name: Constants.WebViewBridgeJS.handlerName, body: body)
+        )
+    }
+
+    @Test("Messages are dropped until the show's own navigation commits")
+    func messagesGatedUntilExpectedCommit() throws {
+        try postValidMessage()
+        #expect(spy.received.isEmpty)
+
+        let expected = makeNavigation()
+        bridge.expectContentNavigation(expected)
+
+        try postValidMessage()
+        #expect(spy.received.isEmpty)
+
+        // A stale (stranger) commit must not open the gate.
+        bridge.webView(webView, didCommit: makeNavigation())
+        try postValidMessage()
+        #expect(spy.received.isEmpty)
+
+        bridge.webView(webView, didCommit: expected)
+        try postValidMessage()
+        #expect(spy.received.count == 1)
+    }
+
+    @Test("A nil expected navigation opens the gate at the first commit (fail-open)")
+    func nilExpectedNavigationGateOpensOnCommit() throws {
+        bridge.expectContentNavigation(nil)
+
+        try postValidMessage()
+        #expect(spy.received.isEmpty)
+
+        bridge.webView(webView, didCommit: makeNavigation())
+        try postValidMessage()
+        #expect(spy.received.count == 1)
+    }
+
+    @Test("A reload re-arms the gate until the new document commits")
+    func reloadRearmsGate() throws {
+        let first = makeNavigation()
+        bridge.expectContentNavigation(first)
+        bridge.webView(webView, didCommit: first)
+        bridge.webView(webView, didFinish: first)
+        try postValidMessage()
+        #expect(spy.received.count == 1)
+
+        let reload = makeNavigation()
+        bridge.expectContentNavigation(reload)
+        try postValidMessage()
+        #expect(spy.received.count == 1)
+
+        bridge.webView(webView, didCommit: reload)
+        try postValidMessage()
+        #expect(spy.received.count == 2)
+    }
+}

--- a/MindboxTests/InApp/Tests/WebView/MindboxWebBridgeTests.swift
+++ b/MindboxTests/InApp/Tests/WebView/MindboxWebBridgeTests.swift
@@ -120,6 +120,25 @@ struct MindboxWebBridgeStalenessTests {
         #expect(spy.failCount == 0)
     }
 
+    @Test("Stale non-provisional failures are filtered too")
+    func staleDidFailIsFiltered() {
+        bridge.expectContentNavigation(makeNavigation())
+
+        bridge.webView(webView, didFail: makeNavigation(), withError: NSError(domain: "test", code: 3))
+
+        #expect(spy.failCount == 0)
+    }
+
+    @Test("The expected navigation's non-provisional failure reaches the delegate")
+    func expectedDidFailReachesDelegate() {
+        let expected = makeNavigation()
+        bridge.expectContentNavigation(expected)
+
+        bridge.webView(webView, didFail: expected, withError: NSError(domain: "test", code: 4))
+
+        #expect(spy.failCount == 1)
+    }
+
     @Test("Only the show's own finish reports the content URL; page navigations report their real URL")
     func finishReportsPerNavigationURL() {
         let contentURL = URL(string: "https://content.mindbox.ru/index.html")


### PR DESCRIPTION
Третий PR стека MOBILE-268 (часть a), в интеграционную ветку `feature/MOBILE-268`. Инфраструктура reuse для прогрева: на переиспользуемом (прогретом) WKWebView колбэки навигации и JS-сообщения могут принадлежать прошлому владельцу.

- Колбэки навигации фильтруются по идентичности `WKNavigation` (fail-open на nil — ранний provisional-fail не доказать как чужой).
- JS-сообщения гейтятся до `didCommit` собственного документа показа (точка подмены документа: кто постит раньше — не эта страница).
- Хендлер и navigationDelegate идемпотентны на реюзе (remove-then-add; delegate weak, чистить в deinit не нужно).

Механизм **инертен** до PR3b: без прогрева переиспользования нет, а армится он вызовом `expectContentNavigation(...)` из фасада (тоже в PR3b). Фасад здесь не трогается. Тесты бьют бридж напрямую.

Тесты: `MindboxWebBridgeStalenessTests` (7) + `MindboxWebBridgeMessageGateTests` (3) — 10/10 зелёные на iOS 26.5, обе мутации (убрать identity-сравнение / не взводить гейт в didCommit) краснят целевой сьют.