### PR TITLE
MOBILE-268: Prewarm engine — head-start and reuse the in-app WebView

### DIFF
--- a/Mindbox.xcodeproj/project.pbxproj
+++ b/Mindbox.xcodeproj/project.pbxproj
@@ -1470,6 +1470,7 @@
 		F385631E2DB6729000D91208 /* InappConfigurationDataFacade */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = InappConfigurationDataFacade; sourceTree = "<group>"; };
 		F397DE1C2CFF568800B72DA9 /* JSONs */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = JSONs; sourceTree = "<group>"; };
 		F3DEB38C2D47CBA200D0EFA4 /* InappSessionManagerTests */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = InappSessionManagerTests; sourceTree = "<group>"; };
+		A8C878878353491FA01AC096 /* WebViewPrewarmTests */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = WebViewPrewarmTests; sourceTree = "<group>"; };
 /* End PBXFileSystemSynchronizedRootGroup section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -2715,6 +2716,7 @@
 			isa = PBXGroup;
 			children = (
 				F367D3772FE43B2900455DB0 /* ModalViewControllerLayoutTests.swift */,
+				A8C878878353491FA01AC096 /* WebViewPrewarmTests */,
 				F385631E2DB6729000D91208 /* InappConfigurationDataFacade */,
 				F3DEB38C2D47CBA200D0EFA4 /* InappSessionManagerTests */,
 				F39B67B62A3FAA62005C0CCA /* ABTesting */,
@@ -3921,6 +3923,7 @@
 				313B233C25ADEA0F00A1CB72 /* PBXTargetDependency */,
 			);
 			fileSystemSynchronizedGroups = (
+				A8C878878353491FA01AC096 /* WebViewPrewarmTests */,
 				F385631E2DB6729000D91208 /* InappConfigurationDataFacade */,
 				F397DE1C2CFF568800B72DA9 /* JSONs */,
 				F3DEB38C2D47CBA200D0EFA4 /* InappSessionManagerTests */,

--- a/Mindbox.xcodeproj/project.pbxproj
+++ b/Mindbox.xcodeproj/project.pbxproj
@@ -7,6 +7,10 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		A881A16C702E41AE93848BD3 /* InAppWebViewLearnedHostsStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B76146361C3402193A00F88 /* InAppWebViewLearnedHostsStore.swift */; };
+		F389B3A639904206A3DADFFA /* InAppWebViewPrewarmPlanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDCC6F9CEEF24C2BAB624DD5 /* InAppWebViewPrewarmPlanner.swift */; };
+		8A94D721DAEF4395A360C5B2 /* InAppWebViewPrewarmNavigationPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96A50D5650094A23A2C667CE /* InAppWebViewPrewarmNavigationPolicy.swift */; };
+		23335221BB1D4F8C8D5C864D /* InAppWebViewPrewarmService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F423FA6C2E243F68A76E9C2 /* InAppWebViewPrewarmService.swift */; };
 		23E4A509BFE94104BD01B61A /* MindboxWebBridgeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CC5ED4F76B046798978B4B9 /* MindboxWebBridgeTests.swift */; };
 		AE190755CA97473B83E1568D /* MBContainerConcurrencyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B4F5CEE405E4BE29F97E43B /* MBContainerConcurrencyTests.swift */; };
 		3FDBA6E4D39A49369A335CF4 /* SDKUserAgentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E45E06561604E6185C33366 /* SDKUserAgentTests.swift */; };
@@ -744,6 +748,10 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		1B76146361C3402193A00F88 /* InAppWebViewLearnedHostsStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InAppWebViewLearnedHostsStore.swift; sourceTree = "<group>"; };
+		DDCC6F9CEEF24C2BAB624DD5 /* InAppWebViewPrewarmPlanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InAppWebViewPrewarmPlanner.swift; sourceTree = "<group>"; };
+		96A50D5650094A23A2C667CE /* InAppWebViewPrewarmNavigationPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InAppWebViewPrewarmNavigationPolicy.swift; sourceTree = "<group>"; };
+		1F423FA6C2E243F68A76E9C2 /* InAppWebViewPrewarmService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InAppWebViewPrewarmService.swift; sourceTree = "<group>"; };
 		9CC5ED4F76B046798978B4B9 /* MindboxWebBridgeTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MindboxWebBridgeTests.swift; sourceTree = "<group>"; };
 		4B4F5CEE405E4BE29F97E43B /* MBContainerConcurrencyTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MBContainerConcurrencyTests.swift; sourceTree = "<group>"; };
 		4E45E06561604E6185C33366 /* SDKUserAgentTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SDKUserAgentTests.swift; sourceTree = "<group>"; };
@@ -3042,6 +3050,17 @@
 			path = InAppTargetingChecker;
 			sourceTree = "<group>";
 		};
+		0E8BCE24EE9540D6BD7F655D /* Prewarm */ = {
+			isa = PBXGroup;
+			children = (
+				1B76146361C3402193A00F88 /* InAppWebViewLearnedHostsStore.swift */,
+				DDCC6F9CEEF24C2BAB624DD5 /* InAppWebViewPrewarmPlanner.swift */,
+				96A50D5650094A23A2C667CE /* InAppWebViewPrewarmNavigationPolicy.swift */,
+				1F423FA6C2E243F68A76E9C2 /* InAppWebViewPrewarmService.swift */,
+			);
+			path = Prewarm;
+			sourceTree = "<group>";
+		};
 		B4E4386F2D8AFA5700603F3A /* WebView */ = {
 			isa = PBXGroup;
 			children = (
@@ -3049,6 +3068,7 @@
 				A85CCBEB1D874078954BB771 /* InAppWebViewHTMLFetcher.swift */,
 				6D096F433EBB44C8B3490CF6 /* InAppWebViewDataStore.swift */,
 				F2DAFC2435264F15B8033CCE /* WebViewReadyChecker.swift */,
+				0E8BCE24EE9540D6BD7F655D /* Prewarm */,
 				47B1B6A92F6174E0000A4B67 /* LocalState */,
 				F3BD9F802F273BC800647BAF /* Bridge */,
 				F30654B92F1A83430058808C /* Debug */,
@@ -4294,6 +4314,10 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				A881A16C702E41AE93848BD3 /* InAppWebViewLearnedHostsStore.swift in Sources */,
+				F389B3A639904206A3DADFFA /* InAppWebViewPrewarmPlanner.swift in Sources */,
+				8A94D721DAEF4395A360C5B2 /* InAppWebViewPrewarmNavigationPolicy.swift in Sources */,
+				23335221BB1D4F8C8D5C864D /* InAppWebViewPrewarmService.swift in Sources */,
 				28375259024D42658E146900 /* InAppWebViewFactory.swift in Sources */,
 				B58D5207F49F4531AA1C516B /* InAppWebViewHTMLFetcher.swift in Sources */,
 				2DBF19F24FEA48AAA39C33E6 /* InAppWebViewDataStore.swift in Sources */,

--- a/Mindbox/DI/Injections/InjectCore.swift
+++ b/Mindbox/DI/Injections/InjectCore.swift
@@ -48,7 +48,8 @@ extension MBContainer {
                 inAppConfigRepository: InAppConfigurationRepository(),
                 inappMapper: DI.injectOrFail(InappMapperProtocol.self),
                 persistenceStorage: persistenceStorage,
-                featureToggleManager: featureToggleManager)
+                featureToggleManager: featureToggleManager,
+                webViewPrewarmService: DI.injectOrFail(InAppWebViewPrewarmServiceProtocol.self))
         }
         
         register(CheckNotifWork.self) {

--- a/Mindbox/DI/Injections/InjectInappTools.swift
+++ b/Mindbox/DI/Injections/InjectInappTools.swift
@@ -129,6 +129,11 @@ extension MBContainer {
             )
         }
 
+        register(InAppWebViewPrewarmServiceProtocol.self) {
+            let persistenceStorage = DI.injectOrFail(PersistenceStorage.self)
+            return InAppWebViewPrewarmService(persistenceStorage: persistenceStorage)
+        }
+
         return self
     }
 }

--- a/Mindbox/InAppMessages/Configuration/InAppConfigurationManager.swift
+++ b/Mindbox/InAppMessages/Configuration/InAppConfigurationManager.swift
@@ -33,19 +33,22 @@ class InAppConfigurationManager: InAppConfigurationManagerProtocol {
     private let inAppConfigAPI: InAppConfigurationAPI
     private let persistenceStorage: PersistenceStorage
     private let featureToggleManager: FeatureToggleManager
+    private let webViewPrewarmService: InAppWebViewPrewarmServiceProtocol
 
     init(
         inAppConfigAPI: InAppConfigurationAPI,
         inAppConfigRepository: InAppConfigurationRepository,
         inappMapper: InappMapperProtocol?,
         persistenceStorage: PersistenceStorage,
-        featureToggleManager: FeatureToggleManager
+        featureToggleManager: FeatureToggleManager,
+        webViewPrewarmService: InAppWebViewPrewarmServiceProtocol
     ) {
         self.inAppConfigRepository = inAppConfigRepository
         self.inappMapper = inappMapper
         self.inAppConfigAPI = inAppConfigAPI
         self.persistenceStorage = persistenceStorage
         self.featureToggleManager = featureToggleManager
+        self.webViewPrewarmService = webViewPrewarmService
     }
 
     weak var delegate: InAppConfigurationDelegate?
@@ -101,6 +104,11 @@ class InAppConfigurationManager: InAppConfigurationManagerProtocol {
             Logger.common(message: "Failed to download InApp configuration. Error: \(error.localizedDescription)", level: .error, category: .inAppMessages)
         }
 
+        // Prewarm stage 2: warm what the config's webview in-apps need (or release the
+        // warm instance when the config proves there are none).
+        if let configResponse {
+            webViewPrewarmService.prewarmResources(for: configResponse)
+        }
         self.delegate?.didPreparedConfiguration()
         sendNotification(with: configResponse?.settings?.slidingExpiration?.pushTokenKeepalive)
     }

