### PR TITLE
MOBILE-197: Send data-only payload in WebView sync onError

### DIFF
--- a/Mindbox/InAppMessages/Presentation/Views/WebView/TransparentView.swift
+++ b/Mindbox/InAppMessages/Presentation/Views/WebView/TransparentView.swift
@@ -486,7 +486,7 @@ extension TransparentView {
             return BridgeMessage(
                 type: .error,
                 action: action,
-                payload: .string(error.createJSON()),
+                payload: .string(error.createDataJSON()),
                 id: id
             )
         }

--- a/Mindbox/Model/MindboxError/MindboxError.swift
+++ b/Mindbox/Model/MindboxError/MindboxError.swift
@@ -142,45 +142,64 @@ public extension MindboxError {
             }
             return errorString
         }
+
+        func convertDataToString() -> String {
+            guard
+                let errorData = try? JSONEncoder().encode(data),
+                let errorString = String(data: errorData, encoding: .utf8) else {
+                return #"{"errorMessage":"Unable to convert Data to JSON"}"#
+            }
+            return errorString
+        }
     }
 
     func createJSON() -> String {
+        makeErrorJSON().convertToString()
+    }
+
+    /// Data-only JSON without the `{type, data}` envelope — the WebView JS-bridge
+    /// `onError` contract. `createJSON()` must keep the envelope: RN/Flutter dispatch on it.
+    internal func createDataJSON() -> String {
+        makeErrorJSON().convertDataToString()
+    }
+
+    private func makeErrorJSON() -> MindboxErrorJSON {
         switch self {
         case .validationError(let error):
             return MindboxErrorJSON(status: error.status,
-                                    validationMessages: error.validationMessages).convertToString()
+                                    validationMessages: error.validationMessages)
         case .protocolError(let error):
             return MindboxErrorJSON(status: error.status,
                                     errorMessage: error.errorMessage,
                                     errorId: error.errorId ?? "",
-                                    httpStatusCode: error.httpStatusCode).convertToString()
+                                    httpStatusCode: error.httpStatusCode)
         case .serverError(let error):
             return MindboxErrorJSON(status: error.status,
                                     errorMessage: error.errorMessage,
                                     errorId: error.errorId ?? "",
-                                    httpStatusCode: error.httpStatusCode).convertToString()
+                                    httpStatusCode: error.httpStatusCode)
         case .internalError(let error):
             return MindboxErrorJSON(errorKey: error.errorKey,
                                     errorName: error.reason ?? "",
-                                    errorMessage: error.description).convertToString()
+                                    errorMessage: error.description)
         case .invalidResponse(let response):
             if let httpResponse = response as? HTTPURLResponse {
                 let httpStatusCode = String(httpResponse.statusCode)
                 let errorMessage = httpResponse.description
 
                 return MindboxErrorJSON(httpStatusCode: httpStatusCode,
-                                        errorMessage: errorMessage).convertToString()
+                                        errorMessage: errorMessage)
             } else {
                 return MindboxErrorJSON(httpStatusCode: "null",
-                                        errorMessage: "Connection error").convertToString()
+                                        errorMessage: "Connection error")
             }
         case .connectionError:
             return MindboxErrorJSON(httpStatusCode: "null",
-                                    errorMessage: "Connection error").convertToString()
+                                    errorMessage: "Connection error")
         case .unknown(let error):
             return MindboxErrorJSON(errorKey: "unknown",
                                     errorName: "",
-                                    errorMessage: error.localizedDescription).convertToString()
+                                    errorMessage: error.localizedDescription)
         }
     }
 }

--- a/Mindbox/Model/MindboxError/MindboxError.swift
+++ b/Mindbox/Model/MindboxError/MindboxError.swift
@@ -128,17 +128,7 @@ public extension MindboxError {
             guard
                 let errorData = try? JSONEncoder().encode(self),
                 let errorString = String(data: errorData, encoding: .utf8) else {
-                return
-                    """
-                    {
-                        type: "InternalError",
-                        data: {
-                            errroKey: "\(self.data.errorKey ?? "null")",
-                            errroName: "JSON encoding error",
-                            errorMessage: "Unable to convert Data to JSON",
-                        }
-                    }
-                    """
+                return #"{"type":"InternalError","data":{"errorKey":"\#(self.data.errorKey ?? "null")","errorName":"JSON encoding error","errorMessage":"Unable to convert Data to JSON"}}"#
             }
             return errorString
         }

