### PR TITLE
chore: tighten per-test timeout allowance to 60s

### DIFF
--- a/TestPlans/Mindbox.xctestplan
+++ b/TestPlans/Mindbox.xctestplan
@@ -4,7 +4,7 @@
       "id" : "5A458544-9C9E-4B2F-B5E9-8D2451CDE5B3",
       "name" : "Unit Tests",
       "options" : {
-        "defaultTestExecutionTimeAllowance" : 120,
+        "defaultTestExecutionTimeAllowance" : 60,
         "testTimeoutsEnabled" : true
       }
     }
@@ -29,7 +29,7 @@
         }
       ]
     },
-    "defaultTestExecutionTimeAllowance" : 120,
+    "defaultTestExecutionTimeAllowance" : 60,
     "environmentVariableEntries" : [
       {
         "key" : "OS_ACTIVITY_MODE",


### PR DESCRIPTION
Per-test `defaultTestExecutionTimeAllowance` was 120s; the slowest unit test is ~7s (a fixed-delay wait), so 60s keeps wide headroom while failing a genuine hang faster. 60s is also the effective floor since the value rounds up to the nearest minute. Sanitizer plans are left untouched (they run far slower).