### PR TITLE
MOBILE-0000: Add start and app-state separators to SDK logs

### DIFF
--- a/Mindbox/CoreController/CoreController.swift
+++ b/Mindbox/CoreController/CoreController.swift
@@ -259,6 +259,7 @@ final class CoreController {
         controllerQueue: DispatchQueue = DispatchQueue(label: "com.Mindbox.controllerQueue"),
         userVisitManager: UserVisitManagerProtocol
     ) {
+        Logger.common(message: "════════════════ [Cold start] SDK initialization ════════════════", level: .info, category: .general)
         self.persistenceStorage = persistenceStorage
         self.utilitiesFetcher = utilitiesFetcher
         self.databaseRepository = databaseRepository

--- a/Mindbox/InAppMessages/InappSessionManager/InappSessionManager.swift
+++ b/Mindbox/InAppMessages/InappSessionManager/InappSessionManager.swift
@@ -70,6 +70,7 @@ final class InappSessionManager: InappSessionManagerProtocol {
         let timeBetweenVisitsSeconds = now.timeIntervalSince(lastTimestamp)
         if timeBetweenVisitsSeconds > Double(sessionTimeInSeconds) {
             updatingInappSession = true
+            Logger.common(message: "──────────────── [New session] ────────────────", level: .info, category: .general)
             Logger.common(message: "[InappSessionManager] Session expired. Need to update session...")
             updateInappSession()
         } else {

--- a/Mindbox/SessionManager/MBSessionManager.swift
+++ b/Mindbox/SessionManager/MBSessionManager.swift
@@ -34,6 +34,7 @@ final class MBSessionManager {
             object: nil,
             queue: nil
         ) { [weak self] _ in
+            Logger.common(message: "········ [Foreground] app did become active ········", level: .info, category: .general)
             self?.isActive = true
         }
 
@@ -42,6 +43,7 @@ final class MBSessionManager {
             object: nil,
             queue: nil
         ) { [weak self] _ in
+            Logger.common(message: "········ [Background] app did enter background ········", level: .info, category: .general)
             self?.isActive = false
         }
 


### PR DESCRIPTION
A heavy banner at process start, a medium separator at inapp-session rollover and light foreground/background lines make launch and session boundaries visible in fetched log dumps and console. Log-only change, no behavior touched. Verified live on the simulator by reading the on-device log DB (cold start, foreground, background); session rollover is covered by InappSessionManagerTests.