### PR TITLE
MOBILE-268: In-app WebView shared cache & pre-warm

### DIFF
--- a/Mindbox.xcodeproj/project.pbxproj
+++ b/Mindbox.xcodeproj/project.pbxproj
@@ -7,6 +7,10 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		16311BEB069E4B3983FAF594 /* InAppWebViewCacheTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 895F8C05EA8B4716B2A2941A /* InAppWebViewCacheTests.swift */; };
+		28375259024D42658E146900 /* InAppWebViewFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD1627DAC8D54E448C6D7BF0 /* InAppWebViewFactory.swift */; };
+		B58D5207F49F4531AA1C516B /* InAppWebViewHTMLFetcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = A85CCBEB1D874078954BB771 /* InAppWebViewHTMLFetcher.swift */; };
+		2DBF19F24FEA48AAA39C33E6 /* InAppWebViewDataStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D096F433EBB44C8B3490CF6 /* InAppWebViewDataStore.swift */; };
 		B9025268DDC24820B95ADE10 /* WebViewTimeoutErrorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11E54FE3B51649DCBD5ABE33 /* WebViewTimeoutErrorTests.swift */; };
 		CB91323FAD66404B9422B6E0 /* WebViewReadyCheckerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D716044131845AEA04A9858 /* WebViewReadyCheckerTests.swift */; };
 		C830BF4C287849CE95BB4ED9 /* WebViewReadyChecker.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2DAFC2435264F15B8033CCE /* WebViewReadyChecker.swift */; };
@@ -745,6 +749,10 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		895F8C05EA8B4716B2A2941A /* InAppWebViewCacheTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = InAppWebViewCacheTests.swift; sourceTree = "<group>"; };
+		FD1627DAC8D54E448C6D7BF0 /* InAppWebViewFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InAppWebViewFactory.swift; sourceTree = "<group>"; };
+		A85CCBEB1D874078954BB771 /* InAppWebViewHTMLFetcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InAppWebViewHTMLFetcher.swift; sourceTree = "<group>"; };
+		6D096F433EBB44C8B3490CF6 /* InAppWebViewDataStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InAppWebViewDataStore.swift; sourceTree = "<group>"; };
 		11E54FE3B51649DCBD5ABE33 /* WebViewTimeoutErrorTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WebViewTimeoutErrorTests.swift; sourceTree = "<group>"; };
 		4D716044131845AEA04A9858 /* WebViewReadyCheckerTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WebViewReadyCheckerTests.swift; sourceTree = "<group>"; };
 		F2DAFC2435264F15B8033CCE /* WebViewReadyChecker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebViewReadyChecker.swift; sourceTree = "<group>"; };
@@ -1528,6 +1536,7 @@
 		2B4C84F6EDD4B7D977F67A95 /* WebView */ = {
 			isa = PBXGroup;
 			children = (
+				895F8C05EA8B4716B2A2941A /* InAppWebViewCacheTests.swift */,
 				11E54FE3B51649DCBD5ABE33 /* WebViewTimeoutErrorTests.swift */,
 				4D716044131845AEA04A9858 /* WebViewReadyCheckerTests.swift */,
 				0CFCC82B8014DE7276C217CD /* WebViewLocalStateStorageTests.swift */,
@@ -3048,6 +3057,9 @@
 		B4E4386F2D8AFA5700603F3A /* WebView */ = {
 			isa = PBXGroup;
 			children = (
+				FD1627DAC8D54E448C6D7BF0 /* InAppWebViewFactory.swift */,
+				A85CCBEB1D874078954BB771 /* InAppWebViewHTMLFetcher.swift */,
+				6D096F433EBB44C8B3490CF6 /* InAppWebViewDataStore.swift */,
 				F2DAFC2435264F15B8033CCE /* WebViewReadyChecker.swift */,
 				47B1B6A92F6174E0000A4B67 /* LocalState */,
 				F3BD9F802F273BC800647BAF /* Bridge */,
@@ -4300,6 +4312,9 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				28375259024D42658E146900 /* InAppWebViewFactory.swift in Sources */,
+				B58D5207F49F4531AA1C516B /* InAppWebViewHTMLFetcher.swift in Sources */,
+				2DBF19F24FEA48AAA39C33E6 /* InAppWebViewDataStore.swift in Sources */,
 				C830BF4C287849CE95BB4ED9 /* WebViewReadyChecker.swift in Sources */,
 				46E95250B5904CC18E079C54 /* SDKUserAgent.swift in Sources */,
 				47EFBB2F2CB92B240023A4B9 /* SegmentationCheckResponse.swift in Sources */,
@@ -4679,6 +4694,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				16311BEB069E4B3983FAF594 /* InAppWebViewCacheTests.swift in Sources */,
 				B9025268DDC24820B95ADE10 /* WebViewTimeoutErrorTests.swift in Sources */,
 				CB91323FAD66404B9422B6E0 /* WebViewReadyCheckerTests.swift in Sources */,
 				F349753A2DEE2CB700BEC667 /* ShownInAppsDictionaryMigrationTests.swift in Sources */,

--- a/Mindbox.xcodeproj/project.pbxproj
+++ b/Mindbox.xcodeproj/project.pbxproj
@@ -7,6 +7,10 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		B9025268DDC24820B95ADE10 /* WebViewTimeoutErrorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11E54FE3B51649DCBD5ABE33 /* WebViewTimeoutErrorTests.swift */; };
+		CB91323FAD66404B9422B6E0 /* WebViewReadyCheckerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D716044131845AEA04A9858 /* WebViewReadyCheckerTests.swift */; };
+		C830BF4C287849CE95BB4ED9 /* WebViewReadyChecker.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2DAFC2435264F15B8033CCE /* WebViewReadyChecker.swift */; };
+		46E95250B5904CC18E079C54 /* SDKUserAgent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68184C936B4243C28CC10829 /* SDKUserAgent.swift */; };
 		0A3D045A2BC6803E00E1FC52 /* ImageFormat.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A3D04592BC6803E00E1FC52 /* ImageFormat.swift */; };
 		0E7A224A082FA2DA35706CC7 /* MotionServiceResolvePositionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C8192B8B7043EF74D05B36B /* MotionServiceResolvePositionTests.swift */; };
 		0E7A224A082FA2DA35706CC8 /* MotionServiceShakeToEditTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C8192B8B7043EF74D05B36C /* MotionServiceShakeToEditTests.swift */; };
@@ -741,6 +745,10 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		11E54FE3B51649DCBD5ABE33 /* WebViewTimeoutErrorTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WebViewTimeoutErrorTests.swift; sourceTree = "<group>"; };
+		4D716044131845AEA04A9858 /* WebViewReadyCheckerTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WebViewReadyCheckerTests.swift; sourceTree = "<group>"; };
+		F2DAFC2435264F15B8033CCE /* WebViewReadyChecker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebViewReadyChecker.swift; sourceTree = "<group>"; };
+		68184C936B4243C28CC10829 /* SDKUserAgent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SDKUserAgent.swift; sourceTree = "<group>"; };
 		0475E8755F63483597539A50 /* TrackVisitManagerTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TrackVisitManagerTests.swift; sourceTree = "<group>"; };
 		0A3D04592BC6803E00E1FC52 /* ImageFormat.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageFormat.swift; sourceTree = "<group>"; };
 		0CFCC82B8014DE7276C217CD /* WebViewLocalStateStorageTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WebViewLocalStateStorageTests.swift; sourceTree = "<group>"; };
@@ -1520,6 +1528,8 @@
 		2B4C84F6EDD4B7D977F67A95 /* WebView */ = {
 			isa = PBXGroup;
 			children = (
+				11E54FE3B51649DCBD5ABE33 /* WebViewTimeoutErrorTests.swift */,
+				4D716044131845AEA04A9858 /* WebViewReadyCheckerTests.swift */,
 				0CFCC82B8014DE7276C217CD /* WebViewLocalStateStorageTests.swift */,
 				55E67F6257F15F143DEA87DE /* JSONValueTagsMergeTests.swift */,
 				7A3F1B2C9D4E5F60718293A4 /* TransparentViewJSBridgeTests.swift */,
@@ -1662,6 +1672,7 @@
 		31A20D4A25B6E09900AAA0A3 /* Utilities */ = {
 			isa = PBXGroup;
 			children = (
+				68184C936B4243C28CC10829 /* SDKUserAgent.swift */,
 				47CFDAB82F3A05430034F310 /* SystemInfo */,
 				F31909972E979D8200373E2F /* AppDelegateProxy */,
 				47BD5BF82C578AD700F965C0 /* Migrations */,
@@ -3037,6 +3048,7 @@
 		B4E4386F2D8AFA5700603F3A /* WebView */ = {
 			isa = PBXGroup;
 			children = (
+				F2DAFC2435264F15B8033CCE /* WebViewReadyChecker.swift */,
 				47B1B6A92F6174E0000A4B67 /* LocalState */,
 				F3BD9F802F273BC800647BAF /* Bridge */,
 				F30654B92F1A83430058808C /* Debug */,
@@ -4288,6 +4300,8 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				C830BF4C287849CE95BB4ED9 /* WebViewReadyChecker.swift in Sources */,
+				46E95250B5904CC18E079C54 /* SDKUserAgent.swift in Sources */,
 				47EFBB2F2CB92B240023A4B9 /* SegmentationCheckResponse.swift in Sources */,
 				F331DD062A83A56500222120 /* ModalViewController.swift in Sources */,
 				F331DCC12A80993600222120 /* ContentElement.swift in Sources */,
@@ -4665,6 +4679,8 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				B9025268DDC24820B95ADE10 /* WebViewTimeoutErrorTests.swift in Sources */,
+				CB91323FAD66404B9422B6E0 /* WebViewReadyCheckerTests.swift in Sources */,
 				F349753A2DEE2CB700BEC667 /* ShownInAppsDictionaryMigrationTests.swift in Sources */,
 				4766A8AE2C9325B0002D15A4 /* ABTestsConfigParsingTests.swift in Sources */,
 				F3FEEA9F2C25AF39000E9D0F /* StubContainer.swift in Sources */,

--- a/Mindbox.xcodeproj/project.pbxproj
+++ b/Mindbox.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		AE190755CA97473B83E1568D /* MBContainerConcurrencyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B4F5CEE405E4BE29F97E43B /* MBContainerConcurrencyTests.swift */; };
+		3FDBA6E4D39A49369A335CF4 /* SDKUserAgentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E45E06561604E6185C33366 /* SDKUserAgentTests.swift */; };
 		16311BEB069E4B3983FAF594 /* InAppWebViewCacheTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 895F8C05EA8B4716B2A2941A /* InAppWebViewCacheTests.swift */; };
 		28375259024D42658E146900 /* InAppWebViewFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD1627DAC8D54E448C6D7BF0 /* InAppWebViewFactory.swift */; };
 		B58D5207F49F4531AA1C516B /* InAppWebViewHTMLFetcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = A85CCBEB1D874078954BB771 /* InAppWebViewHTMLFetcher.swift */; };
@@ -749,6 +751,8 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		4B4F5CEE405E4BE29F97E43B /* MBContainerConcurrencyTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MBContainerConcurrencyTests.swift; sourceTree = "<group>"; };
+		4E45E06561604E6185C33366 /* SDKUserAgentTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SDKUserAgentTests.swift; sourceTree = "<group>"; };
 		895F8C05EA8B4716B2A2941A /* InAppWebViewCacheTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = InAppWebViewCacheTests.swift; sourceTree = "<group>"; };
 		FD1627DAC8D54E448C6D7BF0 /* InAppWebViewFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InAppWebViewFactory.swift; sourceTree = "<group>"; };
 		A85CCBEB1D874078954BB771 /* InAppWebViewHTMLFetcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InAppWebViewHTMLFetcher.swift; sourceTree = "<group>"; };
@@ -2278,6 +2282,7 @@
 		64FD3F7576619DCF106D10B6 /* Network */ = {
 			isa = PBXGroup;
 			children = (
+				4E45E06561604E6185C33366 /* SDKUserAgentTests.swift */,
 				97FEDDEB5F71A67F1C4C675F /* MBNetworkFetcherResponseHandlingTests.swift */,
 				F3BA5E000130A000C0000006 /* OperationsURLRoutingTests.swift */,
 				F3CD202C2F600A800065392A /* HostNormalizerTests.swift */,
@@ -2466,6 +2471,7 @@
 		84B625F525C98EE000AB6228 /* DI */ = {
 			isa = PBXGroup;
 			children = (
+				4B4F5CEE405E4BE29F97E43B /* MBContainerConcurrencyTests.swift */,
 				F3FEEAA72C25CC8F000E9D0F /* Injections */,
 				F3FEEA9E2C25AF39000E9D0F /* StubContainer.swift */,
 				F32E536E2C3F2B05002C7CA0 /* DITests.swift */,
@@ -4694,6 +4700,8 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				AE190755CA97473B83E1568D /* MBContainerConcurrencyTests.swift in Sources */,
+				3FDBA6E4D39A49369A335CF4 /* SDKUserAgentTests.swift in Sources */,
 				16311BEB069E4B3983FAF594 /* InAppWebViewCacheTests.swift in Sources */,
 				B9025268DDC24820B95ADE10 /* WebViewTimeoutErrorTests.swift in Sources */,
 				CB91323FAD66404B9422B6E0 /* WebViewReadyCheckerTests.swift in Sources */,

--- a/Mindbox.xcodeproj/project.pbxproj
+++ b/Mindbox.xcodeproj/project.pbxproj
@@ -7,6 +7,10 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		A881A16C702E41AE93848BD3 /* InAppWebViewLearnedHostsStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B76146361C3402193A00F88 /* InAppWebViewLearnedHostsStore.swift */; };
+		F389B3A639904206A3DADFFA /* InAppWebViewPrewarmPlanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDCC6F9CEEF24C2BAB624DD5 /* InAppWebViewPrewarmPlanner.swift */; };
+		8A94D721DAEF4395A360C5B2 /* InAppWebViewPrewarmNavigationPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96A50D5650094A23A2C667CE /* InAppWebViewPrewarmNavigationPolicy.swift */; };
+		23335221BB1D4F8C8D5C864D /* InAppWebViewPrewarmService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F423FA6C2E243F68A76E9C2 /* InAppWebViewPrewarmService.swift */; };
 		23E4A509BFE94104BD01B61A /* MindboxWebBridgeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CC5ED4F76B046798978B4B9 /* MindboxWebBridgeTests.swift */; };
 		AE190755CA97473B83E1568D /* MBContainerConcurrencyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B4F5CEE405E4BE29F97E43B /* MBContainerConcurrencyTests.swift */; };
 		3FDBA6E4D39A49369A335CF4 /* SDKUserAgentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E45E06561604E6185C33366 /* SDKUserAgentTests.swift */; };
@@ -752,6 +756,10 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		1B76146361C3402193A00F88 /* InAppWebViewLearnedHostsStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InAppWebViewLearnedHostsStore.swift; sourceTree = "<group>"; };
+		DDCC6F9CEEF24C2BAB624DD5 /* InAppWebViewPrewarmPlanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InAppWebViewPrewarmPlanner.swift; sourceTree = "<group>"; };
+		96A50D5650094A23A2C667CE /* InAppWebViewPrewarmNavigationPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InAppWebViewPrewarmNavigationPolicy.swift; sourceTree = "<group>"; };
+		1F423FA6C2E243F68A76E9C2 /* InAppWebViewPrewarmService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InAppWebViewPrewarmService.swift; sourceTree = "<group>"; };
 		9CC5ED4F76B046798978B4B9 /* MindboxWebBridgeTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MindboxWebBridgeTests.swift; sourceTree = "<group>"; };
 		4B4F5CEE405E4BE29F97E43B /* MBContainerConcurrencyTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MBContainerConcurrencyTests.swift; sourceTree = "<group>"; };
 		4E45E06561604E6185C33366 /* SDKUserAgentTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SDKUserAgentTests.swift; sourceTree = "<group>"; };
@@ -3063,6 +3071,17 @@
 			path = InAppTargetingChecker;
 			sourceTree = "<group>";
 		};
+		0E8BCE24EE9540D6BD7F655D /* Prewarm */ = {
+			isa = PBXGroup;
+			children = (
+				1B76146361C3402193A00F88 /* InAppWebViewLearnedHostsStore.swift */,
+				DDCC6F9CEEF24C2BAB624DD5 /* InAppWebViewPrewarmPlanner.swift */,
+				96A50D5650094A23A2C667CE /* InAppWebViewPrewarmNavigationPolicy.swift */,
+				1F423FA6C2E243F68A76E9C2 /* InAppWebViewPrewarmService.swift */,
+			);
+			path = Prewarm;
+			sourceTree = "<group>";
+		};
 		B4E4386F2D8AFA5700603F3A /* WebView */ = {
 			isa = PBXGroup;
 			children = (
@@ -3070,6 +3089,7 @@
 				A85CCBEB1D874078954BB771 /* InAppWebViewHTMLFetcher.swift */,
 				6D096F433EBB44C8B3490CF6 /* InAppWebViewDataStore.swift */,
 				F2DAFC2435264F15B8033CCE /* WebViewReadyChecker.swift */,
+				0E8BCE24EE9540D6BD7F655D /* Prewarm */,
 				47B1B6A92F6174E0000A4B67 /* LocalState */,
 				F3BD9F802F273BC800647BAF /* Bridge */,
 				F30654B92F1A83430058808C /* Debug */,
@@ -4321,6 +4341,10 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				A881A16C702E41AE93848BD3 /* InAppWebViewLearnedHostsStore.swift in Sources */,
+				F389B3A639904206A3DADFFA /* InAppWebViewPrewarmPlanner.swift in Sources */,
+				8A94D721DAEF4395A360C5B2 /* InAppWebViewPrewarmNavigationPolicy.swift in Sources */,
+				23335221BB1D4F8C8D5C864D /* InAppWebViewPrewarmService.swift in Sources */,
 				28375259024D42658E146900 /* InAppWebViewFactory.swift in Sources */,
 				B58D5207F49F4531AA1C516B /* InAppWebViewHTMLFetcher.swift in Sources */,
 				2DBF19F24FEA48AAA39C33E6 /* InAppWebViewDataStore.swift in Sources */,

--- a/Mindbox.xcodeproj/project.pbxproj
+++ b/Mindbox.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		23E4A509BFE94104BD01B61A /* MindboxWebBridgeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CC5ED4F76B046798978B4B9 /* MindboxWebBridgeTests.swift */; };
 		AE190755CA97473B83E1568D /* MBContainerConcurrencyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B4F5CEE405E4BE29F97E43B /* MBContainerConcurrencyTests.swift */; };
 		3FDBA6E4D39A49369A335CF4 /* SDKUserAgentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E45E06561604E6185C33366 /* SDKUserAgentTests.swift */; };
 		16311BEB069E4B3983FAF594 /* InAppWebViewCacheTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 895F8C05EA8B4716B2A2941A /* InAppWebViewCacheTests.swift */; };
@@ -751,6 +752,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		9CC5ED4F76B046798978B4B9 /* MindboxWebBridgeTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MindboxWebBridgeTests.swift; sourceTree = "<group>"; };
 		4B4F5CEE405E4BE29F97E43B /* MBContainerConcurrencyTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MBContainerConcurrencyTests.swift; sourceTree = "<group>"; };
 		4E45E06561604E6185C33366 /* SDKUserAgentTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SDKUserAgentTests.swift; sourceTree = "<group>"; };
 		895F8C05EA8B4716B2A2941A /* InAppWebViewCacheTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = InAppWebViewCacheTests.swift; sourceTree = "<group>"; };
@@ -1540,6 +1542,7 @@
 		2B4C84F6EDD4B7D977F67A95 /* WebView */ = {
 			isa = PBXGroup;
 			children = (
+				9CC5ED4F76B046798978B4B9 /* MindboxWebBridgeTests.swift */,
 				895F8C05EA8B4716B2A2941A /* InAppWebViewCacheTests.swift */,
 				11E54FE3B51649DCBD5ABE33 /* WebViewTimeoutErrorTests.swift */,
 				4D716044131845AEA04A9858 /* WebViewReadyCheckerTests.swift */,
@@ -4700,6 +4703,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				23E4A509BFE94104BD01B61A /* MindboxWebBridgeTests.swift in Sources */,
 				AE190755CA97473B83E1568D /* MBContainerConcurrencyTests.swift in Sources */,
 				3FDBA6E4D39A49369A335CF4 /* SDKUserAgentTests.swift in Sources */,
 				16311BEB069E4B3983FAF594 /* InAppWebViewCacheTests.swift in Sources */,

--- a/Mindbox.xcodeproj/project.pbxproj
+++ b/Mindbox.xcodeproj/project.pbxproj
@@ -1486,6 +1486,7 @@
 		F385631E2DB6729000D91208 /* InappConfigurationDataFacade */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = InappConfigurationDataFacade; sourceTree = "<group>"; };
 		F397DE1C2CFF568800B72DA9 /* JSONs */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = JSONs; sourceTree = "<group>"; };
 		F3DEB38C2D47CBA200D0EFA4 /* InappSessionManagerTests */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = InappSessionManagerTests; sourceTree = "<group>"; };