--- a/Mindbox/InAppMessages/Presentation/Views/WebView/Debug/MindboxWebViewFacade.swift
+++ b/Mindbox/InAppMessages/Presentation/Views/WebView/Debug/MindboxWebViewFacade.swift
@@ -81,13 +81,32 @@ public final class MindboxWebViewFacade: MindboxInternalWebViewFacadeProtocol {
     private let log: WebViewLog
     private let logError: WebViewLogError
 
+    // Main-confined. A borrowed prewarmed `webView` outlives this facade (the prewarm
+    // service keeps it warm across shows), so a `[weak webView]` guard is not enough to
+    // stop a slow fetch that completes after the show closed — it would load the dead
+    // show's page into the parked hidden instance. `isClosed` gates the load and the
+    // in-flight fetch is cancelled outright on teardown.
+    private var fetchTask: URLSessionDataTask?
+    private var isClosed = false
+
     public init(params: [String: JSONValue]?,
                 operation: (name: String, body: String)? = nil,
                 userAgent: String,
                 inAppId: String = "",
                 log: @escaping WebViewLog = { _ in },
                 logError: @escaping WebViewLogError = { _ in }) {
-        let webView = InAppWebViewFactory.make(userAgent: userAgent)
+        // Borrow the prewarmed live instance when available (kept across shows — hidden,
+        // not destroyed); otherwise create one on the same shared data store so cached
+        // resources stay visible either way. A warm instance can only serve a caller that
+        // wants the stock UA: its applicationNameForUserAgent was baked at prewarm
+        // creation and cannot change on a live WKWebView.
+        let webView: WKWebView
+        if userAgent == SDKUserAgent.build(),
+           let warm = DI.injectOrFail(InAppWebViewPrewarmServiceProtocol.self).borrowWarmWebView() {
+            webView = warm
+        } else {
+            webView = InAppWebViewFactory.make(userAgent: userAgent)
+        }
         let bridge = MindboxWebBridge(webView: webView)
 
         self.webView = webView
@@ -97,6 +116,12 @@ public final class MindboxWebViewFacade: MindboxInternalWebViewFacadeProtocol {
         self.inAppId = inAppId
         self.log = log
         self.logError = logError
+    }
+
+    deinit {
+        // The fetch completion holds only a weak self, so a pending request can outlive
+        // the facade; cancel it so it can never resume work against a reused webView.
+        fetchTask?.cancel()
     }
 
     public func makeView() -> UIView {
@@ -110,36 +135,35 @@ public final class MindboxWebViewFacade: MindboxInternalWebViewFacadeProtocol {
         let contentURL = URL(string: contentUrl)
         bridge.updateContentURL(contentURL)
         
-        fetchHTML(from: contentUrl) { [weak webView] html in
-            guard let webView else {
-                DispatchQueue.main.async {
+        fetchHTML(from: contentUrl) { [weak self] html in
+            DispatchQueue.main.async {
+                // A show that closed while the fetch was in flight must not load into the
+                // (possibly reused) webView, and must not re-report failure — it is already
+                // tearing down.
+                guard let self, !self.isClosed else { return }
+                guard let html else {
                     onFailure()
+                    return
                 }
-                return
+                self.bridge.expectContentNavigation(self.webView.loadHTMLString(html, baseURL: url))
             }
+        }
+    }
 
-            if let html {
-                DispatchQueue.main.async {
-                    webView.loadHTMLString(html, baseURL: url)
-                }
-            } else {
-                DispatchQueue.main.async {
-                    onFailure()
-                }
-            }
-        }
-    }
-    
     public func reloadWebView() {
-        DispatchQueue.main.async { [weak webView] in
-            webView?.reload()
+        DispatchQueue.main.async { [weak self] in
+            guard let self, !self.isClosed else { return }
+            self.bridge.expectContentNavigation(self.webView.reload())
         }
     }
-    
+
     public func cleanWebView() {
-        DispatchQueue.main.async { [weak webView] in
-            guard let webView else { return }
-            webView.stopLoading()
+        DispatchQueue.main.async { [weak self] in
+            guard let self else { return }
+            self.isClosed = true
+            self.fetchTask?.cancel()
+            self.fetchTask = nil
+            self.webView.stopLoading()
         }
     }
     
@@ -301,7 +325,7 @@ extension MindboxWebViewFacade {
             completion(nil)
             return
         }
-        
+
         let (session, request) = InAppWebViewHTMLFetcher.sessionAndRequest(for: url)
 
         log("Fetching HTML from \(url.absoluteString)")
@@ -331,6 +355,9 @@ extension MindboxWebViewFacade {
             completion(htmlString)
         }
 
+        // Retained so teardown can cancel an in-flight request. Main-confined: `loadHTML`
+        // (the sole caller) runs on the main thread.
+        fetchTask = task
         task.resume()
     }
 }

--- a/Mindbox/InAppMessages/Presentation/Views/WebView/Prewarm/InAppWebViewLearnedHostsStore.swift
+++ b/Mindbox/InAppMessages/Presentation/Views/WebView/Prewarm/InAppWebViewLearnedHostsStore.swift
@@ -1,0 +1,53 @@
+//
+//  InAppWebViewLearnedHostsStore.swift
+//  Mindbox
+//
+//  Created by Sergei Semko on 06.07.2026.
+//  Copyright © 2026 Mindbox. All rights reserved.
+//
+
+import Foundation
+
+/// Persists resource hosts observed during real shows, per endpoint. These are the hosts
+/// the config cannot know (image CDNs, the web runtime's static hosts, fonts) and they
+/// let the next launch's preconnect cover the heavy part of the page. A stale entry is
+/// harmless — preconnect to an unused host is a no-op. Backed by `PersistenceStorage`
+/// like the rest of the SDK's state.
+final class InAppWebViewLearnedHostsStore {
+    static let maxHosts = 12
+
+    private let persistenceStorage: PersistenceStorage
+
+    init(persistenceStorage: PersistenceStorage) {
+        self.persistenceStorage = persistenceStorage
+    }
+
+    func hosts(endpoint: String) -> [String] {
+        persistenceStorage.webViewLearnedHosts?[endpoint] ?? []
+    }
+
+    /// Appends newly observed hosts, keeping insertion order and dropping the oldest
+    /// beyond the cap. Values come from page JS — only bare https hosts are accepted.
+    ///
+    /// Main-thread only: this is an unsynchronized read-modify-write, safe because the
+    /// single caller (the show's evaluateJavaScript completion) always runs on main.
+    func remember(_ observed: [String], endpoint: String) {
+        guard !observed.isEmpty else { return }
+        var all = persistenceStorage.webViewLearnedHosts ?? [:]
+        var merged = all[endpoint] ?? []
+        var didAppend = false
+        for host in observed where InAppWebViewPrewarmPlanner.isValidHost(host) && !merged.contains(host) {
+            merged.append(host)
+            didAppend = true
+        }
+        // Steady state after the first shows: every observed host is already known. Skip
+        // the app-group UserDefaults rewrite (a synchronous cfprefsd round-trip on the
+        // main thread) when nothing was added.
+        guard didAppend else { return }
+        if merged.count > Self.maxHosts {
+            merged.removeFirst(merged.count - Self.maxHosts)
+        }
+        all[endpoint] = merged
+        persistenceStorage.webViewLearnedHosts = all
+    }
+}

--- a/Mindbox/InAppMessages/Presentation/Views/WebView/Prewarm/InAppWebViewPrewarmNavigationPolicy.swift
+++ b/Mindbox/InAppMessages/Presentation/Views/WebView/Prewarm/InAppWebViewPrewarmNavigationPolicy.swift
@@ -1,0 +1,44 @@
+//
+//  InAppWebViewPrewarmNavigationPolicy.swift
+//  Mindbox
+//
+//  Created by Sergei Semko on 06.07.2026.
+//  Copyright © 2026 Mindbox. All rights reserved.
+//
+
+import WebKit
+import MindboxLogger
+
+/// Pins the hidden prewarm instance to the documents the SDK itself loads: any
+/// page-initiated main-frame navigation (JS redirect, meta refresh) is cancelled — a
+/// hidden WebView must never wander off and keep fetching arbitrary URLs. Active only
+/// until the first borrow; the show's bridge installs its own delegate then.
+final class InAppWebViewPrewarmNavigationPolicy: NSObject, WKNavigationDelegate {
+
+    // Main-thread confined, like every WKWebView interaction around it.
+    private var allowedURLs: Set<String> = ["about:blank"]
+
+    /// Registers a document URL the service is about to load itself.
+    func allow(_ url: URL) {
+        allowedURLs.insert(url.absoluteString)
+    }
+
+    /// Pure decision core (WKNavigationAction cannot be faked in tests). Subframes are
+    /// the page's own business; a nil target frame (window.open) is pinned like the top frame.
+    func decision(for url: URL?, targetIsMainFrame: Bool?) -> WKNavigationActionPolicy {
+        if targetIsMainFrame == false { return .allow }
+        return allowedURLs.contains(url?.absoluteString ?? "about:blank") ? .allow : .cancel
+    }
+
+    func webView(_ webView: WKWebView,
+                 decidePolicyFor navigationAction: WKNavigationAction,
+                 decisionHandler: @escaping (WKNavigationActionPolicy) -> Void) {
+        let verdict = decision(for: navigationAction.request.url,
+                               targetIsMainFrame: navigationAction.targetFrame?.isMainFrame)
+        if verdict == .cancel {
+            Logger.common(message: "[WebView] Prewarm: blocked page-initiated navigation to \(navigationAction.request.url?.absoluteString ?? "nil")",
+                          level: .info, category: .webViewInAppMessages)
+        }
+        decisionHandler(verdict)
+    }
+}

--- a/Mindbox/InAppMessages/Presentation/Views/WebView/Prewarm/InAppWebViewPrewarmPlanner.swift
+++ b/Mindbox/InAppMessages/Presentation/Views/WebView/Prewarm/InAppWebViewPrewarmPlanner.swift
@@ -1,0 +1,106 @@
+//
+//  InAppWebViewPrewarmPlanner.swift
+//  Mindbox
+//
+//  Created by Sergei Semko on 06.07.2026.
+//  Copyright © 2026 Mindbox. All rights reserved.
+//
+
+import Foundation
+
+/// Derives everything the webview prewarm needs from the in-app config. Pure functions.
+enum InAppWebViewPrewarmPlanner {
+
+    /// WebKit partitions its HTTP cache by the top-level document's host, which for
+    /// `loadHTMLString` is the `baseURL` host — so the prewarm MUST use the same baseUrl
+    /// the shows use, and both URLs MUST come from the same layer (mixing layers would
+    /// warm one layer's content under another layer's partition, invisible to its show).
+    static func prewarmSource(for layers: [WebviewContentBackgroundLayerDTO]) -> (baseURL: URL, contentURL: URL)? {
+        for layer in layers {
+            guard let baseURL = layer.baseUrl.flatMap(URL.init(string:)),
+                  baseURL.scheme?.lowercased() == "https", baseURL.host != nil,
+                  let contentURL = layer.contentUrl.flatMap(URL.init(string:)),
+                  contentURL.scheme?.lowercased() == "https" else { continue }
+            return (baseURL, contentURL)
+        }
+        return nil
+    }
+
+    /// Hosts worth opening DNS+TCP+TLS to before the first show: every webview layer's
+    /// `contentUrl` host, the configured API domain, plus hosts learned from previous shows.
+    static func preconnectHosts(layers: [WebviewContentBackgroundLayerDTO],
+                                apiDomain: String?,
+                                learnedHosts: [String]) -> [String] {
+        var hosts = Set(layers.compactMap { layer -> String? in
+            guard let contentUrl = layer.contentUrl, let host = URL(string: contentUrl)?.host else { return nil }
+            return host
+        })
+        if let apiDomain, !apiDomain.isEmpty {
+            hosts.insert(apiDomain)
+        }
+        hosts.formUnion(learnedHosts)
+        return hosts.sorted()
+    }
+
+    /// A page of `<link rel="preconnect">` hints: WebKit opens pooled connections to each
+    /// host without downloading anything; the show reuses the pool. Every host is
+    /// re-validated at this single choke point — hosts get interpolated into markup.
+    static func preconnectHTML(hosts: [String]) -> String {
+        let links = hosts
+            .filter(isValidHost)
+            .map { "<link rel=\"preconnect\" href=\"https://\($0)\" crossorigin><link rel=\"dns-prefetch\" href=\"https://\($0)\">" }
+            .joined()
+        return "<html><head><meta charset=\"utf-8\">\(links)</head><body></body></html>"
+    }
+
+    /// Accepts only strings that pass the SDK-wide RFC 1123 host validation, so no source
+    /// (page JS, config, API domain) can ever turn a host slot into markup. An explicit
+    /// charset, unlike a `URL(string:)` round-trip, doesn't ride on Foundation's parser
+    /// semantics and rejects sub-delims (`&`, `'`, `;`, …) that survive a URL host slot.
+    static func isValidHost(_ host: String) -> Bool {
+        URLValidator.isValidHost(host)
+    }
+
+    /// The official prewarm contract with the web runtime: the prewarm content page is
+    /// loaded with these parameters on its document URL (`loadHTMLString` baseURL →
+    /// `location.search`), and a runtime that knows the contract boots tracker-only —
+    /// no `ready` handshake, no form, byendpoint straight into the HTTP cache. Older
+    /// runtimes ignore the parameters (plain page warm). Shows never get these parameters.
+    static func prewarmContentBaseURL(from baseURL: URL, endpoint: String, deviceUUID: String) -> URL {
+        guard var components = URLComponents(url: baseURL, resolvingAgainstBaseURL: false) else { return baseURL }
+        var queryItems = components.queryItems ?? []
+        queryItems.append(URLQueryItem(name: "prewarm", value: "1"))
+        queryItems.append(URLQueryItem(name: "endpointId", value: endpoint))
+        queryItems.append(URLQueryItem(name: "deviceUuid", value: deviceUUID))
+        components.queryItems = queryItems
+        return components.url ?? baseURL
+    }
+
+    static func webviewLayers(in config: ConfigResponse) -> [WebviewContentBackgroundLayerDTO] {
+        var result: [WebviewContentBackgroundLayerDTO] = []
+        for inapp in config.inapps?.elements ?? [] {
+            for variant in inapp.form.variants ?? [] {
+                let layers: [ContentBackgroundLayerDTO]?
+                switch variant {
+                case .modal(let modal): layers = modal.content?.background?.layers
+                case .snackbar(let snackbar): layers = snackbar.content?.background?.layers
+                case .unknown: layers = nil
+                }
+                for layer in layers ?? [] {
+                    if case .webview(let webview) = layer {
+                        result.append(webview)
+                    }
+                }
+            }
+        }
+        return result
+    }
+
+    /// JS evaluated in a shown WebView to collect the distinct https hosts its resources
+    /// actually came from. Host names only — no URLs, no payloads.
+    static let observedHostsScript = """
+    Array.from(new Set(performance.getEntriesByType('resource').map(function (r) {
+      try { var u = new URL(r.name); return u.protocol === 'https:' ? u.host : null } catch (e) { return null }
+    }).filter(Boolean)))
+    """
+}

--- a/Mindbox/InAppMessages/Presentation/Views/WebView/Prewarm/InAppWebViewPrewarmService.swift
+++ b/Mindbox/InAppMessages/Presentation/Views/WebView/Prewarm/InAppWebViewPrewarmService.swift
@@ -1,0 +1,307 @@
+//
+//  InAppWebViewPrewarmService.swift
+//  Mindbox
+//
+//  Created by Sergei Semko on 06.07.2026.
+//  Copyright © 2026 Mindbox. All rights reserved.
+//
+
+import Foundation
+import UIKit
+import WebKit
+import MindboxLogger
+
+protocol InAppWebViewPrewarmServiceProtocol: AnyObject {
+    /// Stage 1, at SDK initialization: when the previous launch left a cached config with
+    /// webview in-apps, creates the warm instance and starts the resource prewarm ahead of
+    /// the fresh config download. Hosts without webview in-apps never pay for a
+    /// web-content process — nothing is created until a config proves it's needed.
+    func prewarmProcess()
+
+    /// Stage 2, when a freshly downloaded config has been parsed: starts the resource
+    /// prewarm if it hasn't run from the cached config yet, or releases the stage-1
+    /// instance when the config has no webview in-apps.
+    func prewarmResources(for config: ConfigResponse)
+
+    /// Hands the warm instance to a show (borrow, not consume — the same live instance
+    /// serves subsequent shows). Any prewarm page is torn down first.
+    func borrowWarmWebView() -> WKWebView?
+
+    /// Called when a show is torn down: navigates the parked instance to a blank page so
+    /// the closed in-app's JS stops running hidden, keeping the process warm for the next show.
+    func parkWarmWebView()
+
+    /// Called by a show when its page is done: persists the observed resource hosts for
+    /// the next launch's preconnect.
+    func rememberObservedHosts(_ hosts: [String])
+}
+
+final class InAppWebViewPrewarmService: InAppWebViewPrewarmServiceProtocol {
+
+    private let persistenceStorage: PersistenceStorage
+    private let learnedHostsStore: InAppWebViewLearnedHostsStore
+    private let makeWebView: () -> WKWebView
+    private let fetchHTML: (URL, @escaping (String?) -> Void) -> Void
+    private let loadCachedConfig: () -> ConfigResponse?
+
+    // Main-thread confined (WKWebView requirement); all mutations hop to main. The flags
+    // latch for the rest of the launch by design: after the first borrow the cache is
+    // warmer than any prewarm could make it, and re-running the prewarm would navigate a
+    // live show's webview.
+    private var warmWebView: WKWebView?
+    private var hasBeenBorrowed = false
+    // Write-once, decided on the main hop: set when the resource prewarm starts OR when a
+    // config-driven release fires. The release must latch too — one that lands on main
+    // before the slow stage-1 hop has nothing to drop yet, and without the latch the stale
+    // stage-1 block would then create the instance a fresh config already said to kill.
+    private var resourcePrewarmLatched = false
+    // True between borrow and park: `superview` alone can't tell (there is a window
+    // between borrow and addSubview).
+    private var isLentToShow = false
+    private var memoryWarningObserver: NSObjectProtocol?
+    // Retained here because navigationDelegate is weak; armed until the first borrow.
+    private let prewarmNavigationPolicy = InAppWebViewPrewarmNavigationPolicy()
+
+    init(persistenceStorage: PersistenceStorage,
+         makeWebView: @escaping () -> WKWebView = { InAppWebViewFactory.make() },
+         fetchHTML: @escaping (URL, @escaping (String?) -> Void) -> Void = InAppWebViewPrewarmService.defaultFetchHTML,
+         loadCachedConfig: @escaping () -> ConfigResponse? = InAppWebViewPrewarmService.defaultLoadCachedConfig) {
+        self.persistenceStorage = persistenceStorage
+        self.learnedHostsStore = InAppWebViewLearnedHostsStore(persistenceStorage: persistenceStorage)
+        self.makeWebView = makeWebView
+        self.fetchHTML = fetchHTML
+        self.loadCachedConfig = loadCachedConfig
+        startMemoryWarningObserver()
+    }
+
+    deinit {
+        // Block-based observers are not auto-removed. The token is optional solely
+        // because its block captures self and can't be created during two-phase init.
+        if let memoryWarningObserver {
+            NotificationCenter.default.removeObserver(memoryWarningObserver)
+        }
+    }
+
+    /// Frees the parked warm instance under memory pressure: the HTTP cache is disk-level
+    /// and survives, so the next show only re-pays the web-content process spin-up. An
+    /// instance lent to a live show is left alone — the show owns it.
+    private func startMemoryWarningObserver() {
+        memoryWarningObserver = NotificationCenter.default.addObserver(
+            forName: UIApplication.didReceiveMemoryWarningNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            guard let self, let webView = self.warmWebView, !self.isLentToShow else { return }
+            webView.stopLoading()
+            self.warmWebView = nil
+            Logger.common(message: "[WebView] Prewarm: memory warning — releasing the parked warm instance",
+                          level: .info, category: .webViewInAppMessages)
+        }
+    }
+
+    func prewarmProcess() {
+        // Boots from the PREVIOUS launch's cached config: waiting for the fresh one would
+        // lose the race to a launch-triggered show. A stale URL is harmless — the next
+        // launch picks up the fresh config.
+        DispatchQueue.global(qos: .utility).async { [weak self] in
+            // Warm the cache-toggle latch here: its initializer reads and decodes the
+            // cached config, and every other first-access path runs on the main thread.
+            _ = InAppWebViewDataStore.isCacheFeatureEnabled
+            guard let self, let config = self.loadCachedConfig() else { return }
+            guard Self.isPrewarmEnabled(in: config) else { return }
+            let layers = InAppWebViewPrewarmPlanner.webviewLayers(in: config)
+            guard !layers.isEmpty else { return }
+            self.startResourcePrewarm(layers: layers)
+        }
+    }
+
+    func prewarmResources(for config: ConfigResponse) {
+        // A fresh config that turns the toggle off also kills a stage-1 instance started
+        // under the previous launch's config.
+        guard Self.isPrewarmEnabled(in: config) else {
+            releaseUnusedWarmWebView(reason: .featureToggleOff)
+            return
+        }
+        let layers = InAppWebViewPrewarmPlanner.webviewLayers(in: config)
+        guard !layers.isEmpty else {
+            releaseUnusedWarmWebView(reason: .noWebviewInApps)
+            return
+        }
+        startResourcePrewarm(layers: layers)
+    }
+
+    /// The prewarm half of the WebView feature toggles, read from the config each stage
+    /// works with: stage 1 sees the previous launch's cached toggles, stage 2 the fresh
+    /// ones. An absent key or section means "enabled" — a kill switch, not an opt-in.
+    private static func isPrewarmEnabled(in config: ConfigResponse) -> Bool {
+        config.settings?.featureToggles?.shouldPrewarmInAppWebView
+            ?? FeatureFlag.shouldPrewarmInAppWebView.defaultValue
+    }
+
+    func borrowWarmWebView() -> WKWebView? {
+        // Never trap in a host app: an off-main caller just doesn't get the warm
+        // instance — returning nil is always correct (the show creates its own WebView
+        // on the shared store) and touches none of the main-confined state.
+        guard Thread.isMainThread else {
+            Logger.common(message: "[WebView] Prewarm: borrowWarmWebView() called off the main thread — ignoring",
+                          level: .error, category: .webViewInAppMessages)
+            return nil
+        }
+        // Latch even when there is nothing to hand out: a show is starting, and a
+        // resource prewarm kicked off after this point would compete with it.
+        hasBeenBorrowed = true
+        guard let webView = warmWebView else { return nil }
+        // Presentation is serialized upstream, but that flag has known races — never let
+        // a second show steal the instance out of an on-screen in-app.
+        guard !isLentToShow else { return nil }
+        // Never hand out an instance mid-navigation: the show's load would land on a
+        // half-committed document and its didFinish can fire before the page's module
+        // scripts evaluate. Park it instead; the show creates a fresh WKWebView on the
+        // same shared store (pays process spin-up, keeps the HTTP cache).
+        guard !webView.isLoading else {
+            webView.stopLoading()
+            webView.loadHTMLString(Self.blankPage, baseURL: nil)
+            Logger.common(message: "[WebView] Prewarm: instance is mid-navigation at borrow — parking it, the show gets a fresh WebView",
+                          level: .info, category: .webViewInAppMessages)
+            return nil
+        }
+        // The instance belongs to the show from here; the blank load tears down the
+        // prewarm page so its JS can't compete with the show for bandwidth. The bridge's
+        // staleness filter ignores both leftovers' callbacks.
+        webView.stopLoading()
+        webView.loadHTMLString(Self.blankPage, baseURL: nil)
+        webView.removeFromSuperview()
+        isLentToShow = true
+        return webView
+    }
+
+    func parkWarmWebView() {
+        DispatchQueue.main.async {
+            guard let webView = self.warmWebView else {
+                self.isLentToShow = false
+                return
+            }
+            // Only park an instance no live show is presenting (a newer show may have
+            // borrowed it before this teardown arrived).
+            guard webView.superview == nil else { return }
+            self.isLentToShow = false
+            // Fully detach the finished show: WKUserContentController retains its script
+            // handlers, so the previous show's bridge would otherwise stay on the
+            // parked instance until the next show replaces it.
+            if #available(iOS 14.0, *) {
+                webView.configuration.userContentController.removeAllScriptMessageHandlers()
+            } else {
+                webView.configuration.userContentController.removeScriptMessageHandler(forName: Constants.WebViewBridgeJS.handlerName)
+            }
+            webView.loadHTMLString(Self.blankPage, baseURL: nil)
+        }
+    }
+
+    func rememberObservedHosts(_ hosts: [String]) {
+        guard let configuration = persistenceStorage.configuration else { return }
+        learnedHostsStore.remember(hosts, endpoint: configuration.endpoint)
+    }
+
+    // MARK: Resource prewarm
+
+    /// Two loads on the warm instance, both under the shows' cache partition (`baseUrl`
+    /// from the config's webview layer): a preconnect page (DNS+TCP+TLS to every known
+    /// host), then the real content page with the official prewarm parameters on its
+    /// baseURL — a runtime that knows the contract downloads its bundles straight into
+    /// the HTTP cache; an older runtime degrades to a plain page warm.
+    private func startResourcePrewarm(layers: [WebviewContentBackgroundLayerDTO]) {
+        guard let configuration = persistenceStorage.configuration,
+              let (baseURL, contentURL) = InAppWebViewPrewarmPlanner.prewarmSource(for: layers) else { return }
+
+        let hosts = InAppWebViewPrewarmPlanner.preconnectHosts(
+            layers: layers,
+            apiDomain: configuration.domain,
+            learnedHosts: learnedHostsStore.hosts(endpoint: configuration.endpoint)
+        )
+        let endpoint = configuration.endpoint
+        let deviceUUID = persistenceStorage.deviceUUID ?? ""
+
+        DispatchQueue.main.async {
+            guard !self.hasBeenBorrowed, !self.resourcePrewarmLatched else { return }
+            self.resourcePrewarmLatched = true
+            if self.warmWebView == nil {
+                self.warmWebView = self.makeWebView()
+                self.warmWebView?.navigationDelegate = self.prewarmNavigationPolicy
+            }
+            if !hosts.isEmpty {
+                self.prewarmNavigationPolicy.allow(baseURL)
+                self.warmWebView?.loadHTMLString(InAppWebViewPrewarmPlanner.preconnectHTML(hosts: hosts), baseURL: baseURL)
+                Logger.common(message: "[WebView] Prewarm: preconnect to \(hosts.joined(separator: ",")) under \(baseURL.absoluteString)",
+                              level: .info, category: .webViewInAppMessages)
+            }
+            self.fetchHTML(contentURL) { html in
+                DispatchQueue.main.async { [weak self] in
+                    self?.loadPrewarmContentPage(html: html, baseURL: baseURL, endpoint: endpoint, deviceUUID: deviceUUID)
+                }
+            }
+        }
+    }
+
+    private func loadPrewarmContentPage(html: String?, baseURL: URL, endpoint: String, deviceUUID: String) {
+        guard let html else {
+            // No retry by design (the latch stands): this launch degrades to preconnect-only.
+            Logger.common(message: "[WebView] Prewarm: content page fetch failed, launch degrades to preconnect-only",
+                          level: .info, category: .webViewInAppMessages)
+            return
+        }
+        // The instance can be gone by now — borrowed by a show, or dropped by a
+        // config-driven release that landed while the fetch was in flight. Either way there
+        // is nothing to warm, and logging success would misreport it.
+        guard !hasBeenBorrowed, let warmWebView else { return }
+        let prewarmBaseURL = InAppWebViewPrewarmPlanner.prewarmContentBaseURL(
+            from: baseURL, endpoint: endpoint, deviceUUID: deviceUUID
+        )
+        prewarmNavigationPolicy.allow(prewarmBaseURL)
+        warmWebView.loadHTMLString(html, baseURL: prewarmBaseURL)
+        Logger.common(message: "[WebView] Prewarm: content page under \(prewarmBaseURL.absoluteString), endpoint \(endpoint)",
+                      level: .info, category: .webViewInAppMessages)
+    }
+
+    private enum ReleaseReason: String {
+        case featureToggleOff = "the prewarm feature toggle is off"
+        case noWebviewInApps = "no webview in-apps in config"
+    }
+
+    /// Most host apps have no webview in-apps: once the config proves that, drop the
+    /// stage-1 instance so they don't keep an idle web-content process. The prewarm does
+    /// not restart within this launch — a show then simply creates its own WebView.
+    private func releaseUnusedWarmWebView(reason: ReleaseReason) {
+        DispatchQueue.main.async {
+            // Latch before the guard: even with nothing to drop yet, a stage-1 hop that
+            // lands after this release must not start a prewarm the config just killed.
+            self.resourcePrewarmLatched = true
+            guard !self.hasBeenBorrowed, let webView = self.warmWebView else { return }
+            webView.stopLoading()
+            self.warmWebView = nil
+            Logger.common(message: "[WebView] Prewarm: \(reason.rawValue) — releasing the warm instance",
+                          level: .info, category: .webViewInAppMessages)
+        }
+    }
+
+    // The empty-page skeleton is exactly a preconnect page with no hosts — reuse the
+    // planner so the parked/teardown markup can never drift from the preconnect markup.
+    private static let blankPage = InAppWebViewPrewarmPlanner.preconnectHTML(hosts: [])
+
+    /// One transport with the shows' fetch (`InAppWebViewHTMLFetcher`): the prewarm must
+    /// fill exactly the cache the shows read.
+    private static func defaultFetchHTML(url: URL, completion: @escaping (String?) -> Void) {
+        let (session, request) = InAppWebViewHTMLFetcher.sessionAndRequest(for: url)
+        session.dataTask(with: request) { data, response, _ in
+            guard let httpResponse = response as? HTTPURLResponse, (200...299).contains(httpResponse.statusCode),
+                  let data, let html = String(data: data, encoding: .utf8) else {
+                completion(nil)
+                return
+            }
+            completion(html)
+        }.resume()
+    }
+
+    private static func defaultLoadCachedConfig() -> ConfigResponse? {
+        InAppConfigurationRepository().fetchDecodedConfigFromCache()
+    }
+}

--- a/Mindbox/InAppMessages/Presentation/Views/WebView/TransparentView.swift
+++ b/Mindbox/InAppMessages/Presentation/Views/WebView/TransparentView.swift
@@ -31,6 +31,7 @@ final class TransparentView: UIView {
     /// later ready-check give-up (a post-load navigation dropped the bridge) has no other
     /// closing authority — it must close the show itself.
     private var hasReceivedInit = false
+    private var hasCapturedObservedHosts = false
     private lazy var localStateStorage: WebViewLocalStateStorageProtocol = DI.injectOrFail(WebViewLocalStateStorageProtocol.self)
     private lazy var permissionHandlerRegistry = DI.injectOrFail(PermissionHandlerRegistryProtocol.self)
     private lazy var hapticService: HapticServiceProtocol = DI.injectOrFail(HapticServiceProtocol.self)
@@ -108,6 +109,19 @@ final class TransparentView: UIView {
 
     func cleanUp() {
         facade?.cleanWebView()
+    }
+
+    /// Persists the hosts this show's resources actually came from so the next launch's
+    /// prewarm can preconnect to them. Called from `viewWillDisappear`, which every
+    /// dismissal path (close action, dim-tap, timeout) goes through while the page is still
+    /// alive; the once-flag is a cheap guard against a repeated disappear.
+    func captureObservedResourceHosts() {
+        guard !hasCapturedObservedHosts else { return }
+        hasCapturedObservedHosts = true
+        facade?.evaluateJavaScript(InAppWebViewPrewarmPlanner.observedHostsScript) { result in
+            guard case .success(let value) = result, let hosts = value as? [String] else { return }
+            DI.injectOrFail(InAppWebViewPrewarmServiceProtocol.self).rememberObservedHosts(hosts)
+        }
     }
 
     func cancelTimeoutTimer() {

--- a/Mindbox/InAppMessages/Presentation/Views/WebView/WebViewController.swift
+++ b/Mindbox/InAppMessages/Presentation/Views/WebView/WebViewController.swift
@@ -83,6 +83,8 @@ final class WebViewController: UIViewController, InappViewControllerProtocol {
         NotificationCenter.default.removeObserver(self)
         Logger.common(message: "[WebView] Deinit WebViewVC", category: .webViewInAppMessages)
         transparentWebView?.cleanUp()
+        // Stop the closed in-app's JS from running hidden on the parked warm instance.
+        DI.injectOrFail(InAppWebViewPrewarmServiceProtocol.self).parkWarmWebView()
     }
 
     private func setupWebView() {
@@ -146,6 +148,13 @@ final class WebViewController: UIViewController, InappViewControllerProtocol {
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         becomeFirstResponder()
+    }
+
+    override func viewWillDisappear(_ animated: Bool) {
+        // Every dismissal path (close action, dim-tap, timeout) goes through here while
+        // the page is still alive — the last moment the learned-hosts capture can run.
+        transparentWebView?.captureObservedResourceHosts()
+        super.viewWillDisappear(animated)
     }
 
     override func motionEnded(_ motion: UIEvent.EventSubtype, with event: UIEvent?) {

--- a/Mindbox/Mindbox.swift
+++ b/Mindbox/Mindbox.swift
@@ -83,6 +83,9 @@ public class Mindbox: NSObject {
      */
     public func initialization(configuration: MBConfiguration) {
         coreController?.initialization(configuration: configuration)
+        // Prewarm stage 1: warm the web-content process as early as possible so the first
+        // webview show doesn't pay process startup. Safe here — assembly() has built DI.
+        DI.injectOrFail(InAppWebViewPrewarmServiceProtocol.self).prewarmProcess()
     }
 
     private var observeTokens: [UUID] = []

--- a/Mindbox/PersistenceStorage/MBPersistenceStorage.swift
+++ b/Mindbox/PersistenceStorage/MBPersistenceStorage.swift
@@ -266,6 +266,9 @@ class MBPersistenceStorage: PersistenceStorage {
     @UserDefaultsWrapper(key: .webViewLocalStateVersion, defaultValue: nil)
     var webViewLocalStateVersion: Int?
 
+    @UserDefaultsWrapper(key: .webViewLearnedHosts, defaultValue: nil)
+    var webViewLearnedHosts: [String: [String]]?
+
     @UserDefaultsWrapper(key: .operationsDomainFromConfig, defaultValue: nil)
     var operationsDomainFromConfig: String? {
         didSet {
@@ -311,6 +314,7 @@ extension MBPersistenceStorage {
             case applicationInfoUpdateVersion = "MBPersistenceStorage-applicationInfoUpdatedVersion"
             case applicationInstanceId = "MBPersistenceStorage-applicationInstanceId"
             case webViewLocalStateVersion = "MBPersistenceStorage-webViewLocalStateVersion"
+            case webViewLearnedHosts = "MBPersistenceStorage-webViewLearnedHosts"
             case operationsDomainFromConfig = "MBPersistenceStorage-operationsDomainFromConfig"
 
             // MARK: - Deprecated Keys

--- a/Mindbox/PersistenceStorage/PersistenceStorage.swift
+++ b/Mindbox/PersistenceStorage/PersistenceStorage.swift
@@ -75,6 +75,10 @@ protocol PersistenceStorage: AnyObject {
     /// Version of the WebView localState, managed by JS via localState.init
     var webViewLocalStateVersion: Int? { get set }
 
+    /// Resource hosts observed by webview in-app shows, keyed by endpoint — feeds the next
+    /// launch's preconnect. See `InAppWebViewLearnedHostsStore`.
+    var webViewLearnedHosts: [String: [String]]? { get set }
+
     // Reset functions
 
     func softReset()
@@ -130,5 +134,6 @@ extension PersistenceStorage {
         operationsDomainFromConfig = nil
         applicationInstanceId = nil
         applicationInfoUpdateVersion = nil
+        webViewLearnedHosts = nil
     }
 }

--- a/MindboxTests/InApp/Tests/WebViewPrewarmTests/InAppWebViewLearnedHostsStoreTests.swift
+++ b/MindboxTests/InApp/Tests/WebViewPrewarmTests/InAppWebViewLearnedHostsStoreTests.swift
@@ -1,0 +1,97 @@
+//
+//  InAppWebViewLearnedHostsStoreTests.swift
+//  MindboxTests
+//
+//  Created by Sergei Semko on 06.07.2026.
+//  Copyright © 2026 Mindbox. All rights reserved.
+//
+
+import Foundation
+import Testing
+@testable import Mindbox
+
+@Suite("InApp WebView learned hosts store", .tags(.webView))
+struct InAppWebViewLearnedHostsStoreTests {
+
+    private let storage = MockPersistenceStorage()
+    private var store: InAppWebViewLearnedHostsStore {
+        InAppWebViewLearnedHostsStore(persistenceStorage: storage)
+    }
+
+    @Test("Observed hosts merge in order without duplicates")
+    func mergesWithoutDuplicates() {
+        store.remember(["a.example", "b.example"], endpoint: "Endpoint")
+        store.remember(["b.example", "c.example", ""], endpoint: "Endpoint")
+
+        #expect(store.hosts(endpoint: "Endpoint") == ["a.example", "b.example", "c.example"])
+    }
+
+    @Test("The oldest hosts are dropped beyond the cap")
+    func capsAtMaximumDroppingOldest() {
+        let cap = InAppWebViewLearnedHostsStore.maxHosts
+
+        store.remember((0..<cap).map { "host\($0).example" }, endpoint: "Endpoint")
+        store.remember(["overflow.example"], endpoint: "Endpoint")
+
+        let hosts = store.hosts(endpoint: "Endpoint")
+        #expect(hosts.count == cap)
+        #expect(hosts.first == "host1.example")
+        #expect(hosts.last == "overflow.example")
+    }
+
+    @Test("Remembering nothing changes nothing")
+    func emptyObservationIsNoOp() {
+        store.remember([], endpoint: "Endpoint")
+        store.remember(["not a host!"], endpoint: "Endpoint")
+
+        #expect(store.hosts(endpoint: "Endpoint").isEmpty)
+        #expect(storage.webViewLearnedHosts == nil)
+    }
+
+    @Test("Page-controlled strings that are not bare hosts are rejected on write")
+    func rejectsNonHostStrings() {
+        // The values come from page JS and are later interpolated into preconnect HTML —
+        // anything that is not a bare RFC 1123 host must never be persisted.
+        store.remember(
+            [
+                "cdn.ok.example",
+                "x\"><script>alert(1)</script>",
+                "bad host with spaces",
+                "https://full.url/path",
+                "host/with/path",
+                "evil.example\"><link>",
+                "a&b.example",
+                ""
+            ],
+            endpoint: "Endpoint"
+        )
+
+        #expect(store.hosts(endpoint: "Endpoint") == ["cdn.ok.example"])
+    }
+
+    @Test("Re-remembering only known hosts does not rewrite storage")
+    func noOpWriteWhenNothingNew() {
+        store.remember(["a.example", "b.example"], endpoint: "Endpoint")
+        let writesAfterFirst = storage.webViewLearnedHostsWriteCount
+
+        // Every observed host is already known — the steady state after the first shows.
+        // The persisted value is unchanged either way, so the write count is the only
+        // observable proof the redundant UserDefaults write is skipped.
+        store.remember(["a.example", "b.example"], endpoint: "Endpoint")
+        #expect(storage.webViewLearnedHostsWriteCount == writesAfterFirst)
+
+        // A genuinely new host still writes.
+        store.remember(["c.example"], endpoint: "Endpoint")
+        #expect(storage.webViewLearnedHostsWriteCount == writesAfterFirst + 1)
+        #expect(store.hosts(endpoint: "Endpoint") == ["a.example", "b.example", "c.example"])
+    }
+
+    @Test("Hosts are scoped per endpoint")
+    func endpointsAreIsolated() {
+        store.remember(["a.example"], endpoint: "First")
+        store.remember(["b.example"], endpoint: "Second")
+
+        #expect(store.hosts(endpoint: "First") == ["a.example"])
+        #expect(store.hosts(endpoint: "Second") == ["b.example"])
+    }
+}

--- a/MindboxTests/InApp/Tests/WebViewPrewarmTests/InAppWebViewPrewarmPlannerTests.swift
+++ b/MindboxTests/InApp/Tests/WebViewPrewarmTests/InAppWebViewPrewarmPlannerTests.swift
@@ -1,0 +1,218 @@
+//
+//  InAppWebViewPrewarmPlannerTests.swift
+//  MindboxTests
+//
+//  Created by Sergei Semko on 06.07.2026.
+//  Copyright © 2026 Mindbox. All rights reserved.
+//
+
+import Foundation
+import Testing
+@testable import Mindbox
+
+@Suite("InApp WebView prewarm planning", .tags(.webView))
+struct InAppWebViewPrewarmPlannerTests {
+
+    private func webviewLayer(
+        baseUrl: String? = "https://inapp.local/popup",
+        contentUrl: String? = "https://mobile-static.mindbox.ru/stable/inapps/webview/content/index.html"
+    ) -> WebviewContentBackgroundLayerDTO {
+        WebviewContentBackgroundLayerDTO(baseUrl: baseUrl, contentUrl: contentUrl, params: nil)
+    }
+
+    // MARK: Prewarm source (partition baseURL + contentURL from one layer)
+
+    @Test("Prewarm source is taken from the first fully showable layer")
+    func prewarmSourcePicksFirstValid() throws {
+        let layers = [
+            webviewLayer(baseUrl: nil),
+            webviewLayer(baseUrl: "https://inapp.local/popup"),
+            webviewLayer(baseUrl: "https://other.example/popup")
+        ]
+        let source = try #require(InAppWebViewPrewarmPlanner.prewarmSource(for: layers))
+        #expect(source.baseURL.absoluteString == "https://inapp.local/popup")
+    }
+
+    @Test("No layer with a usable baseUrl yields no prewarm source", arguments: [
+        [] as [String?],
+        [nil],
+        [""]
+    ])
+    func prewarmSourceMissing(baseUrls: [String?]) {
+        let layers = baseUrls.map { webviewLayer(baseUrl: $0) }
+        #expect(InAppWebViewPrewarmPlanner.prewarmSource(for: layers) == nil)
+    }
+
+    @Test("Host-less baseUrls and layers without contentUrl don't donate a prewarm source")
+    func prewarmSourceRequiresHostAndContent() throws {
+        let hostless = webviewLayer(baseUrl: "popup")
+        let noContent = webviewLayer(contentUrl: nil)
+        let valid = webviewLayer()
+
+        let source = try #require(InAppWebViewPrewarmPlanner.prewarmSource(for: [hostless, noContent, valid]))
+        #expect(source.baseURL.host == "inapp.local")
+        #expect(InAppWebViewPrewarmPlanner.prewarmSource(for: [hostless, noContent]) == nil)
+    }
+
+    @Test("Non-https layers never donate a prewarm source")
+    func prewarmSourceRequiresHttps() throws {
+        let httpBase = webviewLayer(baseUrl: "http://insecure.local/popup")
+        let httpContent = webviewLayer(contentUrl: "http://cdn.example/index.html")
+        let valid = webviewLayer()
+
+        #expect(InAppWebViewPrewarmPlanner.prewarmSource(for: [httpBase, httpContent]) == nil)
+        let source = try #require(InAppWebViewPrewarmPlanner.prewarmSource(for: [httpBase, httpContent, valid]))
+        #expect(source.baseURL.host == "inapp.local")
+    }
+
+    @Test("Base and content URLs always come from the same layer — never mixed across layers")
+    func prewarmSourceNeverMixesLayers() throws {
+        let broken = webviewLayer(baseUrl: "not a url", contentUrl: "https://cdn.a/index.html")
+        let valid = webviewLayer(baseUrl: "https://inapp.local/popup", contentUrl: "https://cdn.b/index.html")
+
+        let source = try #require(InAppWebViewPrewarmPlanner.prewarmSource(for: [broken, valid]))
+        #expect(source.baseURL.host == "inapp.local")
+        #expect(source.contentURL.absoluteString == "https://cdn.b/index.html")
+    }
+
+    // MARK: Preconnect hosts
+
+    @Test("Hosts are deduplicated, merged with API domain and learned hosts, and sorted")
+    func preconnectHostsMergesAllSources() {
+        let layers = [
+            webviewLayer(contentUrl: "https://mobile-static.mindbox.ru/a/index.html"),
+            webviewLayer(contentUrl: "https://mobile-static.mindbox.ru/b/index.html")
+        ]
+        let hosts = InAppWebViewPrewarmPlanner.preconnectHosts(
+            layers: layers,
+            apiDomain: "api.mindbox.ru",
+            learnedHosts: ["web-static.mindbox.ru", "api.mindbox.ru"]
+        )
+        #expect(hosts == ["api.mindbox.ru", "mobile-static.mindbox.ru", "web-static.mindbox.ru"])
+    }
+
+    @Test("Invalid content URLs and an absent API domain contribute nothing")
+    func preconnectHostsSkipsUnusableSources() {
+        let layers = [webviewLayer(contentUrl: nil), webviewLayer(contentUrl: "")]
+        let hosts = InAppWebViewPrewarmPlanner.preconnectHosts(layers: layers, apiDomain: nil, learnedHosts: [])
+        #expect(hosts.isEmpty)
+
+        let emptyDomain = InAppWebViewPrewarmPlanner.preconnectHosts(layers: layers, apiDomain: "", learnedHosts: [])
+        #expect(emptyDomain.isEmpty)
+    }
+
+    // MARK: Preconnect page
+
+    @Test("Preconnect page hints every host and downloads nothing")
+    func preconnectHTMLContainsHints() {
+        let html = InAppWebViewPrewarmPlanner.preconnectHTML(hosts: ["a.example", "b.example"])
+        #expect(html.contains("<link rel=\"preconnect\" href=\"https://a.example\" crossorigin>"))
+        #expect(html.contains("<link rel=\"dns-prefetch\" href=\"https://b.example\">"))
+        #expect(!html.contains("<script"))
+        #expect(!html.contains("<img"))
+    }
+
+    @Test("Every host is re-validated at the markup choke point")
+    func preconnectHTMLRejectsNonHostValues() {
+        let html = InAppWebViewPrewarmPlanner.preconnectHTML(
+            hosts: ["ok.example", "evil\"><script>alert(1)</script>", "spaced host.ru"]
+        )
+        #expect(html.contains("https://ok.example"))
+        #expect(!html.contains("<script"))
+        #expect(!html.contains("spaced host.ru"))
+    }
+
+    @Test("Host validation accepts bare hosts only", arguments: zip(
+        ["cdn.mindbox.ru", "evil.com:443", "user@evil.com", "evil.com?x=1", "host with space", "",
+         "a&b.com", "a'b.com", "a;b.com", "a=b.com", "a_b.com", "(evil).com", "host.ru.",
+         String(repeating: "a", count: 300) + ".com"],
+        [true, false, false, false, false, false,
+         false, false, false, false, false, false, false,
+         false]
+    ))
+    func isValidHost(candidate: String, expected: Bool) {
+        #expect(InAppWebViewPrewarmPlanner.isValidHost(candidate) == expected)
+    }
+
+    // MARK: Prewarm content baseURL (official web prewarm contract)
+
+    @Test("Prewarm content baseURL carries the official prewarm query parameters")
+    func prewarmContentBaseURLAppendsContract() throws {
+        let baseURL = try #require(URL(string: "https://inapp.local/popup"))
+
+        let url = InAppWebViewPrewarmPlanner.prewarmContentBaseURL(
+            from: baseURL, endpoint: "Mpush-test.WebView", deviceUUID: "abc-123"
+        )
+
+        let components = try #require(URLComponents(url: url, resolvingAgainstBaseURL: false))
+        #expect(components.host == "inapp.local")
+        #expect(components.path == "/popup")
+        let query = try #require(components.queryItems)
+        #expect(query.contains(URLQueryItem(name: "prewarm", value: "1")))
+        #expect(query.contains(URLQueryItem(name: "endpointId", value: "Mpush-test.WebView")))
+        #expect(query.contains(URLQueryItem(name: "deviceUuid", value: "abc-123")))
+    }
+
+    @Test("Existing baseURL query survives and unsafe values are percent-encoded")
+    func prewarmContentBaseURLKeepsQueryAndEncodes() throws {
+        let baseURL = try #require(URL(string: "https://inapp.local/popup?keep=me"))
+
+        let url = InAppWebViewPrewarmPlanner.prewarmContentBaseURL(
+            from: baseURL, endpoint: "End point&x", deviceUUID: "uuid"
+        )
+
+        let components = try #require(URLComponents(url: url, resolvingAgainstBaseURL: false))
+        let query = try #require(components.queryItems)
+        #expect(query.contains(URLQueryItem(name: "keep", value: "me")))
+        #expect(query.contains(URLQueryItem(name: "endpointId", value: "End point&x")))
+        #expect(url.absoluteString.contains("endpointId=End%20point%26x"))
+    }
+
+    @Test("Parameters land in the query, not the fragment")
+    func prewarmContentBaseURLKeepsFragmentSeparate() throws {
+        // In the fragment they would be invisible to location.search and the contract
+        // would silently degrade to a plain page warm.
+        let baseURL = try #require(URL(string: "https://inapp.local/popup#main"))
+
+        let url = InAppWebViewPrewarmPlanner.prewarmContentBaseURL(
+            from: baseURL, endpoint: "E", deviceUUID: "d"
+        )
+
+        let components = try #require(URLComponents(url: url, resolvingAgainstBaseURL: false))
+        #expect(components.fragment == "main")
+        let query = try #require(components.queryItems)
+        #expect(query.contains(URLQueryItem(name: "prewarm", value: "1")))
+    }
+
+    // MARK: Layer extraction from a parsed config
+
+    @Test("Webview layers and prewarm inputs are extracted from a parsed config")
+    func extractsLayersFromParsedConfig() throws {
+        let config = try loadPrewarmTestConfig("InAppWebviewValid")
+
+        let layers = InAppWebViewPrewarmPlanner.webviewLayers(in: config)
+
+        let source = try #require(InAppWebViewPrewarmPlanner.prewarmSource(for: layers))
+        #expect(source.baseURL.host == "inapp.local")
+
+        let hosts = InAppWebViewPrewarmPlanner.preconnectHosts(layers: layers, apiDomain: "api.mindbox.ru", learnedHosts: [])
+        let contentUrl = try #require(layers.first?.contentUrl)
+        let contentHost = try #require(URL(string: contentUrl)?.host)
+        #expect(hosts.contains("api.mindbox.ru"))
+        #expect(hosts.contains(contentHost))
+    }
+
+    @Test("Configs without webview layers plan nothing", arguments: [
+        "InAppLayerUnknownType", "InAppFormVariantUnknownType"
+    ])
+    func noWebviewLayersInNonWebviewConfig(fixture: String) throws {
+        let config = try loadPrewarmTestConfig(fixture)
+        #expect(InAppWebViewPrewarmPlanner.webviewLayers(in: config).isEmpty)
+    }
+}
+
+func loadPrewarmTestConfig(_ name: String) throws -> ConfigResponse {
+    let bundle = Bundle(for: MindboxTests.self)
+    let url = try #require(bundle.url(forResource: name, withExtension: "json"))
+    return try JSONDecoder().decode(ConfigResponse.self, from: Data(contentsOf: url))
+}

--- a/MindboxTests/InApp/Tests/WebViewPrewarmTests/InAppWebViewPrewarmServiceTests.swift
+++ b/MindboxTests/InApp/Tests/WebViewPrewarmTests/InAppWebViewPrewarmServiceTests.swift
@@ -264,6 +264,42 @@ struct InAppWebViewPrewarmServiceTests {
         #expect(suite.service.borrowWarmWebView() === suite.spy)
     }
 
+    @Test("Observed hosts are persisted under the configuration endpoint")
+    func rememberObservedHostsPersistsUnderEndpoint() throws {
+        let storage = MockPersistenceStorage()
+        storage.configuration = try MBConfiguration(endpoint: "Test.Endpoint", domain: "api.mindbox.ru")
+        let service = InAppWebViewPrewarmService(
+            persistenceStorage: storage,
+            makeWebView: { SpyWebView(frame: .zero, configuration: WKWebViewConfiguration()) },
+            fetchHTML: { _, completion in completion(nil) },
+            loadCachedConfig: { nil }
+        )
+
+        service.rememberObservedHosts(["a.example", "b.example"])
+
+        #expect(storage.webViewLearnedHosts?["Test.Endpoint"] == ["a.example", "b.example"])
+    }
+
+    @Test("A content-page fetch failure degrades to preconnect-only")
+    func contentFetchFailureLeavesPreconnectOnly() async throws {
+        let storage = MockPersistenceStorage()
+        storage.configuration = try MBConfiguration(endpoint: "Test.Endpoint", domain: "api.mindbox.ru")
+        let spy = SpyWebView(frame: .zero, configuration: WKWebViewConfiguration())
+        let service = InAppWebViewPrewarmService(
+            persistenceStorage: storage,
+            makeWebView: { spy },
+            fetchHTML: { _, completion in completion(nil) },
+            loadCachedConfig: { nil }
+        )
+
+        service.prewarmResources(for: try loadPrewarmTestConfig("InAppWebviewValid"))
+        await drainMainQueue()
+        await drainMainQueue()
+
+        // Preconnect page loaded; the failed content fetch adds nothing.
+        #expect(spy.loadedHTMLCount == 1)
+    }
+
     // MARK: Feature toggle
 
     /// The valid webview config with an explicit `featureToggles` section.

--- a/MindboxTests/InApp/Tests/WebViewPrewarmTests/InAppWebViewPrewarmServiceTests.swift
+++ b/MindboxTests/InApp/Tests/WebViewPrewarmTests/InAppWebViewPrewarmServiceTests.swift
@@ -1,0 +1,371 @@
+//
+//  InAppWebViewPrewarmServiceTests.swift
+//  MindboxTests
+//
+//  Created by Sergei Semko on 06.07.2026.
+//  Copyright © 2026 Mindbox. All rights reserved.
+//
+
+import Foundation
+import Testing
+import WebKit
+@testable import Mindbox
+
+@MainActor
+@Suite("InApp WebView prewarm service guards", .tags(.webView))
+struct InAppWebViewPrewarmServiceTests {
+
+    private final class SpyWebView: WKWebView {
+        private(set) var loadedHTMLCount = 0
+        private(set) var loadedBaseURLs: [URL?] = []
+        private(set) var stopLoadingCount = 0
+        var stubbedIsLoading = false
+
+        override var isLoading: Bool { stubbedIsLoading }
+
+        override func loadHTMLString(_ string: String, baseURL: URL?) -> WKNavigation? {
+            loadedHTMLCount += 1
+            loadedBaseURLs.append(baseURL)
+            return nil // spy only — keep WebKit from actually navigating in unit tests
+        }
+
+        override func stopLoading() {
+            stopLoadingCount += 1
+        }
+    }
+
+    private let spy: SpyWebView
+    private let service: InAppWebViewPrewarmService
+
+    init() throws {
+        self = try Self.init(cachedConfig: nil)
+    }
+
+    private init(cachedConfig: ConfigResponse?) throws {
+        let spy = SpyWebView(frame: .zero, configuration: WKWebViewConfiguration())
+        self.spy = spy
+
+        let storage = MockPersistenceStorage()
+        storage.configuration = try MBConfiguration(endpoint: "Test.Endpoint", domain: "api.mindbox.ru")
+        storage.deviceUUID = "test-device-uuid"
+
+        service = InAppWebViewPrewarmService(
+            persistenceStorage: storage,
+            makeWebView: { spy },
+            fetchHTML: { _, completion in completion("<html><body>content</body></html>") },
+            loadCachedConfig: { cachedConfig }
+        )
+    }
+
+    /// The service hops its mutations through `DispatchQueue.main.async`; one more hop
+    /// behind them guarantees they have run.
+    private func drainMainQueue() async {
+        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+            DispatchQueue.main.async { continuation.resume() }
+        }
+    }
+
+    /// The cached-config head start hops through a background queue first — poll for its
+    /// main-queue effects instead of assuming scheduling order.
+    private func waitUntil(_ condition: @autoclosure () -> Bool) async throws {
+        for _ in 0..<100 where !condition() {
+            try await Task.sleep(nanoseconds: 20_000_000)
+        }
+        #expect(condition())
+    }
+
+    @Test("Without a cached webview config nothing is created at init")
+    func initWithoutCachedConfigCreatesNothing() async {
+        service.prewarmProcess()
+        service.prewarmProcess()
+        await drainMainQueue()
+        await drainMainQueue()
+
+        #expect(spy.loadedHTMLCount == 0)
+        #expect(service.borrowWarmWebView() == nil)
+    }
+
+    @Test("A cached config with webview in-apps starts the resource prewarm at init")
+    func headStartRunsFromCachedConfig() async throws {
+        let suite = try Self.init(cachedConfig: loadPrewarmTestConfig("InAppWebviewValid"))
+
+        suite.service.prewarmProcess()
+
+        // preconnect + content page (the instance is created lazily by the prewarm itself)
+        try await suite.waitUntil(suite.spy.loadedHTMLCount == 2)
+    }
+
+    @Test("Resource prewarm runs once: preconnect page, then the content page with the prewarm params")
+    func resourcePrewarmRunsOnce() async throws {
+        let config = try loadPrewarmTestConfig("InAppWebviewValid")
+        service.prewarmResources(for: config)
+        service.prewarmResources(for: config)
+        await drainMainQueue()
+        await drainMainQueue()
+
+        #expect(spy.loadedHTMLCount == 2) // one preconnect + one content page
+
+        let contentBaseURL = try #require(spy.loadedBaseURLs.last ?? nil)
+        #expect(contentBaseURL.host == "inapp.local")
+        let query = try #require(URLComponents(url: contentBaseURL, resolvingAgainstBaseURL: false)?.queryItems)
+        #expect(query.contains(URLQueryItem(name: "prewarm", value: "1")))
+        #expect(query.contains(URLQueryItem(name: "endpointId", value: "Test.Endpoint")))
+        #expect(query.contains(URLQueryItem(name: "deviceUuid", value: "test-device-uuid")))
+
+        // The prewarm injects nothing into the page: user scripts persist across
+        // navigations and would leak into the borrowed instance's shows.
+        #expect(spy.configuration.userContentController.userScripts.isEmpty)
+    }
+
+    @Test("The prewarm instance is pinned by the navigation policy until a show takes over")
+    func prewarmArmsNavigationPolicy() async throws {
+        let suite = try Self.init(cachedConfig: loadPrewarmTestConfig("InAppWebviewValid"))
+        suite.service.prewarmProcess()
+        try await suite.waitUntil(suite.spy.loadedHTMLCount == 2)
+
+        #expect(suite.spy.navigationDelegate is InAppWebViewPrewarmNavigationPolicy)
+    }
+
+    @Test("Borrow stops in-flight loading, tears the prewarm page down, and keeps the instance")
+    func borrowStopsLoadingAndKeepsInstance() async throws {
+        let suite = try Self.init(cachedConfig: loadPrewarmTestConfig("InAppWebviewValid"))
+        suite.service.prewarmProcess()
+        try await suite.waitUntil(suite.spy.loadedHTMLCount == 2)
+
+        let borrowed = suite.service.borrowWarmWebView()
+
+        #expect(borrowed === suite.spy)
+        #expect(suite.spy.stopLoadingCount == 1)
+        #expect(suite.spy.loadedHTMLCount == 3) // preconnect + content + the hard-kill blank at borrow
+
+        // While lent to a live show the instance must never be stolen by a second borrow.
+        #expect(suite.service.borrowWarmWebView() == nil)
+
+        suite.service.parkWarmWebView()
+        await suite.drainMainQueue()
+        #expect(suite.service.borrowWarmWebView() === suite.spy)
+    }
+
+    @Test("Borrow refuses an instance whose prewarm navigation hasn't settled and parks it for the next show")
+    func borrowRefusesMidNavigationInstance() async throws {
+        let suite = try Self.init(cachedConfig: loadPrewarmTestConfig("InAppWebviewValid"))
+        suite.service.prewarmProcess()
+        try await suite.waitUntil(suite.spy.loadedHTMLCount == 2)
+        suite.spy.stubbedIsLoading = true
+
+        // A mid-navigation document must never reach a show: its didFinish can fire
+        // before module scripts evaluate.
+        #expect(suite.service.borrowWarmWebView() == nil)
+        #expect(suite.spy.stopLoadingCount == 1)
+        #expect(suite.spy.loadedHTMLCount == 3) // head start (2) + park blank
+
+        suite.spy.stubbedIsLoading = false
+        #expect(suite.service.borrowWarmWebView() === suite.spy)
+    }
+
+    @Test("Resource prewarm never navigates a borrowed instance")
+    func resourcePrewarmSkippedAfterBorrow() async throws {
+        let suite = try Self.init(cachedConfig: loadPrewarmTestConfig("InAppWebviewValid"))
+        suite.service.prewarmProcess()
+        try await suite.waitUntil(suite.spy.loadedHTMLCount == 2)
+        _ = suite.service.borrowWarmWebView()
+
+        suite.service.prewarmResources(for: try loadPrewarmTestConfig("InAppWebviewValid"))
+        await suite.drainMainQueue()
+        await suite.drainMainQueue()
+
+        #expect(suite.spy.loadedHTMLCount == 3) // head start + borrow hard-kill; nothing more
+    }
+
+    @Test("A show starting before any prewarm blocks later resource prewarms")
+    func showBeforePrewarmBlocksLaterPrewarm() async throws {
+        #expect(service.borrowWarmWebView() == nil)
+
+        service.prewarmResources(for: try loadPrewarmTestConfig("InAppWebviewValid"))
+        await drainMainQueue()
+        await drainMainQueue()
+
+        #expect(spy.loadedHTMLCount == 0)
+    }
+
+    @Test("A config without webview in-apps releases the unused warm instance")
+    func noWebviewConfigReleasesInstance() async throws {
+        let suite = try Self.init(cachedConfig: loadPrewarmTestConfig("InAppWebviewValid"))
+        suite.service.prewarmProcess()
+        try await suite.waitUntil(suite.spy.loadedHTMLCount == 2)
+
+        suite.service.prewarmResources(for: ConfigResponse())
+        await suite.drainMainQueue()
+
+        // An in-flight prewarm navigation must not keep burning bandwidth if anything
+        // briefly retains the dropped instance.
+        #expect(suite.spy.stopLoadingCount == 1)
+        #expect(suite.service.borrowWarmWebView() == nil)
+    }
+
+    @Test("Parking an idle borrowed instance loads a blank page to stop hidden JS")
+    func parkingLoadsBlankPage() async throws {
+        let suite = try Self.init(cachedConfig: loadPrewarmTestConfig("InAppWebviewValid"))
+        suite.service.prewarmProcess()
+        try await suite.waitUntil(suite.spy.loadedHTMLCount == 2)
+        _ = suite.service.borrowWarmWebView()
+
+        suite.service.parkWarmWebView()
+        await suite.drainMainQueue()
+
+        #expect(suite.spy.loadedHTMLCount == 4) // head start (2) + borrow hard-kill + park blank
+    }
+
+    @Test("An off-main borrow is refused without touching the warm instance")
+    func offMainBorrowRefusedSafely() async throws {
+        let suite = try Self.init(cachedConfig: loadPrewarmTestConfig("InAppWebviewValid"))
+        suite.service.prewarmProcess()
+        try await suite.waitUntil(suite.spy.loadedHTMLCount == 2)
+
+        // Deliberate off-main access — exactly what the guard under test refuses.
+        nonisolated(unsafe) let service = suite.service
+        let refused = await withCheckedContinuation { (continuation: CheckedContinuation<Bool, Never>) in
+            DispatchQueue.global().async {
+                continuation.resume(returning: service.borrowWarmWebView() == nil)
+            }
+        }
+
+        #expect(refused)
+        // Main-confined state untouched: the instance still serves a main-thread borrow.
+        #expect(suite.service.borrowWarmWebView() === suite.spy)
+    }
+
+    @Test("A memory warning frees the parked instance; the disk cache keeps the prewarm benefit")
+    func memoryWarningFreesParkedInstance() async throws {
+        let suite = try Self.init(cachedConfig: loadPrewarmTestConfig("InAppWebviewValid"))
+        suite.service.prewarmProcess()
+        try await suite.waitUntil(suite.spy.loadedHTMLCount == 2)
+
+        NotificationCenter.default.post(name: UIApplication.didReceiveMemoryWarningNotification, object: nil)
+        await suite.drainMainQueue()
+
+        #expect(suite.spy.stopLoadingCount == 1)
+        // The next show creates its own WKWebView on the shared store instead.
+        #expect(suite.service.borrowWarmWebView() == nil)
+    }
+
+    @Test("A memory warning never touches an instance lent to a live show")
+    func memoryWarningSparesLentInstance() async throws {
+        let suite = try Self.init(cachedConfig: loadPrewarmTestConfig("InAppWebviewValid"))
+        suite.service.prewarmProcess()
+        try await suite.waitUntil(suite.spy.loadedHTMLCount == 2)
+        _ = suite.service.borrowWarmWebView()
+
+        NotificationCenter.default.post(name: UIApplication.didReceiveMemoryWarningNotification, object: nil)
+        await suite.drainMainQueue()
+
+        suite.service.parkWarmWebView()
+        await suite.drainMainQueue()
+        #expect(suite.service.borrowWarmWebView() === suite.spy)
+    }
+
+    // MARK: Feature toggle
+
+    /// The valid webview config with an explicit `featureToggles` section.
+    private static func config(prewarmToggle: Bool?) throws -> ConfigResponse {
+        let base = try loadPrewarmTestConfig("InAppWebviewValid")
+        let toggles = Settings.FeatureToggles(
+            shouldSendInAppShowError: nil,
+            shouldPrewarmInAppWebView: prewarmToggle,
+            shouldCacheInAppWebView: nil
+        )
+        let settings = Settings(
+            operations: nil, ttl: nil, slidingExpiration: nil,
+            inapp: nil, featureToggles: toggles, baseAddresses: nil
+        )
+        return ConfigResponse(inapps: base.inapps, settings: settings)
+    }
+
+    @Test("Prewarm toggle off in the cached config skips the head start")
+    func prewarmToggleOffSkipsHeadStart() async throws {
+        let suite = try Self.init(cachedConfig: Self.config(prewarmToggle: false))
+
+        suite.service.prewarmProcess()
+        try await Task.sleep(nanoseconds: 100_000_000)
+        await suite.drainMainQueue()
+
+        #expect(suite.spy.loadedHTMLCount == 0)
+        #expect(suite.service.borrowWarmWebView() == nil)
+    }
+
+    @Test("Prewarm toggle off in the fresh config releases the stage-1 instance")
+    func prewarmToggleOffReleasesStageOneInstance() async throws {
+        service.prewarmResources(for: try loadPrewarmTestConfig("InAppWebviewValid"))
+        await drainMainQueue()
+        #expect(spy.loadedHTMLCount == 2)
+
+        service.prewarmResources(for: try Self.config(prewarmToggle: false))
+        await drainMainQueue()
+
+        #expect(spy.stopLoadingCount >= 1)
+        #expect(service.borrowWarmWebView() == nil)
+    }
+
+    @Test("A present section without the key, or an explicit true, keeps the prewarm on",
+          arguments: [nil, true] as [Bool?])
+    func prewarmToggleAbsentOrTrueKeepsFeatureOn(_ toggle: Bool?) async throws {
+        service.prewarmResources(for: try Self.config(prewarmToggle: toggle))
+        await drainMainQueue()
+
+        #expect(spy.loadedHTMLCount == 2)
+    }
+
+    @Test("A toggle-off release that beats the slow stage-1 hop still kills the head start")
+    func releaseBeforeStageOneBlocksHeadStart() async throws {
+        let suite = try Self.init(cachedConfig: loadPrewarmTestConfig("InAppWebviewValid"))
+
+        suite.service.prewarmResources(for: try Self.config(prewarmToggle: false))
+        await suite.drainMainQueue()
+
+        suite.service.prewarmProcess()
+        try await Task.sleep(nanoseconds: 100_000_000)
+        await suite.drainMainQueue()
+
+        #expect(suite.spy.loadedHTMLCount == 0)
+        #expect(suite.service.borrowWarmWebView() == nil)
+    }
+
+    @Test("A no-layers release also blocks a late stage-1 hop")
+    func noLayersReleaseBlocksLateStageOne() async throws {
+        let suite = try Self.init(cachedConfig: loadPrewarmTestConfig("InAppWebviewValid"))
+
+        suite.service.prewarmResources(for: ConfigResponse())
+        await suite.drainMainQueue()
+
+        suite.service.prewarmProcess()
+        try await Task.sleep(nanoseconds: 100_000_000)
+        await suite.drainMainQueue()
+
+        #expect(suite.spy.loadedHTMLCount == 0)
+    }
+}
+
+/// A hidden prewarm WebView must never be able to wander off to arbitrary URLs.
+@Suite("InApp WebView prewarm navigation policy", .tags(.webView))
+@MainActor
+struct InAppWebViewPrewarmNavigationPolicyTests {
+
+    private let policy = InAppWebViewPrewarmNavigationPolicy()
+
+    @Test("SDK-issued documents are allowed; anything else on the main frame is cancelled")
+    func pinsMainFrameToIssuedDocuments() throws {
+        let issued = try #require(URL(string: "https://inapp.local/popup?prewarm=1"))
+        policy.allow(issued)
+
+        #expect(policy.decision(for: issued, targetIsMainFrame: true) == .allow)
+        #expect(policy.decision(for: URL(string: "https://evil.example/landing"), targetIsMainFrame: true) == .cancel)
+        // The park/borrow blank load is always ours.
+        #expect(policy.decision(for: URL(string: "about:blank"), targetIsMainFrame: true) == .allow)
+    }
+
+    @Test("Subframes stay the page's own business; a nil target frame (window.open) is pinned")
+    func subframesAllowedNilTargetPinned() {
+        #expect(policy.decision(for: URL(string: "https://ads.example/frame"), targetIsMainFrame: false) == .allow)
+        #expect(policy.decision(for: URL(string: "https://popup.example/win"), targetIsMainFrame: nil) == .cancel)
+    }
+}

--- a/MindboxTests/Mock/MockPersistenceStorage.swift
+++ b/MindboxTests/Mock/MockPersistenceStorage.swift
@@ -132,6 +132,13 @@ class MockPersistenceStorage: PersistenceStorage {
 
     var webViewLocalStateVersion: Int?
 
+    // Counts writes so a no-op-write regression (rewriting an unchanged dictionary) is
+    // observable — the persisted value alone can't distinguish "written again" from "unchanged".
+    var webViewLearnedHostsWriteCount = 0
+    var webViewLearnedHosts: [String: [String]]? {
+        didSet { webViewLearnedHostsWriteCount += 1 }
+    }
+
     var operationsDomainFromConfig: String? {
         didSet {
             onDidChange?()


### PR DESCRIPTION
Финальный PR стека MOBILE-268 (часть b), нацелен в ветку PR3a (`feature/MOBILE-268-pr3a-bridge`), поверх которой лежит. Смотреть после мержа PR3a. Собирает фичу воедино поверх кэша (PR2) и bridge-фильтра (PR3a).

**Что делает.** Холодный показ WebView in-app каждый раз платит за спин-ап WKWebView + полную загрузку ресурсов. Прогрев готовит переиспользуемый инстанс в два этапа мимо основного пути инициализации, а показ его одалживает:
- **Stage 1** (`Mindbox.initialization`): по кэш-конфигу прошлого запуска стартуем ресурсный прогрев ещё до свежего конфига (гонка с launch-триггерным показом). Нет webview-инаппов → ничего не создаём.
- **Stage 2** (свежий конфиг распарсен): добираем прогрев, либо релизим stage-1 инстанс, если webview-инаппов нет / тогл выключен.
- **Borrow-not-consume + park**: показ берёт тёплый инстанс (тот же живёт для следующих показов); при закрытии — blank-страница, чтобы скрытый JS не крутился; под memory-warning паркованный инстанс освобождается (диск-кэш переживает).
- Навигация тёплого инстанса запинена на SDK-документы (`InAppWebViewPrewarmNavigationPolicy`); хосты из конфига + API-домен + выученные за прошлые показы преконнектятся; borrow армит staleness-фильтр бриджа из PR3a.
- Контракт прогрева `?prewarm=1&endpointId&deviceUuid` через baseURL `loadHTMLString` (сервер его не видит, ветвление клиентское). Learned-hosts живут в `PersistenceStorage` (не в `.standard`), с cap 12 и строгой валидацией хостов (JS-источник).
- Гейтится прогрев-тоглом (PR2); полный откат к старому поведению = оба тогла false.

**Тесты** (sync-группа `WebViewPrewarmTests/`): `InAppWebViewPrewarmServiceTests` (гарды/тоглы/гонки/borrow/park/memory), `InAppWebViewPrewarmNavigationPolicyTests`, `InAppWebViewPrewarmPlannerTests`, `InAppWebViewLearnedHostsStoreTests` — 41/41 зелёные на iOS 26.5. Четыре мутации (release-латч, игнор тогла, cap хостов, слабый isValidHost) краснят целевые сьюты.

Прод-код всего стека (PR1+PR2+PR3a+PR3b) байт-в-байт совпал с рабочей веткой-эталоном — ничего не потеряно при нарезке.