--- a/MindboxTests/InApp/Tests/TransparentViewSyncOperationResponseTests.swift
+++ b/MindboxTests/InApp/Tests/TransparentViewSyncOperationResponseTests.swift
@@ -118,43 +118,95 @@ struct TransparentViewSyncOperationResponseTests {
         }
     }
 
-    // MARK: - Failure (.connectionError) → .error with createJSON payload
+    // MARK: - Failure payloads: data contents only, no {type, data} envelope (MOBILE-197)
 
-    @Test("Connection failure becomes .error with MindboxError.createJSON payload")
-    func connectionError_becomesError() {
-        let outgoing = TransparentView.makeSyncOperationResponse(
-            result: .failure(.connectionError),
-            action: action,
-            id: requestId
-        )
-
+    private func decodedErrorPayload(_ outgoing: BridgeMessage) throws -> [String: Any] {
         #expect(outgoing.type == .error)
-        if case .string(let value) = outgoing.payload {
-            #expect(value.contains("NetworkError"), "createJSON for connectionError produces a NetworkError envelope")
-            #expect(value.contains("Connection error"))
-        } else {
-            Issue.record("Expected .string payload")
-        }
+        var jsonString: String?
+        if case .string(let value) = outgoing.payload { jsonString = value }
+        let json = try #require(jsonString, "Expected .string payload, got \(String(describing: outgoing.payload))")
+        let data = try #require(json.data(using: .utf8))
+        let object = try #require(try JSONSerialization.jsonObject(with: data) as? [String: Any])
+        #expect(object["type"] == nil, "Payload must not carry the {type, data} envelope")
+        #expect(object["data"] == nil, "Payload must not carry the {type, data} envelope")
+        return object
     }
 
-    // MARK: - Failure (.protocolError) → .error with createJSON payload
-
-    @Test("Protocol error becomes .error with MindboxError.createJSON payload")
-    func protocolError_becomesError() {
-        let pe = ProtocolError(status: .protocolError, errorMessage: "Bad", httpStatusCode: 400)
+    @Test("Protocol error payload is the data contents: status, errorMessage, httpStatusCode, errorId")
+    func protocolError_payloadIsDataContentsOnly() throws {
+        let pe = ProtocolError(status: .protocolError, errorMessage: "Operation Test not found", httpStatusCode: 400, errorId: "error-id-1")
         let outgoing = TransparentView.makeSyncOperationResponse(
             result: .failure(.protocolError(pe)),
             action: action,
             id: requestId
         )
 
-        #expect(outgoing.type == .error)
-        if case .string(let value) = outgoing.payload {
-            #expect(value.contains("MindboxError"))
-            #expect(value.contains("ProtocolError"))
-        } else {
-            Issue.record("Expected .string payload")
-        }
+        let payload = try decodedErrorPayload(outgoing)
+        #expect(payload["status"] as? String == "ProtocolError")
+        #expect(payload["errorMessage"] as? String == "Operation Test not found")
+        #expect(payload["httpStatusCode"] as? String == "400")
+        #expect(payload["errorId"] as? String == "error-id-1")
+    }
+
+    @Test("Server error payload is the data contents with InternalServerError status")
+    func serverError_payloadIsDataContentsOnly() throws {
+        let pe = ProtocolError(status: .internalServerError, errorMessage: "Something went wrong", httpStatusCode: 500)
+        let outgoing = TransparentView.makeSyncOperationResponse(
+            result: .failure(.serverError(pe)),
+            action: action,
+            id: requestId
+        )
+
+        let payload = try decodedErrorPayload(outgoing)
+        #expect(payload["status"] as? String == "InternalServerError")
+        #expect(payload["errorMessage"] as? String == "Something went wrong")
+        #expect(payload["httpStatusCode"] as? String == "500")
+    }
+
+    @Test("Connection failure payload is the data contents without the NetworkError envelope")
+    func connectionError_payloadIsDataContentsOnly() throws {
+        let outgoing = TransparentView.makeSyncOperationResponse(
+            result: .failure(.connectionError),
+            action: action,
+            id: requestId
+        )
+
+        let payload = try decodedErrorPayload(outgoing)
+        #expect(payload["httpStatusCode"] as? String == "null")
+        #expect(payload["errorMessage"] as? String == "Connection error")
+    }
+
+    @Test("Validation error payload is the data contents with validationMessages")
+    func validationError_payloadIsDataContentsOnly() throws {
+        let ve = ValidationError(
+            status: .validationError,
+            validationMessages: [ValidationMessage(message: "Invalid email", location: "/customer/email")]
+        )
+        let outgoing = TransparentView.makeSyncOperationResponse(
+            result: .failure(.validationError(ve)),
+            action: action,
+            id: requestId
+        )
+
+        let payload = try decodedErrorPayload(outgoing)
+        #expect(payload["status"] as? String == "ValidationError")
+        let messages = try #require(payload["validationMessages"] as? [[String: Any]])
+        #expect(messages.count == 1)
+        #expect(messages.first?["message"] as? String == "Invalid email")
+        #expect(messages.first?["location"] as? String == "/customer/email")
+    }
+
+    @Test("Internal error payload is the data contents with errorKey")
+    func internalError_payloadIsDataContentsOnly() throws {
+        let outgoing = TransparentView.makeSyncOperationResponse(
+            result: .failure(.internalError(InternalError(errorKey: .parsing, reason: "Broken body"))),
+            action: action,
+            id: requestId
+        )
+
+        let payload = try decodedErrorPayload(outgoing)
+        #expect(payload["errorKey"] as? String == "Error_parsing")
+        #expect(payload["errorName"] as? String == "Broken body")
     }
 
     // MARK: - id and action propagated

--- a/MindboxTests/InApp/Tests/TransparentViewSyncOperationResponseTests.swift
+++ b/MindboxTests/InApp/Tests/TransparentViewSyncOperationResponseTests.swift
@@ -209,6 +209,37 @@ struct TransparentViewSyncOperationResponseTests {
         #expect(payload["errorName"] as? String == "Broken body")
     }
 
+    @Test("Invalid response payload is the data contents with httpStatusCode from the response")
+    func invalidResponse_payloadIsDataContentsOnly() throws {
+        let url = try #require(URL(string: "https://api.mindbox.ru/v3/operations/sync"))
+        let httpResponse = try #require(HTTPURLResponse(url: url, statusCode: 403, httpVersion: nil, headerFields: nil))
+
+        let outgoing = TransparentView.makeSyncOperationResponse(
+            result: .failure(.invalidResponse(httpResponse)),
+            action: action,
+            id: requestId
+        )
+
+        let payload = try decodedErrorPayload(outgoing)
+        #expect(payload["httpStatusCode"] as? String == "403")
+        #expect((payload["errorMessage"] as? String)?.isEmpty == false)
+    }
+
+    @Test("Unknown error payload is the data contents with errorKey 'unknown'")
+    func unknownError_payloadIsDataContentsOnly() throws {
+        let underlying = NSError(domain: "test", code: 1, userInfo: [NSLocalizedDescriptionKey: "Something exploded"])
+
+        let outgoing = TransparentView.makeSyncOperationResponse(
+            result: .failure(.unknown(underlying)),
+            action: action,
+            id: requestId
+        )
+
+        let payload = try decodedErrorPayload(outgoing)
+        #expect(payload["errorKey"] as? String == "unknown")
+        #expect(payload["errorMessage"] as? String == "Something exploded")
+    }
+
     // MARK: - id and action propagated
 
     @Test("Action and id from the request are preserved on the outgoing message")


### PR DESCRIPTION
The WebView JS-bridge `onError` for `mindbox("sync", ...)` delivered the error wrapped in a `{type, data}` envelope, while `onValidationError` gets the `data` contents directly — and Android wrapped it differently, so popup JS needed per-platform parsing. The failure branch now sends a data-only JSON via a new internal `createDataJSON()`; public `createJSON()` is byte-identical since RN/Flutter wrappers dispatch on the `{type, data}` envelope. Mirrored in mindbox-cloud/android-sdk#736 — both must release in the same window since this is a breaking change of the popup-JS contract.