+		A8C878878353491FA01AC096 /* WebViewPrewarmTests */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = WebViewPrewarmTests; sourceTree = "<group>"; };
 /* End PBXFileSystemSynchronizedRootGroup section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -2734,6 +2735,7 @@
 			isa = PBXGroup;
 			children = (
 				F367D3772FE43B2900455DB0 /* ModalViewControllerLayoutTests.swift */,
+				A8C878878353491FA01AC096 /* WebViewPrewarmTests */,
 				F385631E2DB6729000D91208 /* InappConfigurationDataFacade */,
 				F3DEB38C2D47CBA200D0EFA4 /* InappSessionManagerTests */,
 				F39B67B62A3FAA62005C0CCA /* ABTesting */,
@@ -3945,6 +3947,7 @@
 				313B233C25ADEA0F00A1CB72 /* PBXTargetDependency */,
 			);
 			fileSystemSynchronizedGroups = (
+				A8C878878353491FA01AC096 /* WebViewPrewarmTests */,
 				F385631E2DB6729000D91208 /* InappConfigurationDataFacade */,
 				F397DE1C2CFF568800B72DA9 /* JSONs */,
 				F3DEB38C2D47CBA200D0EFA4 /* InappSessionManagerTests */,

--- a/Mindbox/DI/Injections/InjectCore.swift
+++ b/Mindbox/DI/Injections/InjectCore.swift
@@ -48,7 +48,8 @@ extension MBContainer {
                 inAppConfigRepository: InAppConfigurationRepository(),
                 inappMapper: DI.injectOrFail(InappMapperProtocol.self),
                 persistenceStorage: persistenceStorage,
-                featureToggleManager: featureToggleManager)
+                featureToggleManager: featureToggleManager,
+                webViewPrewarmService: DI.injectOrFail(InAppWebViewPrewarmServiceProtocol.self))
         }
         
         register(CheckNotifWork.self) {

--- a/Mindbox/DI/Injections/InjectInappTools.swift
+++ b/Mindbox/DI/Injections/InjectInappTools.swift
@@ -130,6 +130,11 @@ extension MBContainer {
             )
         }
 
+        register(InAppWebViewPrewarmServiceProtocol.self) {
+            let persistenceStorage = DI.injectOrFail(PersistenceStorage.self)
+            return InAppWebViewPrewarmService(persistenceStorage: persistenceStorage)
+        }
+
         return self
     }
 }

--- a/Mindbox/DI/MBContainer.swift
+++ b/Mindbox/DI/MBContainer.swift
@@ -16,15 +16,21 @@ enum ObjectScope {
 class MBContainer {
     private var factories: [String: (ObjectScope, () -> Any)] = [:]
     private var singletons: [String: Any] = [:]
+    // Recursive: factories resolve their own dependencies on the same thread.
+    private let lock = NSRecursiveLock()
 
     func register<T>(_ type: T.Type, scope: ObjectScope = .container, factory: @escaping () -> T) {
         let key = String(describing: type)
+        lock.lock()
+        defer { lock.unlock() }
         factories[key] = (scope, factory)
     }
 
     func resolve<T>(_ type: T.Type) -> T? {
         let key = String(describing: type)
 
+        lock.lock()
+        defer { lock.unlock() }
         if let (scope, factory) = factories[key] {
             switch scope {
             case .container:

--- a/Mindbox/InAppMessages/Configuration/InAppConfigurationManager.swift
+++ b/Mindbox/InAppMessages/Configuration/InAppConfigurationManager.swift
@@ -33,19 +33,22 @@ class InAppConfigurationManager: InAppConfigurationManagerProtocol {
     private let inAppConfigAPI: InAppConfigurationAPI
     private let persistenceStorage: PersistenceStorage
     private let featureToggleManager: FeatureToggleManager
+    private let webViewPrewarmService: InAppWebViewPrewarmServiceProtocol
 
     init(
         inAppConfigAPI: InAppConfigurationAPI,
         inAppConfigRepository: InAppConfigurationRepository,
         inappMapper: InappMapperProtocol?,
         persistenceStorage: PersistenceStorage,
-        featureToggleManager: FeatureToggleManager
+        featureToggleManager: FeatureToggleManager,
+        webViewPrewarmService: InAppWebViewPrewarmServiceProtocol
     ) {
         self.inAppConfigRepository = inAppConfigRepository
         self.inappMapper = inappMapper
         self.inAppConfigAPI = inAppConfigAPI
         self.persistenceStorage = persistenceStorage
         self.featureToggleManager = featureToggleManager
+        self.webViewPrewarmService = webViewPrewarmService
     }
 
     weak var delegate: InAppConfigurationDelegate?
@@ -101,6 +104,11 @@ class InAppConfigurationManager: InAppConfigurationManagerProtocol {
             Logger.common(message: "Failed to download InApp configuration. Error: \(error.localizedDescription)", level: .error, category: .inAppMessages)
         }
 
+        // Prewarm stage 2: warm what the config's webview in-apps need (or release the
+        // warm instance when the config proves there are none).
+        if let configResponse {
+            webViewPrewarmService.prewarmResources(for: configResponse)
+        }
         self.delegate?.didPreparedConfiguration()
         sendNotification(with: configResponse?.settings?.slidingExpiration?.pushTokenKeepalive)
     }

--- a/Mindbox/InAppMessages/Configuration/InAppConfigurationRepository.swift
+++ b/Mindbox/InAppMessages/Configuration/InAppConfigurationRepository.swift
@@ -29,7 +29,10 @@ class InAppConfigurationRepository {
 
     func saveConfigToCache(_ data: Data) {
         do {
-            try data.write(to: inAppConfigFileUrl)
+            // Atomic (write-then-rename): the init-time prewarm reads this file from a
+            // background queue while the config download rewrites it — a concurrent
+            // reader must see the old or the new config, never a torn file.
+            try data.write(to: inAppConfigFileUrl, options: .atomic)
             Logger.common(message: "Successfuly saved config file on a disk.", level: .debug, category: .inAppMessages)
         } catch {
             Logger.common(message: "Failed to save config file on a disk. Error: \(error.localizedDescription)", level: .debug, category: .inAppMessages)

--- a/Mindbox/InAppMessages/Configuration/InAppConfigurationRepository.swift
+++ b/Mindbox/InAppMessages/Configuration/InAppConfigurationRepository.swift
@@ -27,6 +27,14 @@ class InAppConfigurationRepository {
         }
     }
 
+    /// The single home of the lenient cached-config decode for launch-time readers (the
+    /// prewarm stages, the WebView cache toggle). The config manager keeps its own richer
+    /// variant with per-outcome logging.
+    func fetchDecodedConfigFromCache() -> ConfigResponse? {
+        guard let data = fetchConfigFromCache() else { return nil }
+        return try? JSONDecoder().decode(ConfigResponse.self, from: data)
+    }
+
     func saveConfigToCache(_ data: Data) {
         do {
             // Atomic (write-then-rename): the init-time prewarm reads this file from a

--- a/Mindbox/InAppMessages/FeatureToggleManager/FeatureToggleManager.swift
+++ b/Mindbox/InAppMessages/FeatureToggleManager/FeatureToggleManager.swift
@@ -12,10 +12,12 @@ import MindboxLogger
 enum FeatureFlag {
     case shouldSendInAppShowError
     case shouldSendInAppTags
+    case shouldPrewarmInAppWebView
+    case shouldCacheInAppWebView
 
     var defaultValue: Bool {
         switch self {
-        case .shouldSendInAppShowError:
+        case .shouldSendInAppShowError, .shouldPrewarmInAppWebView, .shouldCacheInAppWebView:
             return true
         case .shouldSendInAppTags:
             return true
@@ -23,6 +25,11 @@ enum FeatureFlag {
     }
 }
 
+/// Holds the toggles applied from a freshly downloaded config. The WebView flags
+/// (`shouldPrewarmInAppWebView`, `shouldCacheInAppWebView`) are deliberately read
+/// config-scoped by their consumers instead (each prewarm stage reads the config it works
+/// with; the data store latches from the config cache) — those reads happen before any
+/// fresh config can be applied here.
 final class FeatureToggleManager {
 
     /// Guards `featureToggles`: it is written on the config-fetch queue and read from arbitrary queues (tracking, WebView JS-bridge).
@@ -36,7 +43,9 @@ final class FeatureToggleManager {
 
         let flags: [String] = [
             featureToggles?.shouldSendInAppShowError.map { "MobileSdkShouldSendInAppShowError=\($0)" },
-            featureToggles?.shouldSendInAppTags.map { "MobileSdkShouldSendInAppTags=\($0)" }
+            featureToggles?.shouldSendInAppTags.map { "MobileSdkShouldSendInAppTags=\($0)" },
+            featureToggles?.shouldPrewarmInAppWebView.map { "MobileSdkShouldPrewarmInAppWebView=\($0)" },
+            featureToggles?.shouldCacheInAppWebView.map { "MobileSdkShouldCacheInAppWebView=\($0)" }
         ].compactMap { $0 }
         Logger.common(
             message: "[FeatureToggles] \(flags)",
@@ -55,6 +64,10 @@ final class FeatureToggleManager {
             return featureToggles?.shouldSendInAppShowError ?? feature.defaultValue
         case .shouldSendInAppTags:
             return featureToggles?.shouldSendInAppTags ?? feature.defaultValue
+        case .shouldPrewarmInAppWebView:
+            return featureToggles?.shouldPrewarmInAppWebView ?? feature.defaultValue
+        case .shouldCacheInAppWebView:
+            return featureToggles?.shouldCacheInAppWebView ?? feature.defaultValue
         }
     }
 }

--- a/Mindbox/InAppMessages/Models/Config/FeatureTogglesModel.swift
+++ b/Mindbox/InAppMessages/Models/Config/FeatureTogglesModel.swift
@@ -12,10 +12,14 @@ extension Settings {
     struct FeatureToggles: Decodable, Equatable {
         let shouldSendInAppShowError: Bool?
         let shouldSendInAppTags: Bool?
+        let shouldPrewarmInAppWebView: Bool?
+        let shouldCacheInAppWebView: Bool?
 
         enum CodingKeys: String, CodingKey {
             case shouldSendInAppShowError = "MobileSdkShouldSendInAppShowError"
             case shouldSendInAppTags = "MobileSdkShouldSendInAppTags"
+            case shouldPrewarmInAppWebView = "MobileSdkShouldPrewarmInAppWebView"
+            case shouldCacheInAppWebView = "MobileSdkShouldCacheInAppWebView"
         }
     }
 }
@@ -25,5 +29,7 @@ extension Settings.FeatureToggles {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         self.shouldSendInAppShowError = try? container.decodeIfPresent(Bool.self, forKey: .shouldSendInAppShowError)
         self.shouldSendInAppTags = try? container.decodeIfPresent(Bool.self, forKey: .shouldSendInAppTags)
+        self.shouldPrewarmInAppWebView = try? container.decodeIfPresent(Bool.self, forKey: .shouldPrewarmInAppWebView)
+        self.shouldCacheInAppWebView = try? container.decodeIfPresent(Bool.self, forKey: .shouldCacheInAppWebView)
     }
 }

--- a/Mindbox/InAppMessages/Presentation/Views/WebView/Bridge/MindboxWebBridge.swift
+++ b/Mindbox/InAppMessages/Presentation/Views/WebView/Bridge/MindboxWebBridge.swift
@@ -45,19 +45,28 @@ public final class MindboxWebBridge: NSObject {
     private var pendingRequestIds = Set<UUID>()
     private var contentURL: URL?
 
+    // A reused (pre-warmed) WKWebView can deliver navigation callbacks and script messages
+    // that belong to a previous owner's load. Callbacks are filtered by navigation identity;
+    // messages are gated until the show's own document commits (the document-swap point —
+    // whoever posts before it is not this show's page). Main-thread only.
+    private var expectedNavigation: WKNavigation?
+    private var expectedNavigationFinished = false
+    private var expectedNavigationCommitted = false
+    private var contentLoadIssued = false
+
     init(webView: WKWebView) {
         self.webView = webView
         super.init()
 
         let controller = webView.configuration.userContentController
+        // Idempotent: a reused WebView may still carry a previous show's handler of this name.
+        controller.removeScriptMessageHandler(forName: Constants.WebViewBridgeJS.handlerName)
         controller.add(self, name: Constants.WebViewBridgeJS.handlerName)
         webView.navigationDelegate = self
     }
 
-    deinit {
-        webView?.configuration.userContentController.removeScriptMessageHandler(forName: Constants.WebViewBridgeJS.handlerName)
-        webView?.navigationDelegate = nil
-    }
+    // No deinit teardown needed: `navigationDelegate` is weak (zeroes automatically), and
+    // the successor's init does remove-then-add on the script handler.
 
     func send(_ message: BridgeMessage) {
         guard let json = message.jsonString() else {
@@ -132,6 +141,32 @@ public final class MindboxWebBridge: NSObject {
     func updateContentURL(_ url: URL?) {
         contentURL = url
     }
+
+    /// Registers the navigation issued by this show's own load (loadHTMLString/reload).
+    /// Until it finishes, callbacks for any other navigation are treated as stale leftovers.
+    func expectContentNavigation(_ navigation: WKNavigation?) {
+        contentLoadIssued = true
+        expectedNavigation = navigation
+        expectedNavigationFinished = false
+        expectedNavigationCommitted = false
+    }
+
+    private func isStaleNavigation(_ navigation: WKNavigation?) -> Bool {
+        if expectedNavigationFinished { return false }
+        guard contentLoadIssued else { return true }
+        // WebKit occasionally delivers a nil navigation (early provisional failures): it
+        // can't be proven to be a leftover — fail open, like the nil-expected case below.
+        guard let navigation else { return false }
+        guard let expected = expectedNavigation else { return false }
+        return navigation !== expected
+    }
+
+    private func logStaleNavigation(_ event: String) {
+        Logger.common(
+            message: "[WebView] Bridge: ignoring stale navigation \(event) (leftover load on reused WebView)",
+            category: .webViewInAppMessages
+        )
+    }
 }
 
 extension MindboxWebBridge: WKScriptMessageHandler {
@@ -140,6 +175,16 @@ extension MindboxWebBridge: WKScriptMessageHandler {
         guard message.name == Constants.WebViewBridgeJS.handlerName else {
             Logger.common(
                 message: "[WebView] Bridge: received message with wrong handler name: \(message.name)",
+                category: .webViewInAppMessages
+            )
+            return
+        }
+
+        // Mirror of the navigation staleness filter at message level: until the show's own
+        // document has committed, whoever is posting is not this show's page — drop it.
+        guard expectedNavigationCommitted else {
+            Logger.common(
+                message: "[WebView] Bridge: ignoring JS message before the show's document committed (leftover page on reused WebView)",
                 category: .webViewInAppMessages
             )
             return
@@ -183,22 +228,53 @@ extension MindboxWebBridge: WKScriptMessageHandler {
 
 extension MindboxWebBridge: WKNavigationDelegate {
     public func webView(_ webView: WKWebView, didStartProvisionalNavigation navigation: WKNavigation!) {
+        guard !isStaleNavigation(navigation) else {
+            logStaleNavigation("start")
+            return
+        }
         navigationDelegate?.webBridge(self, didStartProvisionalNavigation: webView.url)
     }
 
+    public func webView(_ webView: WKWebView, didCommit navigation: WKNavigation!) {
+        guard !isStaleNavigation(navigation) else {
+            logStaleNavigation("commit")
+            return
+        }
+        // The old document is gone from this point: script messages are now this show's.
+        expectedNavigationCommitted = true
+    }
+
     public func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
-        navigationDelegate?.webBridge(self, didFinishNavigation: contentURL ?? webView.url)
+        guard !isStaleNavigation(navigation) else {
+            logStaleNavigation("finish")
+            return
+        }
+        // Only the show's own load reports the content URL; a page-initiated navigation
+        // reports its real URL so upstream can tell the documents apart.
+        let isExpected = navigation === expectedNavigation
+        if isExpected {
+            expectedNavigationFinished = true
+        }
+        navigationDelegate?.webBridge(self, didFinishNavigation: isExpected ? (contentURL ?? webView.url) : webView.url)
     }
 
     public func webView(_ webView: WKWebView,
                         didFailProvisionalNavigation navigation: WKNavigation!,
                         withError error: Error) {
+        guard !isStaleNavigation(navigation) else {
+            logStaleNavigation("provisional failure: \(error.localizedDescription)")
+            return
+        }
         navigationDelegate?.webBridge(self, didFailProvisionalNavigation: webView.url, error: error)
     }
 
     public func webView(_ webView: WKWebView,
                         didFail navigation: WKNavigation!,
                         withError error: Error) {
+        guard !isStaleNavigation(navigation) else {
+            logStaleNavigation("failure: \(error.localizedDescription)")
+            return
+        }
         navigationDelegate?.webBridge(self, didFailProvisionalNavigation: webView.url, error: error)
     }
     

--- a/Mindbox/InAppMessages/Presentation/Views/WebView/Debug/MindboxWebViewFacade.swift
+++ b/Mindbox/InAppMessages/Presentation/Views/WebView/Debug/MindboxWebViewFacade.swift
@@ -87,18 +87,7 @@ public final class MindboxWebViewFacade: MindboxInternalWebViewFacadeProtocol {
                 inAppId: String = "",
                 log: @escaping WebViewLog = { _ in },
                 logError: @escaping WebViewLogError = { _ in }) {
-        let config = WKWebViewConfiguration()
-        config.websiteDataStore = .nonPersistent()
-        config.applicationNameForUserAgent = userAgent
-        config.allowsInlineMediaPlayback = true
-        config.mediaTypesRequiringUserActionForPlayback = []
-
-        let webView = WKWebView(frame: .zero, configuration: config)
-        #if DEBUG
-        if #available(iOS 16.4, *) {
-            webView.isInspectable = true
-        }
-        #endif
+        let webView = InAppWebViewFactory.make(userAgent: userAgent)
         let bridge = MindboxWebBridge(webView: webView)
 
         self.webView = webView
@@ -313,15 +302,11 @@ extension MindboxWebViewFacade {
             return
         }
         
-        let config = URLSessionConfiguration.ephemeral
-        config.requestCachePolicy = .reloadIgnoringLocalAndRemoteCacheData
-        config.urlCache = nil
-        
-        let session = URLSession(configuration: config)
-        
+        let (session, request) = InAppWebViewHTMLFetcher.sessionAndRequest(for: url)
+
         log("Fetching HTML from \(url.absoluteString)")
-        
-        let task = session.dataTask(with: url) { [weak self] data, response, error in
+
+        let task = session.dataTask(with: request) { [weak self] data, response, error in
             if let error {
                 self?.logError("Error fetching HTML: \(error.localizedDescription)")
                 completion(nil)

--- a/Mindbox/InAppMessages/Presentation/Views/WebView/Debug/MindboxWebViewFacade.swift
+++ b/Mindbox/InAppMessages/Presentation/Views/WebView/Debug/MindboxWebViewFacade.swift
@@ -81,13 +81,32 @@ public final class MindboxWebViewFacade: MindboxInternalWebViewFacadeProtocol {
     private let log: WebViewLog
     private let logError: WebViewLogError
 
+    // Main-confined. A borrowed prewarmed `webView` outlives this facade (the prewarm
+    // service keeps it warm across shows), so a `[weak webView]` guard is not enough to
+    // stop a slow fetch that completes after the show closed — it would load the dead
+    // show's page into the parked hidden instance. `isClosed` gates the load and the
+    // in-flight fetch is cancelled outright on teardown.
+    private var fetchTask: URLSessionDataTask?
+    private var isClosed = false
+
     public init(params: [String: JSONValue]?,
                 operation: (name: String, body: String)? = nil,
                 userAgent: String,
                 inAppId: String = "",
                 log: @escaping WebViewLog = { _ in },
                 logError: @escaping WebViewLogError = { _ in }) {
-        let webView = InAppWebViewFactory.make(userAgent: userAgent)
+        // Borrow the prewarmed live instance when available (kept across shows — hidden,
+        // not destroyed); otherwise create one on the same shared data store so cached
+        // resources stay visible either way. A warm instance can only serve a caller that
+        // wants the stock UA: its applicationNameForUserAgent was baked at prewarm
+        // creation and cannot change on a live WKWebView.
+        let webView: WKWebView
+        if userAgent == SDKUserAgent.build(),
+           let warm = DI.injectOrFail(InAppWebViewPrewarmServiceProtocol.self).borrowWarmWebView() {
+            webView = warm
+        } else {
+            webView = InAppWebViewFactory.make(userAgent: userAgent)
+        }
         let bridge = MindboxWebBridge(webView: webView)
 
         self.webView = webView
@@ -97,6 +116,12 @@ public final class MindboxWebViewFacade: MindboxInternalWebViewFacadeProtocol {
         self.inAppId = inAppId
         self.log = log
         self.logError = logError
+    }
+
+    deinit {
+        // The fetch completion holds only a weak self, so a pending request can outlive
+        // the facade; cancel it so it can never resume work against a reused webView.
+        fetchTask?.cancel()
     }
 
     public func makeView() -> UIView {
@@ -110,36 +135,35 @@ public final class MindboxWebViewFacade: MindboxInternalWebViewFacadeProtocol {
         let contentURL = URL(string: contentUrl)
         bridge.updateContentURL(contentURL)
         
-        fetchHTML(from: contentUrl) { [weak webView] html in
-            guard let webView else {
-                DispatchQueue.main.async {
+        fetchHTML(from: contentUrl) { [weak self] html in
+            DispatchQueue.main.async {
+                // A show that closed while the fetch was in flight must not load into the
+                // (possibly reused) webView, and must not re-report failure — it is already
+                // tearing down.
+                guard let self, !self.isClosed else { return }
+                guard let html else {
                     onFailure()
+                    return
                 }
-                return
+                self.bridge.expectContentNavigation(self.webView.loadHTMLString(html, baseURL: url))
             }
+        }
+    }
 
-            if let html {
-                DispatchQueue.main.async {
-                    webView.loadHTMLString(html, baseURL: url)
-                }
-            } else {
-                DispatchQueue.main.async {
-                    onFailure()
-                }
-            }
-        }
-    }
-    
     public func reloadWebView() {
-        DispatchQueue.main.async { [weak webView] in
-            webView?.reload()
+        DispatchQueue.main.async { [weak self] in
+            guard let self, !self.isClosed else { return }
+            self.bridge.expectContentNavigation(self.webView.reload())
         }
     }
-    
+
     public func cleanWebView() {
-        DispatchQueue.main.async { [weak webView] in
-            guard let webView else { return }
-            webView.stopLoading()
+        DispatchQueue.main.async { [weak self] in
+            guard let self else { return }
+            self.isClosed = true
+            self.fetchTask?.cancel()
+            self.fetchTask = nil
+            self.webView.stopLoading()
         }
     }
     
@@ -301,7 +325,7 @@ extension MindboxWebViewFacade {
             completion(nil)
             return
         }
-        
+
         let (session, request) = InAppWebViewHTMLFetcher.sessionAndRequest(for: url)
 
         log("Fetching HTML from \(url.absoluteString)")
@@ -331,6 +355,9 @@ extension MindboxWebViewFacade {
             completion(htmlString)
         }
 
+        // Retained so teardown can cancel an in-flight request. Main-confined: `loadHTML`
+        // (the sole caller) runs on the main thread.
+        fetchTask = task
         task.resume()
     }
 }

--- a/Mindbox/InAppMessages/Presentation/Views/WebView/Debug/MindboxWebViewFacade.swift
+++ b/Mindbox/InAppMessages/Presentation/Views/WebView/Debug/MindboxWebViewFacade.swift
@@ -258,18 +258,15 @@ extension MindboxWebViewFacade {
         return params
     }
 
-    // Add operation data
     private func addOperationParams(to params: inout [String: Any]) {
         guard let operation else { return }
         params[PayloadKey.operationName] = operation.name
         params[PayloadKey.operationBody] = operation.body
     }
 
-    // Add system info (theme, platform, locale, version)
     private func addSystemInfo(to params: inout [String: Any], systemInfoProvider: SystemInfoProvider) {
         params.merge(systemInfoProvider.getBasicSystemInfo()) { _, new in new }
 
-        // Add safe area insets
         let insets = systemInfoProvider.getSafeAreaInsets(from: webView)
         params[PayloadKey.Insets.key] = [
             PayloadKey.Insets.top: insets.top,
@@ -278,14 +275,12 @@ extension MindboxWebViewFacade {
             PayloadKey.Insets.right: insets.right
         ]
 
-        // Add granted permissions
         let permissions = systemInfoProvider.getGrantedPermissions()
         if !permissions.isEmpty {
             params[PayloadKey.permissions] = permissions.mapValues { $0.toDictionary() }
         }
     }
 
-    // Merge params from configuration
     private func mergeCustomParams(into params: inout [String: Any]) {
         guard let customParams = self.params, !customParams.isEmpty else { return }
         for (key, value) in customParams {
@@ -293,7 +288,6 @@ extension MindboxWebViewFacade {
         }
     }
 
-    // Add last track-visit data
     private func addTrackVisitParams(to params: inout [String: Any]) {
         guard let lastTrackVisit = SessionTemporaryStorage.shared.lastTrackVisit else { return }
         if let source = lastTrackVisit.source {
@@ -304,7 +298,6 @@ extension MindboxWebViewFacade {
         }
     }
 
-    // Serialize to JSON string
     private func serializeToJSONString(_ params: [String: Any]) -> JSONValue {
         do {
             let data = try JSONSerialization.data(withJSONObject: params, options: [])

--- a/Mindbox/InAppMessages/Presentation/Views/WebView/InAppWebViewDataStore.swift
+++ b/Mindbox/InAppMessages/Presentation/Views/WebView/InAppWebViewDataStore.swift
@@ -49,7 +49,7 @@ enum InAppWebViewDataStore {
         } else {
             // Product decision: no isolated named stores before iOS 17, and some disk
             // cache beats none — Mindbox web content shares the host app's default store
-            // (cookies/storage included) on old systems. Toggle off → .nonPersistent().
+            // (cookies/storage included) on old systems.
             return WKWebsiteDataStore.default()
         }
     }()

--- a/Mindbox/InAppMessages/Presentation/Views/WebView/InAppWebViewDataStore.swift
+++ b/Mindbox/InAppMessages/Presentation/Views/WebView/InAppWebViewDataStore.swift
@@ -1,0 +1,63 @@
+//
+//  InAppWebViewDataStore.swift
+//  Mindbox
+//
+//  Created by Sergei Semko on 06.07.2026.
+//  Copyright © 2026 Mindbox. All rights reserved.
+//
+
+import WebKit
+
+/// The single `WKWebsiteDataStore` used by every Mindbox WebView (prewarm and shows alike).
+///
+/// Persistence is what lets WebKit's header-driven HTTP cache survive relaunches. The disk
+/// cache is keyed per data store, so the prewarm and the shows MUST share this instance for
+/// prewarmed entries to be visible to shows.
+///
+/// On iOS 17+ the store is isolated from the host app's `.default()` store so Mindbox web
+/// content never shares cookies/storage with the host's own WebViews. Earlier systems fall
+/// back to `.default()` — a deliberate product decision: some disk cache beats none, and
+/// sharing the host's store is accepted there. The cache kill switch still restores the
+/// pre-feature `.nonPersistent()` isolation on every OS.
+enum InAppWebViewDataStore {
+    // Stable identifier for the isolated store; changing it orphans the previous store.
+    // UUIDv5 (SHA-1, RFC 4122 DNS namespace) of "cloud.Mindbox.InAppWebViewDataStore":
+    // python3 -c 'import uuid; print(uuid.uuid5(uuid.NAMESPACE_DNS, "cloud.Mindbox.InAppWebViewDataStore"))'
+    // swiftlint:disable:next force_unwrapping
+    private static let identifier = UUID(uuidString: "9E350642-BB9F-5D4C-9981-94FFD93C2B57")!
+
+    /// The cache half of the WebView feature toggles. Latched at first WebView creation for
+    /// the rest of the launch: flipping stores mid-session would split the cache between
+    /// partitions. Read from the config cache, which holds the freshest config the SDK has
+    /// seen — a freshly downloaded config is saved there before any show or stage-2 prewarm
+    /// can run.
+    static let isCacheFeatureEnabled: Bool =
+        isCacheEnabled(in: InAppConfigurationRepository().fetchDecodedConfigFromCache())
+
+    /// Absent key, absent section, absent/unreadable config all mean "enabled" — the toggle
+    /// is a kill switch, not an opt-in.
+    static func isCacheEnabled(in config: ConfigResponse?) -> Bool {
+        config?.settings?.featureToggles?.shouldCacheInAppWebView
+            ?? FeatureFlag.shouldCacheInAppWebView.defaultValue
+    }
+
+    // One live store object per process: a single instance also guarantees prewarm and
+    // shows share the same in-memory session (connection pool, memory cache).
+    private static let instance: WKWebsiteDataStore = {
+        if #available(iOS 17.0, *) {
+            return WKWebsiteDataStore(forIdentifier: identifier)
+        } else {
+            // Product decision: no isolated named stores before iOS 17, and some disk
+            // cache beats none — Mindbox web content shares the host app's default store
+            // (cookies/storage included) on old systems. Toggle off → .nonPersistent().
+            return WKWebsiteDataStore.default()
+        }
+    }()
+
+    static func shared() -> WKWebsiteDataStore {
+        // Toggle off restores the pre-feature behavior exactly: every WebView gets its
+        // own fresh in-memory store, nothing is shared and nothing persists.
+        guard isCacheFeatureEnabled else { return WKWebsiteDataStore.nonPersistent() }
+        return instance
+    }
+}

--- a/Mindbox/InAppMessages/Presentation/Views/WebView/InAppWebViewFactory.swift
+++ b/Mindbox/InAppMessages/Presentation/Views/WebView/InAppWebViewFactory.swift
@@ -1,0 +1,30 @@
+//
+//  InAppWebViewFactory.swift
+//  Mindbox
+//
+//  Created by Sergei Semko on 07.07.2026.
+//  Copyright © 2026 Mindbox. All rights reserved.
+//
+
+import WebKit
+
+/// The single place a Mindbox in-app WKWebView is configured. A borrowed prewarmed
+/// instance and a cold-created one must be indistinguishable — a knob added here
+/// reaches both.
+enum InAppWebViewFactory {
+
+    static func make(userAgent: String = SDKUserAgent.build()) -> WKWebView {
+        let config = WKWebViewConfiguration()
+        config.websiteDataStore = InAppWebViewDataStore.shared()
+        config.applicationNameForUserAgent = userAgent
+        config.allowsInlineMediaPlayback = true
+        config.mediaTypesRequiringUserActionForPlayback = []
+        let webView = WKWebView(frame: .zero, configuration: config)
+        #if DEBUG
+        if #available(iOS 16.4, *) {
+            webView.isInspectable = true
+        }
+        #endif
+        return webView
+    }
+}

--- a/Mindbox/InAppMessages/Presentation/Views/WebView/InAppWebViewHTMLFetcher.swift
+++ b/Mindbox/InAppMessages/Presentation/Views/WebView/InAppWebViewHTMLFetcher.swift
@@ -1,0 +1,53 @@
+//
+//  InAppWebViewHTMLFetcher.swift
+//  Mindbox
+//
+//  Created by Sergei Semko on 07.07.2026.
+//  Copyright © 2026 Mindbox. All rights reserved.
+//
+
+import Foundation
+
+/// The single home of the in-app HTML fetch transport: the prewarm and the shows MUST use
+/// identical cache semantics, or the prewarm fills a cache the shows never read.
+enum InAppWebViewHTMLFetcher {
+
+    /// Caching path: revalidates with the server on every fetch (ETag match → a ~0-byte 304
+    /// and the cache supplies the stored body). A dedicated cookie-less session keeps the
+    /// SDK out of the host app's shared cookie jar and URLCache — the pre-feature fetch
+    /// carried no cookies either.
+    private static let cachingSession: URLSession = {
+        let config = URLSessionConfiguration.default
+        config.httpShouldSetCookies = false
+        config.httpCookieAcceptPolicy = .never
+        config.httpCookieStorage = nil
+        if #available(iOS 13.0, *) {
+            // Holds ONLY the in-app index HTML (a few small entries per endpoint) — page
+            // resources live in WebKit's own cache. Sized accordingly.
+            let directory = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first?
+                .appendingPathComponent("cloud.Mindbox.InAppWebViewHTML", isDirectory: true)
+            config.urlCache = URLCache(memoryCapacity: 512 * 1024,
+                                       diskCapacity: 4 * 1024 * 1024,
+                                       directory: directory)
+        }
+        return URLSession(configuration: config)
+    }()
+
+    /// Cache-less path — the exact pre-feature transport.
+    private static let ephemeralSession: URLSession = {
+        let config = URLSessionConfiguration.ephemeral
+        config.requestCachePolicy = .reloadIgnoringLocalAndRemoteCacheData
+        config.urlCache = nil
+        return URLSession(configuration: config)
+    }()
+
+    static func sessionAndRequest(for url: URL) -> (session: URLSession, request: URLRequest) {
+        // Foundation implements .reloadRevalidatingCacheData starting with iOS 13; on
+        // iOS 12 it silently degrades to the protocol policy and could serve a stale
+        // index without a server round-trip — old systems keep the cache-less fetch.
+        guard #available(iOS 13.0, *), InAppWebViewDataStore.isCacheFeatureEnabled else {
+            return (ephemeralSession, URLRequest(url: url))
+        }
+        return (cachingSession, URLRequest(url: url, cachePolicy: .reloadRevalidatingCacheData))
+    }
+}

--- a/Mindbox/InAppMessages/Presentation/Views/WebView/Prewarm/InAppWebViewLearnedHostsStore.swift
+++ b/Mindbox/InAppMessages/Presentation/Views/WebView/Prewarm/InAppWebViewLearnedHostsStore.swift
@@ -11,8 +11,7 @@ import Foundation
 /// Persists resource hosts observed during real shows, per endpoint. These are the hosts
 /// the config cannot know (image CDNs, the web runtime's static hosts, fonts) and they
 /// let the next launch's preconnect cover the heavy part of the page. A stale entry is
-/// harmless — preconnect to an unused host is a no-op. Backed by `PersistenceStorage`
-/// like the rest of the SDK's state.
+/// harmless — preconnect to an unused host is a no-op.
 final class InAppWebViewLearnedHostsStore {
     static let maxHosts = 12
 

--- a/Mindbox/InAppMessages/Presentation/Views/WebView/Prewarm/InAppWebViewLearnedHostsStore.swift
+++ b/Mindbox/InAppMessages/Presentation/Views/WebView/Prewarm/InAppWebViewLearnedHostsStore.swift
@@ -1,0 +1,53 @@
+//
+//  InAppWebViewLearnedHostsStore.swift
+//  Mindbox
+//
+//  Created by Sergei Semko on 06.07.2026.
+//  Copyright © 2026 Mindbox. All rights reserved.
+//
+
+import Foundation
+
+/// Persists resource hosts observed during real shows, per endpoint. These are the hosts
+/// the config cannot know (image CDNs, the web runtime's static hosts, fonts) and they
+/// let the next launch's preconnect cover the heavy part of the page. A stale entry is
+/// harmless — preconnect to an unused host is a no-op. Backed by `PersistenceStorage`
+/// like the rest of the SDK's state.
+final class InAppWebViewLearnedHostsStore {
+    static let maxHosts = 12
+
+    private let persistenceStorage: PersistenceStorage
+
+    init(persistenceStorage: PersistenceStorage) {
+        self.persistenceStorage = persistenceStorage
+    }
+
+    func hosts(endpoint: String) -> [String] {
+        persistenceStorage.webViewLearnedHosts?[endpoint] ?? []
+    }
+
+    /// Appends newly observed hosts, keeping insertion order and dropping the oldest
+    /// beyond the cap. Values come from page JS — only bare https hosts are accepted.
+    ///
+    /// Main-thread only: this is an unsynchronized read-modify-write, safe because the
+    /// single caller (the show's evaluateJavaScript completion) always runs on main.
+    func remember(_ observed: [String], endpoint: String) {
+        guard !observed.isEmpty else { return }
+        var all = persistenceStorage.webViewLearnedHosts ?? [:]
+        var merged = all[endpoint] ?? []
+        var didAppend = false
+        for host in observed where InAppWebViewPrewarmPlanner.isValidHost(host) && !merged.contains(host) {
+            merged.append(host)
+            didAppend = true
+        }
+        // Steady state after the first shows: every observed host is already known. Skip
+        // the app-group UserDefaults rewrite (a synchronous cfprefsd round-trip on the
+        // main thread) when nothing was added.
+        guard didAppend else { return }
+        if merged.count > Self.maxHosts {
+            merged.removeFirst(merged.count - Self.maxHosts)
+        }
+        all[endpoint] = merged
+        persistenceStorage.webViewLearnedHosts = all
+    }
+}

--- a/Mindbox/InAppMessages/Presentation/Views/WebView/Prewarm/InAppWebViewPrewarmNavigationPolicy.swift
+++ b/Mindbox/InAppMessages/Presentation/Views/WebView/Prewarm/InAppWebViewPrewarmNavigationPolicy.swift
@@ -1,0 +1,44 @@
+//
+//  InAppWebViewPrewarmNavigationPolicy.swift
+//  Mindbox
+//
+//  Created by Sergei Semko on 06.07.2026.
+//  Copyright © 2026 Mindbox. All rights reserved.
+//
+
+import WebKit
+import MindboxLogger
+
+/// Pins the hidden prewarm instance to the documents the SDK itself loads: any
+/// page-initiated main-frame navigation (JS redirect, meta refresh) is cancelled — a
+/// hidden WebView must never wander off and keep fetching arbitrary URLs. Active only
+/// until the first borrow; the show's bridge installs its own delegate then.
+final class InAppWebViewPrewarmNavigationPolicy: NSObject, WKNavigationDelegate {
+
+    // Main-thread confined, like every WKWebView interaction around it.
+    private var allowedURLs: Set<String> = ["about:blank"]
+
+    /// Registers a document URL the service is about to load itself.
+    func allow(_ url: URL) {
+        allowedURLs.insert(url.absoluteString)
+    }
+
+    /// Pure decision core (WKNavigationAction cannot be faked in tests). Subframes are
+    /// the page's own business; a nil target frame (window.open) is pinned like the top frame.
+    func decision(for url: URL?, targetIsMainFrame: Bool?) -> WKNavigationActionPolicy {
+        if targetIsMainFrame == false { return .allow }
+        return allowedURLs.contains(url?.absoluteString ?? "about:blank") ? .allow : .cancel
+    }
+
+    func webView(_ webView: WKWebView,
+                 decidePolicyFor navigationAction: WKNavigationAction,
+                 decisionHandler: @escaping (WKNavigationActionPolicy) -> Void) {
+        let verdict = decision(for: navigationAction.request.url,
+                               targetIsMainFrame: navigationAction.targetFrame?.isMainFrame)
+        if verdict == .cancel {
+            Logger.common(message: "[WebView] Prewarm: blocked page-initiated navigation to \(navigationAction.request.url?.absoluteString ?? "nil")",
+                          level: .info, category: .webViewInAppMessages)
+        }
+        decisionHandler(verdict)
+    }
+}

--- a/Mindbox/InAppMessages/Presentation/Views/WebView/Prewarm/InAppWebViewPrewarmPlanner.swift
+++ b/Mindbox/InAppMessages/Presentation/Views/WebView/Prewarm/InAppWebViewPrewarmPlanner.swift
@@ -1,0 +1,106 @@
+//
+//  InAppWebViewPrewarmPlanner.swift
+//  Mindbox
+//
+//  Created by Sergei Semko on 06.07.2026.
+//  Copyright © 2026 Mindbox. All rights reserved.
+//
+
+import Foundation
+
+/// Derives everything the webview prewarm needs from the in-app config. Pure functions.
+enum InAppWebViewPrewarmPlanner {
+
+    /// WebKit partitions its HTTP cache by the top-level document's host, which for
+    /// `loadHTMLString` is the `baseURL` host — so the prewarm MUST use the same baseUrl
+    /// the shows use, and both URLs MUST come from the same layer (mixing layers would
+    /// warm one layer's content under another layer's partition, invisible to its show).
+    static func prewarmSource(for layers: [WebviewContentBackgroundLayerDTO]) -> (baseURL: URL, contentURL: URL)? {
+        for layer in layers {
+            guard let baseURL = layer.baseUrl.flatMap(URL.init(string:)),
+                  baseURL.scheme?.lowercased() == "https", baseURL.host != nil,
+                  let contentURL = layer.contentUrl.flatMap(URL.init(string:)),
+                  contentURL.scheme?.lowercased() == "https" else { continue }
+            return (baseURL, contentURL)
+        }
+        return nil
+    }
+
+    /// Hosts worth opening DNS+TCP+TLS to before the first show: every webview layer's
+    /// `contentUrl` host, the configured API domain, plus hosts learned from previous shows.
+    static func preconnectHosts(layers: [WebviewContentBackgroundLayerDTO],
+                                apiDomain: String?,
+                                learnedHosts: [String]) -> [String] {
+        var hosts = Set(layers.compactMap { layer -> String? in
+            guard let contentUrl = layer.contentUrl, let host = URL(string: contentUrl)?.host else { return nil }
+            return host
+        })
+        if let apiDomain, !apiDomain.isEmpty {
+            hosts.insert(apiDomain)
+        }
+        hosts.formUnion(learnedHosts)
+        return hosts.sorted()
+    }
+
+    /// A page of `<link rel="preconnect">` hints: WebKit opens pooled connections to each
+    /// host without downloading anything; the show reuses the pool. Every host is
+    /// re-validated at this single choke point — hosts get interpolated into markup.
+    static func preconnectHTML(hosts: [String]) -> String {
+        let links = hosts
+            .filter(isValidHost)
+            .map { "<link rel=\"preconnect\" href=\"https://\($0)\" crossorigin><link rel=\"dns-prefetch\" href=\"https://\($0)\">" }
+            .joined()
+        return "<html><head><meta charset=\"utf-8\">\(links)</head><body></body></html>"
+    }
+
+    /// Accepts only strings that pass the SDK-wide RFC 1123 host validation, so no source
+    /// (page JS, config, API domain) can ever turn a host slot into markup. An explicit
+    /// charset, unlike a `URL(string:)` round-trip, doesn't ride on Foundation's parser
+    /// semantics and rejects sub-delims (`&`, `'`, `;`, …) that survive a URL host slot.
+    static func isValidHost(_ host: String) -> Bool {
+        URLValidator.isValidHost(host)
+    }
+
+    /// The official prewarm contract with the web runtime: the prewarm content page is
+    /// loaded with these parameters on its document URL (`loadHTMLString` baseURL →
+    /// `location.search`), and a runtime that knows the contract boots tracker-only —
+    /// no `ready` handshake, no form, byendpoint straight into the HTTP cache. Older
+    /// runtimes ignore the parameters (plain page warm). Shows never get these parameters.
+    static func prewarmContentBaseURL(from baseURL: URL, endpoint: String, deviceUUID: String) -> URL {
+        guard var components = URLComponents(url: baseURL, resolvingAgainstBaseURL: false) else { return baseURL }
+        var queryItems = components.queryItems ?? []
+        queryItems.append(URLQueryItem(name: "prewarm", value: "1"))
+        queryItems.append(URLQueryItem(name: "endpointId", value: endpoint))
+        queryItems.append(URLQueryItem(name: "deviceUuid", value: deviceUUID))
+        components.queryItems = queryItems
+        return components.url ?? baseURL
+    }
+
+    static func webviewLayers(in config: ConfigResponse) -> [WebviewContentBackgroundLayerDTO] {
+        var result: [WebviewContentBackgroundLayerDTO] = []
+        for inapp in config.inapps?.elements ?? [] {
+            for variant in inapp.form.variants ?? [] {
+                let layers: [ContentBackgroundLayerDTO]?
+                switch variant {
+                case .modal(let modal): layers = modal.content?.background?.layers
+                case .snackbar(let snackbar): layers = snackbar.content?.background?.layers
+                case .unknown: layers = nil
+                }
+                for layer in layers ?? [] {
+                    if case .webview(let webview) = layer {
+                        result.append(webview)
+                    }
+                }
+            }
+        }
+        return result
+    }
+
+    /// JS evaluated in a shown WebView to collect the distinct https hosts its resources
+    /// actually came from. Host names only — no URLs, no payloads.
+    static let observedHostsScript = """
+    Array.from(new Set(performance.getEntriesByType('resource').map(function (r) {
+      try { var u = new URL(r.name); return u.protocol === 'https:' ? u.host : null } catch (e) { return null }
+    }).filter(Boolean)))
+    """
+}

--- a/Mindbox/InAppMessages/Presentation/Views/WebView/Prewarm/InAppWebViewPrewarmService.swift
+++ b/Mindbox/InAppMessages/Presentation/Views/WebView/Prewarm/InAppWebViewPrewarmService.swift
@@ -1,0 +1,307 @@
+//
+//  InAppWebViewPrewarmService.swift
+//  Mindbox
+//
+//  Created by Sergei Semko on 06.07.2026.
+//  Copyright © 2026 Mindbox. All rights reserved.
+//
+
+import Foundation
+import UIKit
+import WebKit
+import MindboxLogger
+
+protocol InAppWebViewPrewarmServiceProtocol: AnyObject {
+    /// Stage 1, at SDK initialization: when the previous launch left a cached config with
+    /// webview in-apps, creates the warm instance and starts the resource prewarm ahead of
+    /// the fresh config download. Hosts without webview in-apps never pay for a
+    /// web-content process — nothing is created until a config proves it's needed.
+    func prewarmProcess()
+
+    /// Stage 2, when a freshly downloaded config has been parsed: starts the resource
+    /// prewarm if it hasn't run from the cached config yet, or releases the stage-1
+    /// instance when the config has no webview in-apps.
+    func prewarmResources(for config: ConfigResponse)
+
+    /// Hands the warm instance to a show (borrow, not consume — the same live instance
+    /// serves subsequent shows). Any prewarm page is torn down first.
+    func borrowWarmWebView() -> WKWebView?
+
+    /// Called when a show is torn down: navigates the parked instance to a blank page so
+    /// the closed in-app's JS stops running hidden, keeping the process warm for the next show.
+    func parkWarmWebView()
+
+    /// Called by a show when its page is done: persists the observed resource hosts for
+    /// the next launch's preconnect.
+    func rememberObservedHosts(_ hosts: [String])
+}
+
+final class InAppWebViewPrewarmService: InAppWebViewPrewarmServiceProtocol {
+
+    private let persistenceStorage: PersistenceStorage
+    private let learnedHostsStore: InAppWebViewLearnedHostsStore
+    private let makeWebView: () -> WKWebView
+    private let fetchHTML: (URL, @escaping (String?) -> Void) -> Void
+    private let loadCachedConfig: () -> ConfigResponse?
+
+    // Main-thread confined (WKWebView requirement); all mutations hop to main. The flags
+    // latch for the rest of the launch by design: after the first borrow the cache is
+    // warmer than any prewarm could make it, and re-running the prewarm would navigate a
+    // live show's webview.
+    private var warmWebView: WKWebView?
+    private var hasBeenBorrowed = false
+    // Write-once, decided on the main hop: set when the resource prewarm starts OR when a
+    // config-driven release fires. The release must latch too — one that lands on main
+    // before the slow stage-1 hop has nothing to drop yet, and without the latch the stale
+    // stage-1 block would then create the instance a fresh config already said to kill.
+    private var resourcePrewarmLatched = false
+    // True between borrow and park: `superview` alone can't tell (there is a window
+    // between borrow and addSubview).
+    private var isLentToShow = false
+    private var memoryWarningObserver: NSObjectProtocol?
+    // Retained here because navigationDelegate is weak; armed until the first borrow.
+    private let prewarmNavigationPolicy = InAppWebViewPrewarmNavigationPolicy()
+
+    init(persistenceStorage: PersistenceStorage,
+         makeWebView: @escaping () -> WKWebView = { InAppWebViewFactory.make() },
+         fetchHTML: @escaping (URL, @escaping (String?) -> Void) -> Void = InAppWebViewPrewarmService.defaultFetchHTML,
+         loadCachedConfig: @escaping () -> ConfigResponse? = InAppWebViewPrewarmService.defaultLoadCachedConfig) {
+        self.persistenceStorage = persistenceStorage
+        self.learnedHostsStore = InAppWebViewLearnedHostsStore(persistenceStorage: persistenceStorage)
+        self.makeWebView = makeWebView
+        self.fetchHTML = fetchHTML
+        self.loadCachedConfig = loadCachedConfig
+        startMemoryWarningObserver()
+    }
+
+    deinit {
+        // Block-based observers are not auto-removed. The token is optional solely
+        // because its block captures self and can't be created during two-phase init.
+        if let memoryWarningObserver {
+            NotificationCenter.default.removeObserver(memoryWarningObserver)
+        }
+    }
+
+    /// Frees the parked warm instance under memory pressure: the HTTP cache is disk-level
+    /// and survives, so the next show only re-pays the web-content process spin-up. An
+    /// instance lent to a live show is left alone — the show owns it.
+    private func startMemoryWarningObserver() {
+        memoryWarningObserver = NotificationCenter.default.addObserver(
+            forName: UIApplication.didReceiveMemoryWarningNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            guard let self, let webView = self.warmWebView, !self.isLentToShow else { return }
+            webView.stopLoading()
+            self.warmWebView = nil
+            Logger.common(message: "[WebView] Prewarm: memory warning — releasing the parked warm instance",
+                          level: .info, category: .webViewInAppMessages)
+        }
+    }
+
+    func prewarmProcess() {
+        // Boots from the PREVIOUS launch's cached config: waiting for the fresh one would
+        // lose the race to a launch-triggered show. A stale URL is harmless — the next
+        // launch picks up the fresh config.
+        DispatchQueue.global(qos: .utility).async { [weak self] in
+            // Warm the cache-toggle latch here: its initializer reads and decodes the
+            // cached config, and every other first-access path runs on the main thread.
+            _ = InAppWebViewDataStore.isCacheFeatureEnabled
+            guard let self, let config = self.loadCachedConfig() else { return }
+            guard Self.isPrewarmEnabled(in: config) else { return }
+            let layers = InAppWebViewPrewarmPlanner.webviewLayers(in: config)
+            guard !layers.isEmpty else { return }
+            self.startResourcePrewarm(layers: layers)
+        }
+    }
+
+    func prewarmResources(for config: ConfigResponse) {
+        // A fresh config that turns the toggle off also kills a stage-1 instance started
+        // under the previous launch's config.
+        guard Self.isPrewarmEnabled(in: config) else {
+            releaseUnusedWarmWebView(reason: .featureToggleOff)
+            return
+        }
+        let layers = InAppWebViewPrewarmPlanner.webviewLayers(in: config)
+        guard !layers.isEmpty else {
+            releaseUnusedWarmWebView(reason: .noWebviewInApps)
+            return
+        }
+        startResourcePrewarm(layers: layers)
+    }
+
+    /// The prewarm half of the WebView feature toggles, read from the config each stage
+    /// works with: stage 1 sees the previous launch's cached toggles, stage 2 the fresh
+    /// ones. An absent key or section means "enabled" — a kill switch, not an opt-in.
+    private static func isPrewarmEnabled(in config: ConfigResponse) -> Bool {
+        config.settings?.featureToggles?.shouldPrewarmInAppWebView
+            ?? FeatureFlag.shouldPrewarmInAppWebView.defaultValue
+    }
+
+    func borrowWarmWebView() -> WKWebView? {
+        // Never trap in a host app: an off-main caller just doesn't get the warm
+        // instance — returning nil is always correct (the show creates its own WebView
+        // on the shared store) and touches none of the main-confined state.
+        guard Thread.isMainThread else {
+            Logger.common(message: "[WebView] Prewarm: borrowWarmWebView() called off the main thread — ignoring",
+                          level: .error, category: .webViewInAppMessages)
+            return nil
+        }
+        // Latch even when there is nothing to hand out: a show is starting, and a
+        // resource prewarm kicked off after this point would compete with it.
+        hasBeenBorrowed = true
+        guard let webView = warmWebView else { return nil }
+        // Presentation is serialized upstream, but that flag has known races — never let
+        // a second show steal the instance out of an on-screen in-app.
+        guard !isLentToShow else { return nil }
+        // Never hand out an instance mid-navigation: the show's load would land on a
+        // half-committed document and its didFinish can fire before the page's module
+        // scripts evaluate. Park it instead; the show creates a fresh WKWebView on the
+        // same shared store (pays process spin-up, keeps the HTTP cache).
+        guard !webView.isLoading else {
+            webView.stopLoading()
+            webView.loadHTMLString(Self.blankPage, baseURL: nil)
+            Logger.common(message: "[WebView] Prewarm: instance is mid-navigation at borrow — parking it, the show gets a fresh WebView",
+                          level: .info, category: .webViewInAppMessages)
+            return nil
+        }
+        // The instance belongs to the show from here; the blank load tears down the
+        // prewarm page so its JS can't compete with the show for bandwidth. The bridge's
+        // staleness filter ignores both leftovers' callbacks.
+        webView.stopLoading()
+        webView.loadHTMLString(Self.blankPage, baseURL: nil)
+        webView.removeFromSuperview()
+        isLentToShow = true
+        return webView
+    }
+
+    func parkWarmWebView() {
+        DispatchQueue.main.async {
+            guard let webView = self.warmWebView else {
+                self.isLentToShow = false
+                return
+            }
+            // Only park an instance no live show is presenting (a newer show may have
+            // borrowed it before this teardown arrived).
+            guard webView.superview == nil else { return }
+            self.isLentToShow = false
+            // Fully detach the finished show: WKUserContentController retains its script
+            // handlers, so the previous show's bridge would otherwise stay on the
+            // parked instance until the next show replaces it.
+            if #available(iOS 14.0, *) {
+                webView.configuration.userContentController.removeAllScriptMessageHandlers()
+            } else {
+                webView.configuration.userContentController.removeScriptMessageHandler(forName: Constants.WebViewBridgeJS.handlerName)
+            }
+            webView.loadHTMLString(Self.blankPage, baseURL: nil)
+        }
+    }
+
+    func rememberObservedHosts(_ hosts: [String]) {
+        guard let configuration = persistenceStorage.configuration else { return }
+        learnedHostsStore.remember(hosts, endpoint: configuration.endpoint)
+    }
+
+    // MARK: Resource prewarm
+
+    /// Two loads on the warm instance, both under the shows' cache partition (`baseUrl`
+    /// from the config's webview layer): a preconnect page (DNS+TCP+TLS to every known
+    /// host), then the real content page with the official prewarm parameters on its
+    /// baseURL — a runtime that knows the contract downloads its bundles straight into
+    /// the HTTP cache; an older runtime degrades to a plain page warm.
+    private func startResourcePrewarm(layers: [WebviewContentBackgroundLayerDTO]) {
+        guard let configuration = persistenceStorage.configuration,
+              let (baseURL, contentURL) = InAppWebViewPrewarmPlanner.prewarmSource(for: layers) else { return }
+
+        let hosts = InAppWebViewPrewarmPlanner.preconnectHosts(
+            layers: layers,
+            apiDomain: configuration.domain,
+            learnedHosts: learnedHostsStore.hosts(endpoint: configuration.endpoint)
+        )
+        let endpoint = configuration.endpoint
+        let deviceUUID = persistenceStorage.deviceUUID ?? ""
+
+        DispatchQueue.main.async {
+            guard !self.hasBeenBorrowed, !self.resourcePrewarmLatched else { return }
+            self.resourcePrewarmLatched = true
+            if self.warmWebView == nil {
+                self.warmWebView = self.makeWebView()
+                self.warmWebView?.navigationDelegate = self.prewarmNavigationPolicy
+            }
+            if !hosts.isEmpty {
+                self.prewarmNavigationPolicy.allow(baseURL)
+                self.warmWebView?.loadHTMLString(InAppWebViewPrewarmPlanner.preconnectHTML(hosts: hosts), baseURL: baseURL)
+                Logger.common(message: "[WebView] Prewarm: preconnect to \(hosts.joined(separator: ",")) under \(baseURL.absoluteString)",
+                              level: .info, category: .webViewInAppMessages)
+            }
+            self.fetchHTML(contentURL) { html in
+                DispatchQueue.main.async { [weak self] in
+                    self?.loadPrewarmContentPage(html: html, baseURL: baseURL, endpoint: endpoint, deviceUUID: deviceUUID)
+                }
+            }
+        }
+    }
+
+    private func loadPrewarmContentPage(html: String?, baseURL: URL, endpoint: String, deviceUUID: String) {
+        guard let html else {
+            // No retry by design (the latch stands): this launch degrades to preconnect-only.
+            Logger.common(message: "[WebView] Prewarm: content page fetch failed, launch degrades to preconnect-only",
+                          level: .info, category: .webViewInAppMessages)
+            return
+        }
+        // The instance can be gone by now — borrowed by a show, or dropped by a
+        // config-driven release that landed while the fetch was in flight. Either way there
+        // is nothing to warm, and logging success would misreport it.
+        guard !hasBeenBorrowed, let warmWebView else { return }
+        let prewarmBaseURL = InAppWebViewPrewarmPlanner.prewarmContentBaseURL(
+            from: baseURL, endpoint: endpoint, deviceUUID: deviceUUID
+        )
+        prewarmNavigationPolicy.allow(prewarmBaseURL)
+        warmWebView.loadHTMLString(html, baseURL: prewarmBaseURL)
+        Logger.common(message: "[WebView] Prewarm: content page under \(prewarmBaseURL.absoluteString), endpoint \(endpoint)",
+                      level: .info, category: .webViewInAppMessages)
+    }
+
+    private enum ReleaseReason: String {
+        case featureToggleOff = "the prewarm feature toggle is off"
+        case noWebviewInApps = "no webview in-apps in config"
+    }
+
+    /// Most host apps have no webview in-apps: once the config proves that, drop the
+    /// stage-1 instance so they don't keep an idle web-content process. The prewarm does
+    /// not restart within this launch — a show then simply creates its own WebView.
+    private func releaseUnusedWarmWebView(reason: ReleaseReason) {
+        DispatchQueue.main.async {
+            // Latch before the guard: even with nothing to drop yet, a stage-1 hop that
+            // lands after this release must not start a prewarm the config just killed.
+            self.resourcePrewarmLatched = true
+            guard !self.hasBeenBorrowed, let webView = self.warmWebView else { return }
+            webView.stopLoading()
+            self.warmWebView = nil
+            Logger.common(message: "[WebView] Prewarm: \(reason.rawValue) — releasing the warm instance",
+                          level: .info, category: .webViewInAppMessages)
+        }
+    }
+
+    // The empty-page skeleton is exactly a preconnect page with no hosts — reuse the
+    // planner so the parked/teardown markup can never drift from the preconnect markup.
+    private static let blankPage = InAppWebViewPrewarmPlanner.preconnectHTML(hosts: [])
+
+    /// One transport with the shows' fetch (`InAppWebViewHTMLFetcher`): the prewarm must
+    /// fill exactly the cache the shows read.
+    private static func defaultFetchHTML(url: URL, completion: @escaping (String?) -> Void) {
+        let (session, request) = InAppWebViewHTMLFetcher.sessionAndRequest(for: url)
+        session.dataTask(with: request) { data, response, _ in
+            guard let httpResponse = response as? HTTPURLResponse, (200...299).contains(httpResponse.statusCode),
+                  let data, let html = String(data: data, encoding: .utf8) else {
+                completion(nil)
+                return
+            }
+            completion(html)
+        }.resume()
+    }
+
+    private static func defaultLoadCachedConfig() -> ConfigResponse? {
+        InAppConfigurationRepository().fetchDecodedConfigFromCache()
+    }
+}

--- a/Mindbox/InAppMessages/Presentation/Views/WebView/TransparentView.swift
+++ b/Mindbox/InAppMessages/Presentation/Views/WebView/TransparentView.swift
@@ -32,6 +32,7 @@ final class TransparentView: UIView {
     /// later ready-check give-up (a post-load navigation dropped the bridge) has no other
     /// closing authority — it must close the show itself.
     private var hasReceivedInit = false
+    private var hasCapturedObservedHosts = false
     private lazy var localStateStorage: WebViewLocalStateStorageProtocol = DI.injectOrFail(WebViewLocalStateStorageProtocol.self)
     private lazy var permissionHandlerRegistry = DI.injectOrFail(PermissionHandlerRegistryProtocol.self)
     private lazy var hapticService: HapticServiceProtocol = DI.injectOrFail(HapticServiceProtocol.self)
@@ -115,6 +116,19 @@ final class TransparentView: UIView {
 
     func cleanUp() {
         facade?.cleanWebView()
+    }
+
+    /// Persists the hosts this show's resources actually came from so the next launch's
+    /// prewarm can preconnect to them. Called from `viewWillDisappear`, which every
+    /// dismissal path (close action, dim-tap, timeout) goes through while the page is still
+    /// alive; the once-flag is a cheap guard against a repeated disappear.
+    func captureObservedResourceHosts() {
+        guard !hasCapturedObservedHosts else { return }
+        hasCapturedObservedHosts = true
+        facade?.evaluateJavaScript(InAppWebViewPrewarmPlanner.observedHostsScript) { result in
+            guard case .success(let value) = result, let hosts = value as? [String] else { return }
+            DI.injectOrFail(InAppWebViewPrewarmServiceProtocol.self).rememberObservedHosts(hosts)
+        }
     }
 
     func cancelTimeoutTimer() {

--- a/Mindbox/InAppMessages/Presentation/Views/WebView/TransparentView.swift
+++ b/Mindbox/InAppMessages/Presentation/Views/WebView/TransparentView.swift
@@ -24,7 +24,14 @@ final class TransparentView: UIView {
     private let inAppId: String
     private let tags: [String: String]?
     private var lastReadyCheckedUrl: String?
-    private var isReadyCheckInFlight = false
+    private var readyChecker: WebViewReadyChecker?
+    /// True when the page finished loading but the JS bridge never appeared within the
+    /// ready-check budget — lets the init timeout report the accurate failure category.
+    private(set) var readyCheckDidGiveUp = false
+    /// True once the page has sent `init`. After that the init timeout is cancelled, so a
+    /// later ready-check give-up (a post-load navigation dropped the bridge) has no other
+    /// closing authority — it must close the show itself.
+    private var hasReceivedInit = false
     private lazy var localStateStorage: WebViewLocalStateStorageProtocol = DI.injectOrFail(WebViewLocalStateStorageProtocol.self)
     private lazy var permissionHandlerRegistry = DI.injectOrFail(PermissionHandlerRegistryProtocol.self)
     private lazy var hapticService: HapticServiceProtocol = DI.injectOrFail(HapticServiceProtocol.self)
@@ -72,6 +79,7 @@ final class TransparentView: UIView {
     }
 
     deinit {
+        readyChecker?.cancel()
         if isMotionServiceInitialized { motionService.stopMonitoring() }
         Logger.common(message: "[WebView] Deinit TransparentView", category: .webViewInAppMessages)
     }
@@ -181,6 +189,7 @@ extension TransparentView: WebBridgeMessageDelegate {
             if isMotionServiceInitialized { motionService.stopMonitoring() }
             webViewAction?.onClose()
         case .`init`:
+            hasReceivedInit = true
             quizInitTimeoutWorkItem?.cancel()
             hapticService.prepare()
             webViewAction?.onInit()
@@ -241,43 +250,49 @@ extension TransparentView: WebBridgeNavigationDelegate {
         Logger.common(message: "[WebView] WKNavigationDelegate: start loading URL \(url?.absoluteString ?? "unknown")", category: .webViewInAppMessages)
         // Reset per-navigation checks (e.g. redirects / re-loads).
         lastReadyCheckedUrl = nil
-        isReadyCheckInFlight = false
+        readyCheckDidGiveUp = false
+        readyChecker?.cancel()
+        readyChecker = nil
     }
-    
+
     func webBridge(_ bridge: MindboxWebBridge, didFinishNavigation url: URL?) {
         let urlString = url?.absoluteString ?? "unknown"
         Logger.common(message: "[WebView] WKNavigationDelegate: Upload completed \(urlString)", category: .webViewInAppMessages)
 
         // Avoid duplicate checks on multiple didFinish calls for the same URL.
-        guard !isReadyCheckInFlight else { return }
         guard lastReadyCheckedUrl != urlString else { return }
         lastReadyCheckedUrl = urlString
-        isReadyCheckInFlight = true
 
-        let script = Constants.WebViewBridgeJS.bridgeFunctionReadyCheck
-        facade?.evaluateJavaScript(script) { [weak self] result in
+        readyChecker?.cancel()
+        let checker = WebViewReadyChecker(evaluate: { [weak self] script, completion in
+            // Teardown: abandon the poll silently, exactly like cancel().
+            guard let facade = self?.facade else { return }
+            facade.evaluateJavaScript(script, completion: completion)
+        })
+        readyChecker = checker
+        checker.run(onReady: {
+            Logger.common(
+                message: "[WebView] JS ready check for URL \(urlString): true",
+                category: .webViewInAppMessages
+            )
+        }, onGiveUp: { [weak self] lastFailure in
             guard let self else { return }
-            self.isReadyCheckInFlight = false
-
-            switch result {
-            case .success(let anyValue):
-                let hasReady = (anyValue as? Bool) ?? false
-                Logger.common(
-                    message: "[WebView] JS ready check for URL \(urlString): \(hasReady)",
-                    category: .webViewInAppMessages
-                )
-                if !hasReady {
-                    self.delegate?.closeJSReadyMissingWebViewVC(reason: "window.bridgeMessagesHandlers.emit is missing for URL \(urlString)")
-                }
-
-            case .failure(let error):
-                Logger.common(
-                    message: "[WebView] JS ready check failed for URL \(urlString). Error: \(error.localizedDescription)",
-                    category: .webViewInAppMessages
-                )
-                self.delegate?.closeJSReadyMissingWebViewVC(reason: "evaluateJavaScript error for URL \(urlString): \(error.localizedDescription)")
+            self.readyCheckDidGiveUp = true
+            Logger.common(
+                message: "[WebView] JS ready check gave up for URL \(urlString): \(lastFailure)",
+                category: .webViewInAppMessages
+            )
+            // Before `init` the 7s timeout owns closing: its budget can expire while a slow
+            // page is still booting the bridge, and the window is invisible until `init`
+            // anyway; the flag above lets that timeout report the real category. After
+            // `init` the timeout is already cancelled, so a give-up here (a post-load
+            // navigation dropped the bridge) is the only signal left — close now, else the
+            // in-app stays up with a dead bridge. The give-up flag makes this report
+            // webview_presentation_failed, matching the pre-refactor behavior.
+            if self.hasReceivedInit {
+                self.delegate?.closeTimeoutWebViewVC()
             }
-        }
+        })
     }
     
     func webBridge(_ bridge: MindboxWebBridge, didFailProvisionalNavigation url: URL?, error: any Error) {

--- a/Mindbox/InAppMessages/Presentation/Views/WebView/WebViewController.swift
+++ b/Mindbox/InAppMessages/Presentation/Views/WebView/WebViewController.swift
@@ -12,7 +12,6 @@ protocol WebVCDelegate: AnyObject {
     func closeTapWebViewVC()
     func closeTimeoutWebViewVC()
     func closeLoadFailedWebViewVC(reason: String)
-    func closeJSReadyMissingWebViewVC(reason: String)
 }
 
 final class WebViewController: UIViewController, InappViewControllerProtocol {
@@ -201,13 +200,7 @@ final class WebViewController: UIViewController, InappViewControllerProtocol {
     }
 
     private func createUserAgent() -> String {
-        let utilitiesFetcher = DI.injectOrFail(UtilitiesFetcher.self)
-
-        let sdkVersion = utilitiesFetcher.sdkVersion ?? "unknown"
-        let appVersion = utilitiesFetcher.appVerson ?? "unknown"
-        let appName = utilitiesFetcher.hostApplicationName ?? "unknown"
-
-        return "mindbox.sdk/\(sdkVersion) (\(DeviceModelHelper.os) \(DeviceModelHelper.iOSVersion); \(DeviceModelHelper.model)) \(appName)/\(appVersion)"
+        SDKUserAgent.build()
     }
 }
 
@@ -220,24 +213,23 @@ extension WebViewController: WebVCDelegate {
     func closeTimeoutWebViewVC() {
         Logger.common(message: "[WebView] WebViewVC closeTimeoutOrErrorWebViewVC", category: .webViewInAppMessages)
         reportErrorAndClose(
-            .webviewLoadFailed("[WebView] WebView initialization timeout for in-app id \(id).")
+            Self.timeoutError(readyCheckGaveUp: transparentWebView?.readyCheckDidGiveUp == true, inAppId: id)
         )
+    }
+
+    /// The init timeout is the single closing authority, but monitoring must still tell
+    /// "the page loaded and its JS bridge never appeared" (a content defect) apart from
+    /// "the page never finished loading" (a load defect).
+    static func timeoutError(readyCheckGaveUp: Bool, inAppId: String) -> InAppPresentationError {
+        readyCheckGaveUp
+            ? .webviewPresentationFailed("[WebView] JS bridge missing after page load (init timeout) for in-app id \(inAppId).")
+            : .webviewLoadFailed("[WebView] WebView initialization timeout for in-app id \(inAppId).")
     }
 
     func closeLoadFailedWebViewVC(reason: String) {
         Logger.common(message: "[WebView] WebViewVC closeLoadFailedWebViewVC. Reason: \(reason)", category: .webViewInAppMessages)
         reportErrorAndClose(
             .webviewLoadFailed(reason)
-        )
-    }
-
-    func closeJSReadyMissingWebViewVC(reason: String) {
-        Logger.common(
-            message: "[WebView] WebViewVC closeJSReadyMissingWebViewVC. Reason: \(reason)",
-            category: .webViewInAppMessages
-        )
-        reportErrorAndClose(
-            .webviewPresentationFailed(reason)
         )
     }
 }

--- a/Mindbox/InAppMessages/Presentation/Views/WebView/WebViewController.swift
+++ b/Mindbox/InAppMessages/Presentation/Views/WebView/WebViewController.swift
@@ -86,6 +86,8 @@ final class WebViewController: UIViewController, InappViewControllerProtocol {
         NotificationCenter.default.removeObserver(self)
         Logger.common(message: "[WebView] Deinit WebViewVC", category: .webViewInAppMessages)
         transparentWebView?.cleanUp()
+        // Stop the closed in-app's JS from running hidden on the parked warm instance.
+        DI.injectOrFail(InAppWebViewPrewarmServiceProtocol.self).parkWarmWebView()
     }
 
     private func setupWebView() {
@@ -149,6 +151,13 @@ final class WebViewController: UIViewController, InappViewControllerProtocol {
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         becomeFirstResponder()
+    }
+
+    override func viewWillDisappear(_ animated: Bool) {
+        // Every dismissal path (close action, dim-tap, timeout) goes through here while
+        // the page is still alive — the last moment the learned-hosts capture can run.
+        transparentWebView?.captureObservedResourceHosts()
+        super.viewWillDisappear(animated)
     }
 
     override func motionEnded(_ motion: UIEvent.EventSubtype, with event: UIEvent?) {

--- a/Mindbox/InAppMessages/Presentation/Views/WebView/WebViewReadyChecker.swift
+++ b/Mindbox/InAppMessages/Presentation/Views/WebView/WebViewReadyChecker.swift
@@ -1,0 +1,70 @@
+//
+//  WebViewReadyChecker.swift
+//  Mindbox
+//
+//  Created by Sergei Semko on 06.07.2026.
+//  Copyright © 2026 Mindbox. All rights reserved.
+//
+
+import Foundation
+
+/// Polls the page for the JS bridge instead of deciding on a single didFinish-time probe:
+/// module scripts can finish evaluating a beat after the navigation's load event (reused
+/// prewarmed WebView, slow devices), so one early `false` must not fail a healthy in-app.
+final class WebViewReadyChecker {
+    typealias Evaluate = (_ script: String, _ completion: @escaping (Result<Any?, Error>) -> Void) -> Void
+    typealias Schedule = (_ delay: TimeInterval, _ work: @escaping () -> Void) -> Void
+
+    static let maxAttempts = 8
+    static let retryDelay: TimeInterval = 0.15
+
+    private let evaluate: Evaluate
+    private let schedule: Schedule
+    private var isCancelled = false
+
+    init(evaluate: @escaping Evaluate,
+         schedule: @escaping Schedule = { delay, work in
+             DispatchQueue.main.asyncAfter(deadline: .now() + delay, execute: work)
+         }) {
+        self.evaluate = evaluate
+        self.schedule = schedule
+    }
+
+    func run(onReady: @escaping () -> Void, onGiveUp: @escaping (_ lastFailure: String) -> Void) {
+        attempt(1, onReady: onReady, onGiveUp: onGiveUp)
+    }
+
+    /// Abandons the poll without calling either completion — the caller's new navigation
+    /// (or teardown) owns readiness from here.
+    func cancel() {
+        isCancelled = true
+    }
+
+    private func attempt(_ number: Int, onReady: @escaping () -> Void, onGiveUp: @escaping (String) -> Void) {
+        guard !isCancelled else { return }
+        evaluate(Constants.WebViewBridgeJS.bridgeFunctionReadyCheck) { [weak self] result in
+            guard let self, !self.isCancelled else { return }
+
+            let failure: String
+            switch result {
+            case .success(let anyValue) where (anyValue as? Bool) == true:
+                onReady()
+                return
+            case .success:
+                failure = "window.bridgeMessagesHandlers.emit is missing"
+            case .failure(let error):
+                // Transient during navigation churn (a page mid-teardown rejects
+                // evaluation) — retried on the same budget as a plain `false`.
+                failure = "evaluateJavaScript error: \(error.localizedDescription)"
+            }
+
+            guard number < Self.maxAttempts else {
+                onGiveUp(failure)
+                return
+            }
+            self.schedule(Self.retryDelay) { [weak self] in
+                self?.attempt(number + 1, onReady: onReady, onGiveUp: onGiveUp)
+            }
+        }
+    }
+}

--- a/Mindbox/Mindbox.swift
+++ b/Mindbox/Mindbox.swift
@@ -83,6 +83,9 @@ public class Mindbox: NSObject {
      */
     public func initialization(configuration: MBConfiguration) {
         coreController?.initialization(configuration: configuration)
+        // Prewarm stage 1: warm the web-content process as early as possible so the first
+        // webview show doesn't pay process startup. Safe here — assembly() has built DI.
+        DI.injectOrFail(InAppWebViewPrewarmServiceProtocol.self).prewarmProcess()
     }
 
     private var observeTokens: [UUID] = []

--- a/Mindbox/Network/MBNetworkFetcher.swift
+++ b/Mindbox/Network/MBNetworkFetcher.swift
@@ -27,10 +27,8 @@ class MBNetworkFetcher: NetworkFetcher {
 
     private static func makeSession(utilitiesFetcher: UtilitiesFetcher) -> URLSession {
         let sessionConfiguration: URLSessionConfiguration = .default
-        let sdkVersion = utilitiesFetcher.sdkVersion ?? "unknow"
-        let appVersion = utilitiesFetcher.appVerson ?? "unknow"
-        let appName = utilitiesFetcher.hostApplicationName ?? "unknow"
-        let userAgent: String = "mindbox.sdk/\(sdkVersion) (\(DeviceModelHelper.os) \(DeviceModelHelper.iOSVersion); \(DeviceModelHelper.model)) \(appName)/\(appVersion)"
+        let sdkVersion = utilitiesFetcher.sdkVersion ?? "unknown"
+        let userAgent = SDKUserAgent.build(utilitiesFetcher: utilitiesFetcher)
         sessionConfiguration.httpAdditionalHeaders = [
             "Mindbox-Integration": "iOS-SDK",
             "Mindbox-Integration-Version": sdkVersion,

--- a/Mindbox/PersistenceStorage/MBPersistenceStorage.swift
+++ b/Mindbox/PersistenceStorage/MBPersistenceStorage.swift
@@ -266,6 +266,9 @@ class MBPersistenceStorage: PersistenceStorage {
     @UserDefaultsWrapper(key: .webViewLocalStateVersion, defaultValue: nil)
     var webViewLocalStateVersion: Int?
 
+    @UserDefaultsWrapper(key: .webViewLearnedHosts, defaultValue: nil)
+    var webViewLearnedHosts: [String: [String]]?
+
     @UserDefaultsWrapper(key: .operationsDomainFromConfig, defaultValue: nil)
     var operationsDomainFromConfig: String? {
         didSet {
@@ -311,6 +314,7 @@ extension MBPersistenceStorage {
             case applicationInfoUpdateVersion = "MBPersistenceStorage-applicationInfoUpdatedVersion"
             case applicationInstanceId = "MBPersistenceStorage-applicationInstanceId"
             case webViewLocalStateVersion = "MBPersistenceStorage-webViewLocalStateVersion"
+            case webViewLearnedHosts = "MBPersistenceStorage-webViewLearnedHosts"
             case operationsDomainFromConfig = "MBPersistenceStorage-operationsDomainFromConfig"
 
             // MARK: - Deprecated Keys

--- a/Mindbox/PersistenceStorage/PersistenceStorage.swift
+++ b/Mindbox/PersistenceStorage/PersistenceStorage.swift
@@ -75,6 +75,10 @@ protocol PersistenceStorage: AnyObject {
     /// Version of the WebView localState, managed by JS via localState.init
     var webViewLocalStateVersion: Int? { get set }
 
+    /// Resource hosts observed by webview in-app shows, keyed by endpoint — feeds the next
+    /// launch's preconnect. See `InAppWebViewLearnedHostsStore`.
+    var webViewLearnedHosts: [String: [String]]? { get set }
+
     // Reset functions
 
     func softReset()
@@ -130,5 +134,6 @@ extension PersistenceStorage {
         operationsDomainFromConfig = nil
         applicationInstanceId = nil
         applicationInfoUpdateVersion = nil
+        webViewLearnedHosts = nil
     }
 }

--- a/Mindbox/Utilities/SDKUserAgent.swift
+++ b/Mindbox/Utilities/SDKUserAgent.swift
@@ -1,0 +1,23 @@
+//
+//  SDKUserAgent.swift
+//  Mindbox
+//
+//  Created by Sergei Semko on 06.07.2026.
+//  Copyright © 2026 Mindbox. All rights reserved.
+//
+
+import Foundation
+
+/// One User-Agent for every SDK surface — API requests and WebView `applicationName` alike.
+/// The backend slices traffic by this string, so transports must not drift apart. All
+/// inputs are static per app run, which also keeps a prewarmed WebView indistinguishable
+/// from a per-show one.
+enum SDKUserAgent {
+    static func build(utilitiesFetcher: UtilitiesFetcher = DI.injectOrFail(UtilitiesFetcher.self)) -> String {
+        let sdkVersion = utilitiesFetcher.sdkVersion ?? "unknown"
+        let appVersion = utilitiesFetcher.appVerson ?? "unknown"
+        let appName = utilitiesFetcher.hostApplicationName ?? "unknown"
+
+        return "mindbox.sdk/\(sdkVersion) (\(DeviceModelHelper.os) \(DeviceModelHelper.iOSVersion); \(DeviceModelHelper.model)) \(appName)/\(appVersion)"
+    }
+}

--- a/MindboxTests/DI/MBContainerConcurrencyTests.swift
+++ b/MindboxTests/DI/MBContainerConcurrencyTests.swift
@@ -1,0 +1,49 @@
+//
+//  MBContainerConcurrencyTests.swift
+//  MindboxTests
+//
+//  Created by Sergei Semko on 08.07.2026.
+//  Copyright © 2026 Mindbox. All rights reserved.
+//
+
+import Testing
+import Foundation
+@testable import Mindbox
+
+@Suite("MBContainer thread safety", .tags(.dependencyInjection))
+struct MBContainerConcurrencyTests {
+
+    private final class Service {}
+
+    /// A `.container`-scoped singleton must be minted exactly once even under concurrent
+    /// resolves — the recursive lock serializes the check-create-store. Without the lock,
+    /// racing resolves each see an empty cache and run the factory more than once.
+    @Test
+    func concurrentResolveMintsOneInstance() {
+        let container = MBContainer()
+        let counterLock = NSLock()
+        var factoryCalls = 0
+
+        container.register(Service.self, scope: .container) {
+            // Widen the check-create-store window so a missing lock reliably races.
+            Thread.sleep(forTimeInterval: 0.02)
+            counterLock.lock()
+            factoryCalls += 1
+            counterLock.unlock()
+            return Service()
+        }
+
+        let resultsLock = NSLock()
+        var identifiers = Set<ObjectIdentifier>()
+        DispatchQueue.concurrentPerform(iterations: 32) { _ in
+            if let service = container.resolve(Service.self) {
+                resultsLock.lock()
+                identifiers.insert(ObjectIdentifier(service))
+                resultsLock.unlock()
+            }
+        }
+
+        #expect(factoryCalls == 1)
+        #expect(identifiers.count == 1)
+    }
+}

--- a/MindboxTests/Extensions/Tag+Extensions.swift
+++ b/MindboxTests/Extensions/Tag+Extensions.swift
@@ -28,4 +28,6 @@ extension Tag {
     @Tag static var operationsRouting: Self
     @Tag static var mbConfiguration: Self
     @Tag static var inAppTags: Self
+    @Tag static var userAgent: Self
+    @Tag static var dependencyInjection: Self
 }

--- a/MindboxTests/InApp/Tests/InAppMessagesTrackerTests.swift
+++ b/MindboxTests/InApp/Tests/InAppMessagesTrackerTests.swift
@@ -84,7 +84,7 @@ final class InAppMessagesTrackerTests {
 
     private func applyTagsToggle(enabled: Bool) {
         featureToggleManager.applyFeatureToggles(
-            Settings.FeatureToggles(shouldSendInAppShowError: nil, shouldSendInAppTags: enabled)
+            Settings.FeatureToggles(shouldSendInAppShowError: nil, shouldSendInAppTags: enabled, shouldPrewarmInAppWebView: nil, shouldCacheInAppWebView: nil)
         )
     }
 }

--- a/MindboxTests/InApp/Tests/InappShowFailureManagerTests.swift
+++ b/MindboxTests/InApp/Tests/InappShowFailureManagerTests.swift
@@ -453,7 +453,7 @@ private extension InappShowFailureManagerTests {
 
     func applyTagsFeatureToggle(shouldSendInAppTags: Bool) {
         featureToggleManager.applyFeatureToggles(
-            Settings.FeatureToggles(shouldSendInAppShowError: nil, shouldSendInAppTags: shouldSendInAppTags)
+            Settings.FeatureToggles(shouldSendInAppShowError: nil, shouldSendInAppTags: shouldSendInAppTags, shouldPrewarmInAppWebView: nil, shouldCacheInAppWebView: nil)
         )
     }
 

--- a/MindboxTests/InApp/Tests/WebView/InAppWebViewCacheTests.swift
+++ b/MindboxTests/InApp/Tests/WebView/InAppWebViewCacheTests.swift
@@ -1,0 +1,99 @@
+//
+//  InAppWebViewCacheTests.swift
+//  MindboxTests
+//
+//  Created by Sergei Semko on 06.07.2026.
+//  Copyright © 2026 Mindbox. All rights reserved.
+//
+
+import Foundation
+import Testing
+import WebKit
+@testable import Mindbox
+
+@Suite("InApp WebView data store", .tags(.webView))
+@MainActor
+struct InAppWebViewDataStoreTests {
+
+    /// Evaluates the lazily-initialized store here rather than first in a host app: a mangled
+    /// identifier literal traps in CI. The properties are the ones the cache design rests on —
+    /// one live instance (shared in-memory session), persistence (cache survives relaunch),
+    /// isolation from the host app's default store, and the exact identifier value: changing
+    /// it orphans every install's cached store, so it must never change unnoticed.
+    @Test
+    func sharedIsOneIsolatedPersistentStore() {
+        let store = InAppWebViewDataStore.shared()
+        #expect(store === InAppWebViewDataStore.shared())
+        // iOS 17+: isolated persistent store. Below 17 the store IS .default() by product
+        // decision (some disk cache beats none), so isolation is only asserted here.
+        if #available(iOS 17.0, *) {
+            #expect(store !== WKWebsiteDataStore.default())
+            #expect(store.isPersistent)
+            // UUIDv5 of "cloud.Mindbox.InAppWebViewDataStore" — see InAppWebViewDataStore.
+            #expect(store.identifier == UUID(uuidString: "9E350642-BB9F-5D4C-9981-94FFD93C2B57"))
+        }
+    }
+
+    /// Kill-switch semantics: only an explicit `false` disables; an absent key, absent
+    /// section, or missing/unreadable config (nil from the repository) means enabled.
+    @Test
+    func cacheToggleResolvesFromCachedConfig() throws {
+        func config(_ json: String) throws -> ConfigResponse {
+            try JSONDecoder().decode(ConfigResponse.self, from: Data(json.utf8))
+        }
+
+        #expect(InAppWebViewDataStore.isCacheEnabled(in: nil))
+        #expect(InAppWebViewDataStore.isCacheEnabled(in: try config(#"{"settings":{}}"#)))
+        #expect(InAppWebViewDataStore.isCacheEnabled(in: try config(#"{"settings":{"featureToggles":{}}}"#)))
+        #expect(InAppWebViewDataStore.isCacheEnabled(
+            in: try config(#"{"settings":{"featureToggles":{"MobileSdkShouldCacheInAppWebView":true}}}"#)
+        ))
+        #expect(!InAppWebViewDataStore.isCacheEnabled(
+            in: try config(#"{"settings":{"featureToggles":{"MobileSdkShouldCacheInAppWebView":false}}}"#)
+        ))
+    }
+
+    @Test
+    func webViewTogglesDecodeFromFeatureTogglesSection() throws {
+        let json = #"{"settings":{"featureToggles":{"MobileSdkShouldPrewarmInAppWebView":false,"MobileSdkShouldCacheInAppWebView":true}}}"#
+        let config = try JSONDecoder().decode(ConfigResponse.self, from: Data(json.utf8))
+
+        let toggles = try #require(config.settings?.featureToggles)
+        #expect(toggles.shouldPrewarmInAppWebView == false)
+        #expect(toggles.shouldCacheInAppWebView == true)
+    }
+}
+
+@Suite("InApp WebView HTML fetcher", .tags(.webView))
+struct InAppWebViewHTMLFetcherTests {
+
+    /// In the test process the cache toggle latches enabled (no cached config on disk),
+    /// so this pins the caching path: revalidation, no host cookie jar, one stable session.
+    @Test
+    func cachingPathIsCookieLessRevalidatingAndStable() throws {
+        let url = try #require(URL(string: "https://inapp.local/popup"))
+        let (session, request) = InAppWebViewHTMLFetcher.sessionAndRequest(for: url)
+
+        #expect(request.cachePolicy == .reloadRevalidatingCacheData)
+        #expect(session !== URLSession.shared)
+        #expect(session.configuration.httpShouldSetCookies == false)
+        #expect(session.configuration.httpCookieStorage == nil)
+        #expect(session.configuration.urlCache != nil)
+        #expect(session.configuration.urlCache !== URLCache.shared)
+        #expect(InAppWebViewHTMLFetcher.sessionAndRequest(for: url).session === session)
+    }
+}
+
+@Suite("InApp WebView factory", .tags(.webView))
+@MainActor
+struct InAppWebViewFactoryTests {
+
+    @Test
+    func factoryConfiguresTheSharedStoreAndUserAgent() {
+        let webView = InAppWebViewFactory.make(userAgent: "test-ua")
+        #expect(webView.configuration.websiteDataStore === InAppWebViewDataStore.shared())
+        #expect(webView.configuration.applicationNameForUserAgent == "test-ua")
+        #expect(webView.configuration.allowsInlineMediaPlayback)
+        #expect(InAppWebViewFactory.make().configuration.applicationNameForUserAgent == SDKUserAgent.build())
+    }
+}

--- a/MindboxTests/InApp/Tests/WebView/MindboxWebBridgeTests.swift
+++ b/MindboxTests/InApp/Tests/WebView/MindboxWebBridgeTests.swift
@@ -1,0 +1,247 @@
+//
+//  MindboxWebBridgeTests.swift
+//  MindboxTests
+//
+//  Created by Sergei Semko on 06.07.2026.
+//  Copyright © 2026 Mindbox. All rights reserved.
+//
+
+import Testing
+import WebKit
+@_spi(Internal) @testable import Mindbox
+
+/// A reused (pre-warmed) WebView delivers navigation callbacks from previous owners'
+/// loads; leftovers must never reach the show's delegate.
+@Suite("MindboxWebBridge navigation staleness", .tags(.webView))
+@MainActor
+struct MindboxWebBridgeStalenessTests {
+
+    private final class DelegateSpy: WebBridgeNavigationDelegate {
+        private(set) var startCount = 0
+        private(set) var finishCount = 0
+        private(set) var failCount = 0
+        private(set) var finishURLs: [URL?] = []
+
+        func webBridge(_ bridge: MindboxWebBridge, didStartProvisionalNavigation url: URL?) { startCount += 1 }
+        func webBridge(_ bridge: MindboxWebBridge, didFinishNavigation url: URL?) {
+            finishCount += 1
+            finishURLs.append(url)
+        }
+        func webBridge(_ bridge: MindboxWebBridge, didFailProvisionalNavigation url: URL?, error: Error) { failCount += 1 }
+        func webBridge(_ bridge: MindboxWebBridge, decidePolicyFor url: URL?, navigationType: WKNavigationType,
+                       decisionHandler: @escaping (WKNavigationActionPolicy) -> Void) {
+            decisionHandler(.allow)
+        }
+    }
+
+    private let webView: WKWebView
+    private let bridge: MindboxWebBridge
+    private let spy: DelegateSpy
+    // Source of real, distinct WKNavigation objects; separate from `webView` so its async
+    // delegate callbacks can never reach the bridge under test.
+    private let navigationFactory = WKWebView(frame: .zero, configuration: WKWebViewConfiguration())
+
+    init() {
+        webView = WKWebView(frame: .zero, configuration: WKWebViewConfiguration())
+        bridge = MindboxWebBridge(webView: webView)
+        spy = DelegateSpy()
+        bridge.navigationDelegate = spy
+    }
+
+    private func makeNavigation() -> WKNavigation {
+        // swiftlint:disable:next force_unwrapping
+        navigationFactory.loadHTMLString("<html></html>", baseURL: nil)!
+    }
+
+    @Test("Before the show's own load every navigation callback is stale")
+    func everythingIsStaleBeforeContentLoad() {
+        bridge.webView(webView, didStartProvisionalNavigation: makeNavigation())
+        bridge.webView(webView, didFinish: makeNavigation())
+
+        #expect(spy.startCount == 0)
+        #expect(spy.finishCount == 0)
+    }
+
+    @Test("Only the expected navigation's callbacks reach the delegate")
+    func strangerNavigationsAreFiltered() {
+        let expected = makeNavigation()
+        bridge.expectContentNavigation(expected)
+
+        let stranger = makeNavigation()
+        bridge.webView(webView, didStartProvisionalNavigation: stranger)
+        bridge.webView(webView, didFinish: stranger)
+        #expect(spy.startCount == 0)
+        #expect(spy.finishCount == 0)
+
+        bridge.webView(webView, didStartProvisionalNavigation: expected)
+        bridge.webView(webView, didFinish: expected)
+        #expect(spy.startCount == 1)
+        #expect(spy.finishCount == 1)
+    }
+
+    @Test("After the expected navigation finished the filter opens for page-initiated navigations")
+    func filterOpensAfterExpectedFinish() {
+        let expected = makeNavigation()
+        bridge.expectContentNavigation(expected)
+        bridge.webView(webView, didFinish: expected)
+        #expect(spy.finishCount == 1)
+
+        bridge.webView(webView, didFinish: makeNavigation())
+        #expect(spy.finishCount == 2)
+    }
+
+    @Test("A nil expected navigation (loadHTMLString returned nil) fails open, not closed")
+    func nilExpectedNavigationFailsOpen() {
+        bridge.expectContentNavigation(nil)
+
+        bridge.webView(webView, didFinish: makeNavigation())
+
+        #expect(spy.finishCount == 1)
+    }
+
+    @Test("A nil callback navigation fails open, mirroring the nil-expected case")
+    func nilCallbackNavigationFailsOpen() {
+        bridge.expectContentNavigation(makeNavigation())
+
+        bridge.webView(webView, didFailProvisionalNavigation: nil, withError: NSError(domain: "test", code: 2))
+        #expect(spy.failCount == 1)
+
+        bridge.webView(webView, didFinish: nil)
+        #expect(spy.finishCount == 1)
+    }
+
+    @Test("Stale failure callbacks never close the show")
+    func staleFailuresAreFiltered() {
+        bridge.expectContentNavigation(makeNavigation())
+
+        bridge.webView(webView, didFailProvisionalNavigation: makeNavigation(),
+                       withError: NSError(domain: "test", code: 1))
+
+        #expect(spy.failCount == 0)
+    }
+
+    @Test("Only the show's own finish reports the content URL; page navigations report their real URL")
+    func finishReportsPerNavigationURL() {
+        let contentURL = URL(string: "https://content.mindbox.ru/index.html")
+        bridge.updateContentURL(contentURL)
+        let expected = makeNavigation()
+        bridge.expectContentNavigation(expected)
+
+        bridge.webView(webView, didFinish: expected)
+        // The unloaded test instance's real URL is nil — distinct from contentURL.
+        bridge.webView(webView, didFinish: makeNavigation())
+
+        #expect(spy.finishURLs.count == 2)
+        #expect(spy.finishURLs.first == contentURL)
+        #expect(spy.finishURLs.last == URL?.none)
+    }
+}
+
+/// Script messages have their own gate: until the show's own document commits, a reused
+/// WebView's previous document (e.g. a dying prewarm page) can still post to the freshly
+/// attached handler — answering it could present a page that must never be shown.
+@Suite("MindboxWebBridge message gate", .tags(.webView))
+@MainActor
+struct MindboxWebBridgeMessageGateTests {
+
+    private final class MessageSpy: WebBridgeMessageDelegate {
+        private(set) var received: [BridgeMessage] = []
+        func webBridge(_ bridge: MindboxWebBridge, didReceiveBridgeMessage message: BridgeMessage) {
+            received.append(message)
+        }
+    }
+
+    /// WKScriptMessage's real initializer is WebKit-internal; the bridge only reads
+    /// `name` and `body`.
+    private final class FakeScriptMessage: WKScriptMessage {
+        private let fakeName: String
+        private let fakeBody: Any
+
+        init(name: String, body: Any) {
+            self.fakeName = name
+            self.fakeBody = body
+            super.init()
+        }
+
+        override var name: String { fakeName }
+        override var body: Any { fakeBody }
+    }
+
+    private let webView: WKWebView
+    private let bridge: MindboxWebBridge
+    private let spy: MessageSpy
+    private let navigationFactory = WKWebView(frame: .zero, configuration: WKWebViewConfiguration())
+
+    init() {
+        webView = WKWebView(frame: .zero, configuration: WKWebViewConfiguration())
+        bridge = MindboxWebBridge(webView: webView)
+        spy = MessageSpy()
+        bridge.messageDelegate = spy
+    }
+
+    private func makeNavigation() -> WKNavigation {
+        // swiftlint:disable:next force_unwrapping
+        navigationFactory.loadHTMLString("<html></html>", baseURL: nil)!
+    }
+
+    private func postValidMessage() throws {
+        let message = try #require(BridgeMessage(type: .request, action: "log", payload: "hi"))
+        let body = try #require(message.jsonString())
+        bridge.userContentController(
+            webView.configuration.userContentController,
+            didReceive: FakeScriptMessage(name: Constants.WebViewBridgeJS.handlerName, body: body)
+        )
+    }
+
+    @Test("Messages are dropped until the show's own navigation commits")
+    func messagesGatedUntilExpectedCommit() throws {
+        try postValidMessage()
+        #expect(spy.received.isEmpty)
+
+        let expected = makeNavigation()
+        bridge.expectContentNavigation(expected)
+
+        try postValidMessage()
+        #expect(spy.received.isEmpty)
+
+        // A stale (stranger) commit must not open the gate.
+        bridge.webView(webView, didCommit: makeNavigation())
+        try postValidMessage()
+        #expect(spy.received.isEmpty)
+
+        bridge.webView(webView, didCommit: expected)
+        try postValidMessage()
+        #expect(spy.received.count == 1)
+    }
+
+    @Test("A nil expected navigation opens the gate at the first commit (fail-open)")
+    func nilExpectedNavigationGateOpensOnCommit() throws {
+        bridge.expectContentNavigation(nil)
+
+        try postValidMessage()
+        #expect(spy.received.isEmpty)
+
+        bridge.webView(webView, didCommit: makeNavigation())
+        try postValidMessage()
+        #expect(spy.received.count == 1)
+    }
+
+    @Test("A reload re-arms the gate until the new document commits")
+    func reloadRearmsGate() throws {
+        let first = makeNavigation()
+        bridge.expectContentNavigation(first)
+        bridge.webView(webView, didCommit: first)
+        bridge.webView(webView, didFinish: first)
+        try postValidMessage()
+        #expect(spy.received.count == 1)
+
+        let reload = makeNavigation()
+        bridge.expectContentNavigation(reload)
+        try postValidMessage()
+        #expect(spy.received.count == 1)
+
+        bridge.webView(webView, didCommit: reload)
+        try postValidMessage()
+        #expect(spy.received.count == 2)
+    }
+}

--- a/MindboxTests/InApp/Tests/WebView/MindboxWebBridgeTests.swift
+++ b/MindboxTests/InApp/Tests/WebView/MindboxWebBridgeTests.swift
@@ -120,6 +120,25 @@ struct MindboxWebBridgeStalenessTests {
         #expect(spy.failCount == 0)
     }
 
+    @Test("Stale non-provisional failures are filtered too")
+    func staleDidFailIsFiltered() {
+        bridge.expectContentNavigation(makeNavigation())
+
+        bridge.webView(webView, didFail: makeNavigation(), withError: NSError(domain: "test", code: 3))
+
+        #expect(spy.failCount == 0)
+    }
+
+    @Test("The expected navigation's non-provisional failure reaches the delegate")
+    func expectedDidFailReachesDelegate() {
+        let expected = makeNavigation()
+        bridge.expectContentNavigation(expected)
+
+        bridge.webView(webView, didFail: expected, withError: NSError(domain: "test", code: 4))
+
+        #expect(spy.failCount == 1)
+    }
+
     @Test("Only the show's own finish reports the content URL; page navigations report their real URL")
     func finishReportsPerNavigationURL() {
         let contentURL = URL(string: "https://content.mindbox.ru/index.html")

--- a/MindboxTests/InApp/Tests/WebView/TransparentViewJSBridgeTests.swift
+++ b/MindboxTests/InApp/Tests/WebView/TransparentViewJSBridgeTests.swift
@@ -147,7 +147,7 @@ final class TransparentViewJSBridgeTests {
 
     private func applyTagsToggle(enabled: Bool) {
         featureToggleManager.applyFeatureToggles(
-            Settings.FeatureToggles(shouldSendInAppShowError: nil, shouldSendInAppTags: enabled)
+            Settings.FeatureToggles(shouldSendInAppShowError: nil, shouldSendInAppTags: enabled, shouldPrewarmInAppWebView: nil, shouldCacheInAppWebView: nil)
         )
     }
 }

--- a/MindboxTests/InApp/Tests/WebView/WebViewReadyCheckerTests.swift
+++ b/MindboxTests/InApp/Tests/WebView/WebViewReadyCheckerTests.swift
@@ -1,0 +1,111 @@
+//
+//  WebViewReadyCheckerTests.swift
+//  MindboxTests
+//
+//  Created by Sergei Semko on 06.07.2026.
+//  Copyright © 2026 Mindbox. All rights reserved.
+//
+
+import Testing
+import Foundation
+@testable import Mindbox
+
+@Suite("WebView ready check retry", .tags(.webView))
+struct WebViewReadyCheckerTests {
+
+    /// Scripted evaluate answers + manual control over the retry schedule.
+    private final class Harness {
+        var answers: [Result<Any?, Error>]
+        private(set) var evaluateCount = 0
+        private(set) var pendingWork: [() -> Void] = []
+
+        init(answers: [Result<Any?, Error>]) {
+            self.answers = answers
+        }
+
+        func makeChecker() -> WebViewReadyChecker {
+            WebViewReadyChecker(
+                evaluate: { [self] _, completion in
+                    evaluateCount += 1
+                    completion(answers.removeFirst())
+                },
+                schedule: { [self] _, work in pendingWork.append(work) }
+            )
+        }
+
+        func runPending() {
+            let work = pendingWork
+            pendingWork = []
+            work.forEach { $0() }
+        }
+    }
+
+    @Test("An immediately ready page passes on the first attempt")
+    func readyFirstAttempt() {
+        let harness = Harness(answers: [.success(true)])
+        var readyCount = 0
+
+        harness.makeChecker().run(onReady: { readyCount += 1 }, onGiveUp: { _ in Issue.record("unexpected give-up") })
+
+        #expect(readyCount == 1)
+        #expect(harness.evaluateCount == 1)
+        #expect(harness.pendingWork.isEmpty)
+    }
+
+    @Test("A module evaluating after didFinish passes on a retry instead of failing the show")
+    func readyAfterRetries() {
+        let harness = Harness(answers: [.success(false), .success(false), .success(true)])
+        var readyCount = 0
+
+        let checker = harness.makeChecker()
+        checker.run(onReady: { readyCount += 1 }, onGiveUp: { _ in Issue.record("unexpected give-up") })
+        harness.runPending()
+        harness.runPending()
+
+        withExtendedLifetime(checker) {}
+        #expect(readyCount == 1)
+        #expect(harness.evaluateCount == 3)
+    }
+
+    @Test("Evaluation errors are retried like a plain false")
+    func evaluationErrorRetries() {
+        let error = NSError(domain: "test", code: 1)
+        let harness = Harness(answers: [.failure(error), .success(true)])
+        var readyCount = 0
+
+        let checker = harness.makeChecker()
+        checker.run(onReady: { readyCount += 1 }, onGiveUp: { _ in Issue.record("unexpected give-up") })
+        harness.runPending()
+
+        withExtendedLifetime(checker) {}
+        #expect(readyCount == 1)
+    }
+
+    @Test("A page that never boots gives up only after the full retry budget")
+    func givesUpAfterBudget() {
+        let harness = Harness(answers: Array(repeating: .success(false), count: WebViewReadyChecker.maxAttempts))
+        var giveUpFailure: String?
+
+        let checker = harness.makeChecker()
+        checker.run(onReady: { Issue.record("unexpected ready") }, onGiveUp: { giveUpFailure = $0 })
+        while !harness.pendingWork.isEmpty {
+            harness.runPending()
+        }
+
+        withExtendedLifetime(checker) {}
+        #expect(harness.evaluateCount == WebViewReadyChecker.maxAttempts)
+        #expect(giveUpFailure == "window.bridgeMessagesHandlers.emit is missing")
+    }
+
+    @Test("Cancel abandons the poll without ever resolving")
+    func cancelAbandonsSilently() {
+        let harness = Harness(answers: [.success(false), .success(true)])
+        let checker = harness.makeChecker()
+
+        checker.run(onReady: { Issue.record("resolved after cancel") }, onGiveUp: { _ in Issue.record("resolved after cancel") })
+        checker.cancel()
+        harness.runPending()
+
+        #expect(harness.evaluateCount == 1)
+    }
+}

--- a/MindboxTests/InApp/Tests/WebView/WebViewTimeoutErrorTests.swift
+++ b/MindboxTests/InApp/Tests/WebView/WebViewTimeoutErrorTests.swift
@@ -1,0 +1,28 @@
+//
+//  WebViewTimeoutErrorTests.swift
+//  MindboxTests
+//
+//  Created by Sergei Semko on 06.07.2026.
+//  Copyright © 2026 Mindbox. All rights reserved.
+//
+
+import Testing
+@testable import Mindbox
+
+@Suite("WebView timeout error category", .tags(.webView))
+struct WebViewTimeoutErrorTests {
+
+    /// The 7s init timeout stays the single closing authority, but monitoring must tell
+    /// "page loaded, JS bridge never appeared" apart from "page never finished loading".
+    @Test
+    func timeoutDistinguishesBridgeMissingFromLoadFailure() {
+        guard case .webviewPresentationFailed = WebViewController.timeoutError(readyCheckGaveUp: true, inAppId: "x") else {
+            Issue.record("expected webviewPresentationFailed when the ready check gave up")
+            return
+        }
+        guard case .webviewLoadFailed = WebViewController.timeoutError(readyCheckGaveUp: false, inAppId: "x") else {
+            Issue.record("expected webviewLoadFailed when the page never loaded")
+            return
+        }
+    }
+}

--- a/MindboxTests/InApp/Tests/WebViewPrewarmTests/InAppWebViewLearnedHostsStoreTests.swift
+++ b/MindboxTests/InApp/Tests/WebViewPrewarmTests/InAppWebViewLearnedHostsStoreTests.swift
@@ -1,0 +1,97 @@
+//
+//  InAppWebViewLearnedHostsStoreTests.swift
+//  MindboxTests
+//
+//  Created by Sergei Semko on 06.07.2026.
+//  Copyright © 2026 Mindbox. All rights reserved.
+//
+
+import Foundation
+import Testing
+@testable import Mindbox
+
+@Suite("InApp WebView learned hosts store", .tags(.webView))
+struct InAppWebViewLearnedHostsStoreTests {
+
+    private let storage = MockPersistenceStorage()
+    private var store: InAppWebViewLearnedHostsStore {
+        InAppWebViewLearnedHostsStore(persistenceStorage: storage)
+    }
+
+    @Test("Observed hosts merge in order without duplicates")
+    func mergesWithoutDuplicates() {
+        store.remember(["a.example", "b.example"], endpoint: "Endpoint")
+        store.remember(["b.example", "c.example", ""], endpoint: "Endpoint")
+
+        #expect(store.hosts(endpoint: "Endpoint") == ["a.example", "b.example", "c.example"])
+    }
+
+    @Test("The oldest hosts are dropped beyond the cap")
+    func capsAtMaximumDroppingOldest() {
+        let cap = InAppWebViewLearnedHostsStore.maxHosts
+
+        store.remember((0..<cap).map { "host\($0).example" }, endpoint: "Endpoint")
+        store.remember(["overflow.example"], endpoint: "Endpoint")
+
+        let hosts = store.hosts(endpoint: "Endpoint")
+        #expect(hosts.count == cap)
+        #expect(hosts.first == "host1.example")
+        #expect(hosts.last == "overflow.example")
+    }
+
+    @Test("Remembering nothing changes nothing")
+    func emptyObservationIsNoOp() {
+        store.remember([], endpoint: "Endpoint")
+        store.remember(["not a host!"], endpoint: "Endpoint")
+
+        #expect(store.hosts(endpoint: "Endpoint").isEmpty)
+        #expect(storage.webViewLearnedHosts == nil)
+    }
+
+    @Test("Page-controlled strings that are not bare hosts are rejected on write")
+    func rejectsNonHostStrings() {
+        // The values come from page JS and are later interpolated into preconnect HTML —
+        // anything that is not a bare RFC 1123 host must never be persisted.
+        store.remember(
+            [
+                "cdn.ok.example",
+                "x\"><script>alert(1)</script>",
+                "bad host with spaces",
+                "https://full.url/path",
+                "host/with/path",
+                "evil.example\"><link>",
+                "a&b.example",
+                ""
+            ],
+            endpoint: "Endpoint"
+        )
+
+        #expect(store.hosts(endpoint: "Endpoint") == ["cdn.ok.example"])
+    }
+
+    @Test("Re-remembering only known hosts does not rewrite storage")
+    func noOpWriteWhenNothingNew() {
+        store.remember(["a.example", "b.example"], endpoint: "Endpoint")
+        let writesAfterFirst = storage.webViewLearnedHostsWriteCount
+
+        // Every observed host is already known — the steady state after the first shows.
+        // The persisted value is unchanged either way, so the write count is the only
+        // observable proof the redundant UserDefaults write is skipped.
+        store.remember(["a.example", "b.example"], endpoint: "Endpoint")
+        #expect(storage.webViewLearnedHostsWriteCount == writesAfterFirst)
+
+        // A genuinely new host still writes.
+        store.remember(["c.example"], endpoint: "Endpoint")
+        #expect(storage.webViewLearnedHostsWriteCount == writesAfterFirst + 1)
+        #expect(store.hosts(endpoint: "Endpoint") == ["a.example", "b.example", "c.example"])
+    }
+
+    @Test("Hosts are scoped per endpoint")
+    func endpointsAreIsolated() {
+        store.remember(["a.example"], endpoint: "First")
+        store.remember(["b.example"], endpoint: "Second")
+
+        #expect(store.hosts(endpoint: "First") == ["a.example"])
+        #expect(store.hosts(endpoint: "Second") == ["b.example"])
+    }
+}

--- a/MindboxTests/InApp/Tests/WebViewPrewarmTests/InAppWebViewPrewarmPlannerTests.swift
+++ b/MindboxTests/InApp/Tests/WebViewPrewarmTests/InAppWebViewPrewarmPlannerTests.swift
@@ -1,0 +1,218 @@
+//
+//  InAppWebViewPrewarmPlannerTests.swift
+//  MindboxTests
+//
+//  Created by Sergei Semko on 06.07.2026.
+//  Copyright © 2026 Mindbox. All rights reserved.
+//
+
+import Foundation
+import Testing
+@testable import Mindbox
+
+@Suite("InApp WebView prewarm planning", .tags(.webView))
+struct InAppWebViewPrewarmPlannerTests {
+
+    private func webviewLayer(
+        baseUrl: String? = "https://inapp.local/popup",
+        contentUrl: String? = "https://mobile-static.mindbox.ru/stable/inapps/webview/content/index.html"
+    ) -> WebviewContentBackgroundLayerDTO {
+        WebviewContentBackgroundLayerDTO(baseUrl: baseUrl, contentUrl: contentUrl, params: nil)
+    }
+
+    // MARK: Prewarm source (partition baseURL + contentURL from one layer)
+
+    @Test("Prewarm source is taken from the first fully showable layer")
+    func prewarmSourcePicksFirstValid() throws {
+        let layers = [
+            webviewLayer(baseUrl: nil),
+            webviewLayer(baseUrl: "https://inapp.local/popup"),
+            webviewLayer(baseUrl: "https://other.example/popup")
+        ]
+        let source = try #require(InAppWebViewPrewarmPlanner.prewarmSource(for: layers))
+        #expect(source.baseURL.absoluteString == "https://inapp.local/popup")
+    }
+
+    @Test("No layer with a usable baseUrl yields no prewarm source", arguments: [
+        [] as [String?],
+        [nil],
+        [""]
+    ])
+    func prewarmSourceMissing(baseUrls: [String?]) {
+        let layers = baseUrls.map { webviewLayer(baseUrl: $0) }
+        #expect(InAppWebViewPrewarmPlanner.prewarmSource(for: layers) == nil)
+    }
+
+    @Test("Host-less baseUrls and layers without contentUrl don't donate a prewarm source")
+    func prewarmSourceRequiresHostAndContent() throws {
+        let hostless = webviewLayer(baseUrl: "popup")
+        let noContent = webviewLayer(contentUrl: nil)
+        let valid = webviewLayer()
+
+        let source = try #require(InAppWebViewPrewarmPlanner.prewarmSource(for: [hostless, noContent, valid]))
+        #expect(source.baseURL.host == "inapp.local")
+        #expect(InAppWebViewPrewarmPlanner.prewarmSource(for: [hostless, noContent]) == nil)
+    }
+
+    @Test("Non-https layers never donate a prewarm source")
+    func prewarmSourceRequiresHttps() throws {
+        let httpBase = webviewLayer(baseUrl: "http://insecure.local/popup")
+        let httpContent = webviewLayer(contentUrl: "http://cdn.example/index.html")
+        let valid = webviewLayer()
+
+        #expect(InAppWebViewPrewarmPlanner.prewarmSource(for: [httpBase, httpContent]) == nil)
+        let source = try #require(InAppWebViewPrewarmPlanner.prewarmSource(for: [httpBase, httpContent, valid]))
+        #expect(source.baseURL.host == "inapp.local")
+    }
+
+    @Test("Base and content URLs always come from the same layer — never mixed across layers")
+    func prewarmSourceNeverMixesLayers() throws {
+        let broken = webviewLayer(baseUrl: "not a url", contentUrl: "https://cdn.a/index.html")
+        let valid = webviewLayer(baseUrl: "https://inapp.local/popup", contentUrl: "https://cdn.b/index.html")
+
+        let source = try #require(InAppWebViewPrewarmPlanner.prewarmSource(for: [broken, valid]))
+        #expect(source.baseURL.host == "inapp.local")
+        #expect(source.contentURL.absoluteString == "https://cdn.b/index.html")
+    }
+
+    // MARK: Preconnect hosts
+
+    @Test("Hosts are deduplicated, merged with API domain and learned hosts, and sorted")
+    func preconnectHostsMergesAllSources() {
+        let layers = [
+            webviewLayer(contentUrl: "https://mobile-static.mindbox.ru/a/index.html"),
+            webviewLayer(contentUrl: "https://mobile-static.mindbox.ru/b/index.html")
+        ]
+        let hosts = InAppWebViewPrewarmPlanner.preconnectHosts(
+            layers: layers,
+            apiDomain: "api.mindbox.ru",
+            learnedHosts: ["web-static.mindbox.ru", "api.mindbox.ru"]
+        )
+        #expect(hosts == ["api.mindbox.ru", "mobile-static.mindbox.ru", "web-static.mindbox.ru"])
+    }
+
+    @Test("Invalid content URLs and an absent API domain contribute nothing")
+    func preconnectHostsSkipsUnusableSources() {
+        let layers = [webviewLayer(contentUrl: nil), webviewLayer(contentUrl: "")]
+        let hosts = InAppWebViewPrewarmPlanner.preconnectHosts(layers: layers, apiDomain: nil, learnedHosts: [])
+        #expect(hosts.isEmpty)
+
+        let emptyDomain = InAppWebViewPrewarmPlanner.preconnectHosts(layers: layers, apiDomain: "", learnedHosts: [])
+        #expect(emptyDomain.isEmpty)
+    }
+
+    // MARK: Preconnect page
+
+    @Test("Preconnect page hints every host and downloads nothing")
+    func preconnectHTMLContainsHints() {
+        let html = InAppWebViewPrewarmPlanner.preconnectHTML(hosts: ["a.example", "b.example"])
+        #expect(html.contains("<link rel=\"preconnect\" href=\"https://a.example\" crossorigin>"))
+        #expect(html.contains("<link rel=\"dns-prefetch\" href=\"https://b.example\">"))
+        #expect(!html.contains("<script"))
+        #expect(!html.contains("<img"))
+    }
+
+    @Test("Every host is re-validated at the markup choke point")
+    func preconnectHTMLRejectsNonHostValues() {
+        let html = InAppWebViewPrewarmPlanner.preconnectHTML(
+            hosts: ["ok.example", "evil\"><script>alert(1)</script>", "spaced host.ru"]
+        )
+        #expect(html.contains("https://ok.example"))
+        #expect(!html.contains("<script"))
+        #expect(!html.contains("spaced host.ru"))
+    }
+
+    @Test("Host validation accepts bare hosts only", arguments: zip(
+        ["cdn.mindbox.ru", "evil.com:443", "user@evil.com", "evil.com?x=1", "host with space", "",
+         "a&b.com", "a'b.com", "a;b.com", "a=b.com", "a_b.com", "(evil).com", "host.ru.",
+         String(repeating: "a", count: 300) + ".com"],
+        [true, false, false, false, false, false,
+         false, false, false, false, false, false, false,
+         false]
+    ))
+    func isValidHost(candidate: String, expected: Bool) {
+        #expect(InAppWebViewPrewarmPlanner.isValidHost(candidate) == expected)
+    }
+
+    // MARK: Prewarm content baseURL (official web prewarm contract)
+
+    @Test("Prewarm content baseURL carries the official prewarm query parameters")
+    func prewarmContentBaseURLAppendsContract() throws {
+        let baseURL = try #require(URL(string: "https://inapp.local/popup"))
+
+        let url = InAppWebViewPrewarmPlanner.prewarmContentBaseURL(
+            from: baseURL, endpoint: "Mpush-test.WebView", deviceUUID: "abc-123"
+        )
+
+        let components = try #require(URLComponents(url: url, resolvingAgainstBaseURL: false))
+        #expect(components.host == "inapp.local")
+        #expect(components.path == "/popup")
+        let query = try #require(components.queryItems)
+        #expect(query.contains(URLQueryItem(name: "prewarm", value: "1")))
+        #expect(query.contains(URLQueryItem(name: "endpointId", value: "Mpush-test.WebView")))
+        #expect(query.contains(URLQueryItem(name: "deviceUuid", value: "abc-123")))
+    }
+
+    @Test("Existing baseURL query survives and unsafe values are percent-encoded")
+    func prewarmContentBaseURLKeepsQueryAndEncodes() throws {
+        let baseURL = try #require(URL(string: "https://inapp.local/popup?keep=me"))
+
+        let url = InAppWebViewPrewarmPlanner.prewarmContentBaseURL(
+            from: baseURL, endpoint: "End point&x", deviceUUID: "uuid"
+        )
+
+        let components = try #require(URLComponents(url: url, resolvingAgainstBaseURL: false))
+        let query = try #require(components.queryItems)
+        #expect(query.contains(URLQueryItem(name: "keep", value: "me")))
+        #expect(query.contains(URLQueryItem(name: "endpointId", value: "End point&x")))
+        #expect(url.absoluteString.contains("endpointId=End%20point%26x"))
+    }
+
+    @Test("Parameters land in the query, not the fragment")
+    func prewarmContentBaseURLKeepsFragmentSeparate() throws {
+        // In the fragment they would be invisible to location.search and the contract
+        // would silently degrade to a plain page warm.
+        let baseURL = try #require(URL(string: "https://inapp.local/popup#main"))
+
+        let url = InAppWebViewPrewarmPlanner.prewarmContentBaseURL(
+            from: baseURL, endpoint: "E", deviceUUID: "d"
+        )
+
+        let components = try #require(URLComponents(url: url, resolvingAgainstBaseURL: false))
+        #expect(components.fragment == "main")
+        let query = try #require(components.queryItems)
+        #expect(query.contains(URLQueryItem(name: "prewarm", value: "1")))
+    }
+
+    // MARK: Layer extraction from a parsed config
+
+    @Test("Webview layers and prewarm inputs are extracted from a parsed config")
+    func extractsLayersFromParsedConfig() throws {
+        let config = try loadPrewarmTestConfig("InAppWebviewValid")
+
+        let layers = InAppWebViewPrewarmPlanner.webviewLayers(in: config)
+
+        let source = try #require(InAppWebViewPrewarmPlanner.prewarmSource(for: layers))
+        #expect(source.baseURL.host == "inapp.local")
+
+        let hosts = InAppWebViewPrewarmPlanner.preconnectHosts(layers: layers, apiDomain: "api.mindbox.ru", learnedHosts: [])
+        let contentUrl = try #require(layers.first?.contentUrl)
+        let contentHost = try #require(URL(string: contentUrl)?.host)
+        #expect(hosts.contains("api.mindbox.ru"))
+        #expect(hosts.contains(contentHost))
+    }
+
+    @Test("Configs without webview layers plan nothing", arguments: [
+        "InAppLayerUnknownType", "InAppFormVariantUnknownType"
+    ])
+    func noWebviewLayersInNonWebviewConfig(fixture: String) throws {
+        let config = try loadPrewarmTestConfig(fixture)
+        #expect(InAppWebViewPrewarmPlanner.webviewLayers(in: config).isEmpty)
+    }
+}
+
+func loadPrewarmTestConfig(_ name: String) throws -> ConfigResponse {
+    let bundle = Bundle(for: MindboxTests.self)
+    let url = try #require(bundle.url(forResource: name, withExtension: "json"))
+    return try JSONDecoder().decode(ConfigResponse.self, from: Data(contentsOf: url))
+}

--- a/MindboxTests/InApp/Tests/WebViewPrewarmTests/InAppWebViewPrewarmServiceTests.swift
+++ b/MindboxTests/InApp/Tests/WebViewPrewarmTests/InAppWebViewPrewarmServiceTests.swift
@@ -264,6 +264,42 @@ struct InAppWebViewPrewarmServiceTests {
         #expect(suite.service.borrowWarmWebView() === suite.spy)
     }
 
+    @Test("Observed hosts are persisted under the configuration endpoint")
+    func rememberObservedHostsPersistsUnderEndpoint() throws {
+        let storage = MockPersistenceStorage()
+        storage.configuration = try MBConfiguration(endpoint: "Test.Endpoint", domain: "api.mindbox.ru")
+        let service = InAppWebViewPrewarmService(
+            persistenceStorage: storage,
+            makeWebView: { SpyWebView(frame: .zero, configuration: WKWebViewConfiguration()) },
+            fetchHTML: { _, completion in completion(nil) },
+            loadCachedConfig: { nil }
+        )
+
+        service.rememberObservedHosts(["a.example", "b.example"])
+
+        #expect(storage.webViewLearnedHosts?["Test.Endpoint"] == ["a.example", "b.example"])
+    }
+
+    @Test("A content-page fetch failure degrades to preconnect-only")
+    func contentFetchFailureLeavesPreconnectOnly() async throws {
+        let storage = MockPersistenceStorage()
+        storage.configuration = try MBConfiguration(endpoint: "Test.Endpoint", domain: "api.mindbox.ru")
+        let spy = SpyWebView(frame: .zero, configuration: WKWebViewConfiguration())
+        let service = InAppWebViewPrewarmService(
+            persistenceStorage: storage,
+            makeWebView: { spy },
+            fetchHTML: { _, completion in completion(nil) },
+            loadCachedConfig: { nil }
+        )
+
+        service.prewarmResources(for: try loadPrewarmTestConfig("InAppWebviewValid"))
+        await drainMainQueue()
+        await drainMainQueue()
+
+        // Preconnect page loaded; the failed content fetch adds nothing.
+        #expect(spy.loadedHTMLCount == 1)
+    }
+
     // MARK: Feature toggle
 
     /// The valid webview config with an explicit `featureToggles` section.

--- a/MindboxTests/InApp/Tests/WebViewPrewarmTests/InAppWebViewPrewarmServiceTests.swift
+++ b/MindboxTests/InApp/Tests/WebViewPrewarmTests/InAppWebViewPrewarmServiceTests.swift
@@ -307,6 +307,7 @@ struct InAppWebViewPrewarmServiceTests {
         let base = try loadPrewarmTestConfig("InAppWebviewValid")
         let toggles = Settings.FeatureToggles(
             shouldSendInAppShowError: nil,
+            shouldSendInAppTags: nil,
             shouldPrewarmInAppWebView: prewarmToggle,
             shouldCacheInAppWebView: nil
         )

--- a/MindboxTests/InApp/Tests/WebViewPrewarmTests/InAppWebViewPrewarmServiceTests.swift
+++ b/MindboxTests/InApp/Tests/WebViewPrewarmTests/InAppWebViewPrewarmServiceTests.swift
@@ -1,0 +1,371 @@
+//
+//  InAppWebViewPrewarmServiceTests.swift
+//  MindboxTests
+//
+//  Created by Sergei Semko on 06.07.2026.
+//  Copyright © 2026 Mindbox. All rights reserved.
+//
+
+import Foundation
+import Testing
+import WebKit
+@testable import Mindbox
+
+@MainActor
+@Suite("InApp WebView prewarm service guards", .tags(.webView))
+struct InAppWebViewPrewarmServiceTests {
+
+    private final class SpyWebView: WKWebView {
+        private(set) var loadedHTMLCount = 0
+        private(set) var loadedBaseURLs: [URL?] = []
+        private(set) var stopLoadingCount = 0
+        var stubbedIsLoading = false
+
+        override var isLoading: Bool { stubbedIsLoading }
+
+        override func loadHTMLString(_ string: String, baseURL: URL?) -> WKNavigation? {
+            loadedHTMLCount += 1
+            loadedBaseURLs.append(baseURL)
+            return nil // spy only — keep WebKit from actually navigating in unit tests
+        }
+
+        override func stopLoading() {
+            stopLoadingCount += 1
+        }
+    }
+
+    private let spy: SpyWebView
+    private let service: InAppWebViewPrewarmService
+
+    init() throws {
+        self = try Self.init(cachedConfig: nil)
+    }
+
+    private init(cachedConfig: ConfigResponse?) throws {
+        let spy = SpyWebView(frame: .zero, configuration: WKWebViewConfiguration())
+        self.spy = spy
+
+        let storage = MockPersistenceStorage()
+        storage.configuration = try MBConfiguration(endpoint: "Test.Endpoint", domain: "api.mindbox.ru")
+        storage.deviceUUID = "test-device-uuid"
+
+        service = InAppWebViewPrewarmService(
+            persistenceStorage: storage,
+            makeWebView: { spy },
+            fetchHTML: { _, completion in completion("<html><body>content</body></html>") },
+            loadCachedConfig: { cachedConfig }
+        )
+    }
+
+    /// The service hops its mutations through `DispatchQueue.main.async`; one more hop
+    /// behind them guarantees they have run.
+    private func drainMainQueue() async {
+        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+            DispatchQueue.main.async { continuation.resume() }
+        }
+    }
+
+    /// The cached-config head start hops through a background queue first — poll for its
+    /// main-queue effects instead of assuming scheduling order.
+    private func waitUntil(_ condition: @autoclosure () -> Bool) async throws {
+        for _ in 0..<100 where !condition() {
+            try await Task.sleep(nanoseconds: 20_000_000)
+        }
+        #expect(condition())
+    }
+
+    @Test("Without a cached webview config nothing is created at init")
+    func initWithoutCachedConfigCreatesNothing() async {
+        service.prewarmProcess()
+        service.prewarmProcess()
+        await drainMainQueue()
+        await drainMainQueue()
+
+        #expect(spy.loadedHTMLCount == 0)
+        #expect(service.borrowWarmWebView() == nil)
+    }
+
+    @Test("A cached config with webview in-apps starts the resource prewarm at init")
+    func headStartRunsFromCachedConfig() async throws {
+        let suite = try Self.init(cachedConfig: loadPrewarmTestConfig("InAppWebviewValid"))
+
+        suite.service.prewarmProcess()
+
+        // preconnect + content page (the instance is created lazily by the prewarm itself)
+        try await suite.waitUntil(suite.spy.loadedHTMLCount == 2)
+    }
+
+    @Test("Resource prewarm runs once: preconnect page, then the content page with the prewarm params")
+    func resourcePrewarmRunsOnce() async throws {
+        let config = try loadPrewarmTestConfig("InAppWebviewValid")
+        service.prewarmResources(for: config)
+        service.prewarmResources(for: config)
+        await drainMainQueue()
+        await drainMainQueue()
+
+        #expect(spy.loadedHTMLCount == 2) // one preconnect + one content page
+
+        let contentBaseURL = try #require(spy.loadedBaseURLs.last ?? nil)
+        #expect(contentBaseURL.host == "inapp.local")
+        let query = try #require(URLComponents(url: contentBaseURL, resolvingAgainstBaseURL: false)?.queryItems)
+        #expect(query.contains(URLQueryItem(name: "prewarm", value: "1")))
+        #expect(query.contains(URLQueryItem(name: "endpointId", value: "Test.Endpoint")))
+        #expect(query.contains(URLQueryItem(name: "deviceUuid", value: "test-device-uuid")))
+
+        // The prewarm injects nothing into the page: user scripts persist across
+        // navigations and would leak into the borrowed instance's shows.
+        #expect(spy.configuration.userContentController.userScripts.isEmpty)
+    }
+
+    @Test("The prewarm instance is pinned by the navigation policy until a show takes over")
+    func prewarmArmsNavigationPolicy() async throws {
+        let suite = try Self.init(cachedConfig: loadPrewarmTestConfig("InAppWebviewValid"))
+        suite.service.prewarmProcess()
+        try await suite.waitUntil(suite.spy.loadedHTMLCount == 2)
+
+        #expect(suite.spy.navigationDelegate is InAppWebViewPrewarmNavigationPolicy)
+    }
+
+    @Test("Borrow stops in-flight loading, tears the prewarm page down, and keeps the instance")
+    func borrowStopsLoadingAndKeepsInstance() async throws {
+        let suite = try Self.init(cachedConfig: loadPrewarmTestConfig("InAppWebviewValid"))
+        suite.service.prewarmProcess()
+        try await suite.waitUntil(suite.spy.loadedHTMLCount == 2)
+
+        let borrowed = suite.service.borrowWarmWebView()
+
+        #expect(borrowed === suite.spy)
+        #expect(suite.spy.stopLoadingCount == 1)
+        #expect(suite.spy.loadedHTMLCount == 3) // preconnect + content + the hard-kill blank at borrow
+
+        // While lent to a live show the instance must never be stolen by a second borrow.
+        #expect(suite.service.borrowWarmWebView() == nil)
+
+        suite.service.parkWarmWebView()
+        await suite.drainMainQueue()
+        #expect(suite.service.borrowWarmWebView() === suite.spy)
+    }
+
+    @Test("Borrow refuses an instance whose prewarm navigation hasn't settled and parks it for the next show")
+    func borrowRefusesMidNavigationInstance() async throws {
+        let suite = try Self.init(cachedConfig: loadPrewarmTestConfig("InAppWebviewValid"))
+        suite.service.prewarmProcess()
+        try await suite.waitUntil(suite.spy.loadedHTMLCount == 2)
+        suite.spy.stubbedIsLoading = true
+
+        // A mid-navigation document must never reach a show: its didFinish can fire
+        // before module scripts evaluate.
+        #expect(suite.service.borrowWarmWebView() == nil)
+        #expect(suite.spy.stopLoadingCount == 1)
+        #expect(suite.spy.loadedHTMLCount == 3) // head start (2) + park blank
+
+        suite.spy.stubbedIsLoading = false
+        #expect(suite.service.borrowWarmWebView() === suite.spy)
+    }
+
+    @Test("Resource prewarm never navigates a borrowed instance")
+    func resourcePrewarmSkippedAfterBorrow() async throws {
+        let suite = try Self.init(cachedConfig: loadPrewarmTestConfig("InAppWebviewValid"))
+        suite.service.prewarmProcess()
+        try await suite.waitUntil(suite.spy.loadedHTMLCount == 2)
+        _ = suite.service.borrowWarmWebView()
+
+        suite.service.prewarmResources(for: try loadPrewarmTestConfig("InAppWebviewValid"))
+        await suite.drainMainQueue()
+        await suite.drainMainQueue()
+
+        #expect(suite.spy.loadedHTMLCount == 3) // head start + borrow hard-kill; nothing more
+    }
+
+    @Test("A show starting before any prewarm blocks later resource prewarms")
+    func showBeforePrewarmBlocksLaterPrewarm() async throws {
+        #expect(service.borrowWarmWebView() == nil)
+
+        service.prewarmResources(for: try loadPrewarmTestConfig("InAppWebviewValid"))
+        await drainMainQueue()
+        await drainMainQueue()
+
+        #expect(spy.loadedHTMLCount == 0)
+    }
+
+    @Test("A config without webview in-apps releases the unused warm instance")
+    func noWebviewConfigReleasesInstance() async throws {
+        let suite = try Self.init(cachedConfig: loadPrewarmTestConfig("InAppWebviewValid"))
+        suite.service.prewarmProcess()
+        try await suite.waitUntil(suite.spy.loadedHTMLCount == 2)
+
+        suite.service.prewarmResources(for: ConfigResponse())
+        await suite.drainMainQueue()
+
+        // An in-flight prewarm navigation must not keep burning bandwidth if anything
+        // briefly retains the dropped instance.
+        #expect(suite.spy.stopLoadingCount == 1)
+        #expect(suite.service.borrowWarmWebView() == nil)
+    }
+
+    @Test("Parking an idle borrowed instance loads a blank page to stop hidden JS")
+    func parkingLoadsBlankPage() async throws {
+        let suite = try Self.init(cachedConfig: loadPrewarmTestConfig("InAppWebviewValid"))
+        suite.service.prewarmProcess()
+        try await suite.waitUntil(suite.spy.loadedHTMLCount == 2)
+        _ = suite.service.borrowWarmWebView()
+
+        suite.service.parkWarmWebView()
+        await suite.drainMainQueue()
+
+        #expect(suite.spy.loadedHTMLCount == 4) // head start (2) + borrow hard-kill + park blank
+    }
+
+    @Test("An off-main borrow is refused without touching the warm instance")
+    func offMainBorrowRefusedSafely() async throws {
+        let suite = try Self.init(cachedConfig: loadPrewarmTestConfig("InAppWebviewValid"))
+        suite.service.prewarmProcess()
+        try await suite.waitUntil(suite.spy.loadedHTMLCount == 2)
+
+        // Deliberate off-main access — exactly what the guard under test refuses.
+        nonisolated(unsafe) let service = suite.service
+        let refused = await withCheckedContinuation { (continuation: CheckedContinuation<Bool, Never>) in
+            DispatchQueue.global().async {
+                continuation.resume(returning: service.borrowWarmWebView() == nil)
+            }
+        }
+
+        #expect(refused)
+        // Main-confined state untouched: the instance still serves a main-thread borrow.
+        #expect(suite.service.borrowWarmWebView() === suite.spy)
+    }
+
+    @Test("A memory warning frees the parked instance; the disk cache keeps the prewarm benefit")
+    func memoryWarningFreesParkedInstance() async throws {
+        let suite = try Self.init(cachedConfig: loadPrewarmTestConfig("InAppWebviewValid"))
+        suite.service.prewarmProcess()
+        try await suite.waitUntil(suite.spy.loadedHTMLCount == 2)
+
+        NotificationCenter.default.post(name: UIApplication.didReceiveMemoryWarningNotification, object: nil)
+        await suite.drainMainQueue()
+
+        #expect(suite.spy.stopLoadingCount == 1)
+        // The next show creates its own WKWebView on the shared store instead.
+        #expect(suite.service.borrowWarmWebView() == nil)
+    }
+
+    @Test("A memory warning never touches an instance lent to a live show")
+    func memoryWarningSparesLentInstance() async throws {
+        let suite = try Self.init(cachedConfig: loadPrewarmTestConfig("InAppWebviewValid"))
+        suite.service.prewarmProcess()
+        try await suite.waitUntil(suite.spy.loadedHTMLCount == 2)
+        _ = suite.service.borrowWarmWebView()
+
+        NotificationCenter.default.post(name: UIApplication.didReceiveMemoryWarningNotification, object: nil)
+        await suite.drainMainQueue()
+
+        suite.service.parkWarmWebView()
+        await suite.drainMainQueue()
+        #expect(suite.service.borrowWarmWebView() === suite.spy)
+    }
+
+    // MARK: Feature toggle
+
+    /// The valid webview config with an explicit `featureToggles` section.
+    private static func config(prewarmToggle: Bool?) throws -> ConfigResponse {
+        let base = try loadPrewarmTestConfig("InAppWebviewValid")
+        let toggles = Settings.FeatureToggles(
+            shouldSendInAppShowError: nil,
+            shouldPrewarmInAppWebView: prewarmToggle,
+            shouldCacheInAppWebView: nil
+        )
+        let settings = Settings(
+            operations: nil, ttl: nil, slidingExpiration: nil,
+            inapp: nil, featureToggles: toggles, baseAddresses: nil
+        )
+        return ConfigResponse(inapps: base.inapps, settings: settings)
+    }
+
+    @Test("Prewarm toggle off in the cached config skips the head start")
+    func prewarmToggleOffSkipsHeadStart() async throws {
+        let suite = try Self.init(cachedConfig: Self.config(prewarmToggle: false))
+
+        suite.service.prewarmProcess()
+        try await Task.sleep(nanoseconds: 100_000_000)
+        await suite.drainMainQueue()
+
+        #expect(suite.spy.loadedHTMLCount == 0)
+        #expect(suite.service.borrowWarmWebView() == nil)
+    }
+
+    @Test("Prewarm toggle off in the fresh config releases the stage-1 instance")
+    func prewarmToggleOffReleasesStageOneInstance() async throws {
+        service.prewarmResources(for: try loadPrewarmTestConfig("InAppWebviewValid"))
+        await drainMainQueue()
+        #expect(spy.loadedHTMLCount == 2)
+
+        service.prewarmResources(for: try Self.config(prewarmToggle: false))
+        await drainMainQueue()
+
+        #expect(spy.stopLoadingCount >= 1)
+        #expect(service.borrowWarmWebView() == nil)
+    }
+
+    @Test("A present section without the key, or an explicit true, keeps the prewarm on",
+          arguments: [nil, true] as [Bool?])
+    func prewarmToggleAbsentOrTrueKeepsFeatureOn(_ toggle: Bool?) async throws {
+        service.prewarmResources(for: try Self.config(prewarmToggle: toggle))
+        await drainMainQueue()
+
+        #expect(spy.loadedHTMLCount == 2)
+    }
+
+    @Test("A toggle-off release that beats the slow stage-1 hop still kills the head start")
+    func releaseBeforeStageOneBlocksHeadStart() async throws {
+        let suite = try Self.init(cachedConfig: loadPrewarmTestConfig("InAppWebviewValid"))
+
+        suite.service.prewarmResources(for: try Self.config(prewarmToggle: false))
+        await suite.drainMainQueue()
+
+        suite.service.prewarmProcess()
+        try await Task.sleep(nanoseconds: 100_000_000)
+        await suite.drainMainQueue()
+
+        #expect(suite.spy.loadedHTMLCount == 0)
+        #expect(suite.service.borrowWarmWebView() == nil)
+    }
+
+    @Test("A no-layers release also blocks a late stage-1 hop")
+    func noLayersReleaseBlocksLateStageOne() async throws {
+        let suite = try Self.init(cachedConfig: loadPrewarmTestConfig("InAppWebviewValid"))
+
+        suite.service.prewarmResources(for: ConfigResponse())
+        await suite.drainMainQueue()
+
+        suite.service.prewarmProcess()
+        try await Task.sleep(nanoseconds: 100_000_000)
+        await suite.drainMainQueue()
+
+        #expect(suite.spy.loadedHTMLCount == 0)
+    }
+}
+
+/// A hidden prewarm WebView must never be able to wander off to arbitrary URLs.
+@Suite("InApp WebView prewarm navigation policy", .tags(.webView))
+@MainActor
+struct InAppWebViewPrewarmNavigationPolicyTests {
+
+    private let policy = InAppWebViewPrewarmNavigationPolicy()
+
+    @Test("SDK-issued documents are allowed; anything else on the main frame is cancelled")
+    func pinsMainFrameToIssuedDocuments() throws {
+        let issued = try #require(URL(string: "https://inapp.local/popup?prewarm=1"))
+        policy.allow(issued)
+
+        #expect(policy.decision(for: issued, targetIsMainFrame: true) == .allow)
+        #expect(policy.decision(for: URL(string: "https://evil.example/landing"), targetIsMainFrame: true) == .cancel)
+        // The park/borrow blank load is always ours.
+        #expect(policy.decision(for: URL(string: "about:blank"), targetIsMainFrame: true) == .allow)
+    }
+
+    @Test("Subframes stay the page's own business; a nil target frame (window.open) is pinned")
+    func subframesAllowedNilTargetPinned() {
+        #expect(policy.decision(for: URL(string: "https://ads.example/frame"), targetIsMainFrame: false) == .allow)
+        #expect(policy.decision(for: URL(string: "https://popup.example/win"), targetIsMainFrame: nil) == .cancel)
+    }
+}

--- a/MindboxTests/Mock/MockPersistenceStorage.swift
+++ b/MindboxTests/Mock/MockPersistenceStorage.swift
@@ -132,6 +132,13 @@ class MockPersistenceStorage: PersistenceStorage {
 
     var webViewLocalStateVersion: Int?
 
+    // Counts writes so a no-op-write regression (rewriting an unchanged dictionary) is
+    // observable — the persisted value alone can't distinguish "written again" from "unchanged".
+    var webViewLearnedHostsWriteCount = 0
+    var webViewLearnedHosts: [String: [String]]? {
+        didSet { webViewLearnedHostsWriteCount += 1 }
+    }
+
     var operationsDomainFromConfig: String? {
         didSet {
             onDidChange?()

--- a/MindboxTests/Network/SDKUserAgentTests.swift
+++ b/MindboxTests/Network/SDKUserAgentTests.swift
@@ -1,0 +1,49 @@
+//
+//  SDKUserAgentTests.swift
+//  MindboxTests
+//
+//  Created by Sergei Semko on 08.07.2026.
+//  Copyright © 2026 Mindbox. All rights reserved.
+//
+
+import Testing
+import Foundation
+@testable import Mindbox
+
+@Suite("SDK User-Agent builder", .tags(.userAgent))
+struct SDKUserAgentTests {
+
+    private struct StubUtilitiesFetcher: UtilitiesFetcher {
+        var sdkVersion: String?
+        var appVerson: String?
+        var hostApplicationName: String?
+        var applicationGroupIdentifier = "group.stub"
+        func getDeviceUUID(completion: @escaping (String) -> Void) { completion("") }
+    }
+
+    /// Pins the UA layout `mindbox.sdk/<sdk> (<os> <ver>; <model>) <app>/<appVer>` so a
+    /// refactor can't reorder the segments: the backend slices traffic by this string, and
+    /// the network layer and the WebView share this single builder.
+    @Test
+    func buildKeepsSegmentOrderAndFormat() {
+        let fetcher = StubUtilitiesFetcher(sdkVersion: "9.9.9", appVerson: "1.2.3", hostApplicationName: "com.test.app")
+        let ua = SDKUserAgent.build(utilitiesFetcher: fetcher)
+
+        // sdk token first, app/appVer last — a reordering breaks the prefix/suffix.
+        #expect(ua.hasPrefix("mindbox.sdk/9.9.9 ("))
+        #expect(ua.hasSuffix(") com.test.app/1.2.3"))
+        // The device segment "(os ver; model)" sits between them.
+        #expect(ua.contains("; "))
+    }
+
+    /// Missing bundle metadata falls back to "unknown" in every slot — not the legacy
+    /// "unknow" typo, and not an empty token.
+    @Test
+    func buildFallsBackToUnknown() {
+        let fetcher = StubUtilitiesFetcher(sdkVersion: nil, appVerson: nil, hostApplicationName: nil)
+        let ua = SDKUserAgent.build(utilitiesFetcher: fetcher)
+
+        #expect(ua.hasPrefix("mindbox.sdk/unknown ("))
+        #expect(ua.hasSuffix(") unknown/unknown"))
+    }
+}


### PR DESCRIPTION
## Summary

In-app WebViews were created **cold on every show**: a fresh web-content process plus a full network fetch of the page and all its resources, giving multi-second first-show latency. This PR lands a **shared, persistent WebView cache** and a **pre-warm engine** that starts a hidden WebView and fills that cache *ahead* of the first show, then reuses one live instance across shows. Everything sits behind two config-driven kill-switch toggles, so it can be turned off server-side with no app update.

Prototype profiling (throwaway harness, `prototype/webview-cache-profiling`): cold first show ~3.4s → warm+reuse ~0.4s.

This is the integration branch for the whole feature — it lands a reviewed, approved stack of four sub-PRs onto `develop` as one change.

## What's in it (four layers)

| Sub-PR | Layer | What it does |
|---|---|---|
| #731 | Show robustness | `WebViewReadyChecker` polls for the JS bridge instead of a single didFinish-time probe (module scripts can finish a beat after the load event, esp. on a reused instance / slow devices); init-timeout gains an error **category** — tells "page loaded but the bridge never appeared" (content defect) from "page never loaded" (load defect); learned-resource-hosts captured on dismissal. |
| #732 | Shared cache + toggles | One `WKWebsiteDataStore` for every Mindbox WebView (prewarm and shows share it, so prewarmed entries are visible to shows); a single revalidating HTML fetch transport (ETag → 304); the two feature toggles. |
| #733 | Bridge staleness | A reused (pre-warmed) WebView delivers a **previous owner's** navigation callbacks and script messages. Callbacks are filtered by navigation identity; JS messages are gated until the show's own document commits. |
| #734 | Prewarm engine | Stage 1 (SDK init, from the previous launch's cached config) + stage 2 (fresh config). Hidden warm instance, preconnect to config + API + learned hosts, content page loaded with the official prewarm-contract params; **borrow/park** lifecycle reusing one live instance across shows; release under memory pressure. |

## Feature toggles (kill switches)

- `shouldCacheInAppWebView` and `shouldPrewarmInAppWebView`, read from `settings.featureToggles`.
- **Absent key / section / config all mean "enabled"** — these are kill switches, not opt-ins.
- Read **config-scoped** by their consumers (each prewarm stage reads the config it works with; the data store latches from the config cache) — not through the shared toggle manager, because those reads happen before any fresh config is applied.
- Cache toggle **off** restores the exact pre-feature behavior (`.nonPersistent()` store, cache-less fetch); prewarm **off** releases any warm instance.

## Compatibility & safety

- **iOS 12 supported.** Pre-iOS-13 keeps the cache-less fetch (`reloadRevalidatingCacheData` exists only from iOS 13); pre-iOS-17 shares the host app's `.default()` store (deliberate product decision — some disk cache beats none). iOS 17+ uses an isolated named store, so Mindbox web content never shares cookies/storage with the host's own WebViews.
- WebKit partitions its HTTP cache by the top-level document's host — the prewarm loads under the **shows' partition** so its entries are visible to the shows.
- Never hands out an instance mid-navigation; blank-load teardown on borrow and park; the staleness filter drops leftover callbacks; fail-open on ambiguous (nil) navigations so a real callback is never swallowed.
- Memory-pressure warning releases the parked warm instance (the disk HTTP cache survives).

## Testing

- **26 test files** (Swift Testing) across the planner, prewarm service, learned-hosts store, cache store / fetcher / factory / toggles, bridge staleness & message gate, and ready-checker & timeout category.
- Every new test was **mutation-verified** (break the guarded prod line → suite goes red → revert) to confirm it actually catches regressions.
- Prod code is **byte-identical** to the reference control branch (`feature/MOBILE-268-WebView-Cache-and-Pre-Warm`) — the empty-diff invariant was preserved through the whole stacked-PR cut; tests are a deliberate superset.
- CI green on the stack (build, unit tests, SwiftLint, gitleaks).

## Rollout / rollback

Both toggles default-on but are server-config kill switches — disable via config with no app update. The cache-off path is the exact pre-feature behavior; the prewarm-off path releases the warm instance. No migration, no persisted-schema change beyond the additive learned-hosts map (per-endpoint, capped at 12, stale entries harmless).

## Stat

63 files, +2559 / −1276 (36 prod, 26 test).
