### PR TITLE
MOBILE-0000: Drop ticket and PR references from comments and test names

### DIFF
--- a/Mindbox/DI/Injections/InjectReplaceable.swift
+++ b/Mindbox/DI/Injections/InjectReplaceable.swift
@@ -34,13 +34,13 @@ extension MBContainer {
 
             guard !appGroup.isEmpty else {
                 // App Group unavailable (already reported by the fetcher) — fall back to
-                // `.standard` so the SDK keeps working instead of crashing the host (issue #705).
+                // `.standard` so the SDK keeps working instead of crashing the host.
                 // A later App Group fix re-registers the install; see `AppGroupStorageTransitionReporter`.
                 return MBPersistenceStorage(defaults: .standard)
             }
 
             guard let defaults = UserDefaults(suiteName: appGroup) else {
-                // Unreachable for a resolved App Group id; degrade without trapping (issue #705).
+                // Unreachable for a resolved App Group id; degrade without trapping.
                 Logger.common(message: "[PersistenceStorage] UserDefaults(suiteName: \(appGroup)) failed; using .standard.", level: .fault, category: .general)
                 return MBPersistenceStorage(defaults: .standard)
             }

--- a/Mindbox/PersistenceStorage/MBPersistenceStorage.swift
+++ b/Mindbox/PersistenceStorage/MBPersistenceStorage.swift
@@ -370,7 +370,7 @@ extension MBPersistenceStorage {
     }
 }
 
-/// Reports (issue #705 follow-up) a fallback-then-recovery fingerprint: install state in BOTH the
+/// Reports a fallback-then-recovery fingerprint: install state in BOTH the
 /// `.standard` fallback and the App Group suite. Read-only by design (cleanup deferred to a future
 /// migration). Runs after re-registration, so it fires on the recovery launch itself and on every
 /// cold start while the fingerprint persists.

--- a/Mindbox/Utilities/UtilitiesFetcher/MBUtilitiesFetcher.swift
+++ b/Mindbox/Utilities/UtilitiesFetcher/MBUtilitiesFetcher.swift
@@ -33,9 +33,9 @@ class MBUtilitiesFetcher: UtilitiesFetcher {
     /// (events database + `UserDefaults` suite).
     ///
     /// Returns `""` when the host bundle id is missing or the container is unavailable,
-    /// so the SDK falls back to local storage instead of crashing the host (issue #705).
+    /// so the SDK falls back to local storage instead of crashing the host.
     /// Must never trap — not even in Debug: Debug builds on device farms routinely lack a
-    /// configured App Group, the exact scenario #705 is about. Surfaced as a `.fault` log.
+    /// configured App Group — the exact scenario this guards. Surfaced as a `.fault` log.
     var applicationGroupIdentifier: String {
         guard let hostApplicationName = hostApplicationName else {
             Logger.common(message: "[MBUtilitiesFetcher] Host application bundle identifier is unavailable", level: .fault, category: .general)

--- a/MindboxLogger/Shared/Extensions/MBLoggerUtilitiesFetcher.swift
+++ b/MindboxLogger/Shared/Extensions/MBLoggerUtilitiesFetcher.swift
@@ -21,7 +21,7 @@ class MBLoggerUtilitiesFetcher {
     ///
     /// `nil` makes `LoggerDatabaseLoader` fall back to the app's local caches store, so the
     /// logger keeps working instead of being disabled. Must never trap — the SDK must not
-    /// bring down its host over an unavailable container, on simulator or device (issue #705).
+    /// bring down its host over an unavailable container, on simulator or device.
     var applicationGroupIdentifier: String? {
         guard let hostApplicationName = hostApplicationName else {
             return nil

--- a/MindboxLoggerTests/FileManagerStoreURLTests.swift
+++ b/MindboxLoggerTests/FileManagerStoreURLTests.swift
@@ -10,7 +10,7 @@ import Foundation
 import CoreData
 @testable import MindboxLogger
 
-/// Regression coverage for App Group store-URL resolution (issue #705).
+/// Regression coverage for App Group store-URL resolution.
 ///
 /// Previously `FileManager.storeURL(for:databaseName:)` called `fatalError` when
 /// the shared container was unavailable, which crashed the host straight through

--- a/MindboxLoggerTests/MBLoggerUtilitiesFetcherTests.swift
+++ b/MindboxLoggerTests/MBLoggerUtilitiesFetcherTests.swift
@@ -9,13 +9,13 @@ import Testing
 import Foundation
 @testable import MindboxLogger
 
-/// Regression coverage for issue #705: `MBLoggerUtilitiesFetcher.applicationGroupIdentifier`
+/// Regression coverage: `MBLoggerUtilitiesFetcher.applicationGroupIdentifier`
 /// must NEVER trap. It used to `fatalError` when the shared container was unavailable; it now
 /// returns `nil` so `LoggerDatabaseLoader` falls back to the app's local store.
 @Suite("MBLoggerUtilitiesFetcher App Group resolution")
 struct MBLoggerUtilitiesFetcherTests {
 
-    /// #705 core invariant: the getter must resolve WITHOUT trapping. It used to `fatalError`
+    /// Core invariant: the getter must resolve WITHOUT trapping. It used to `fatalError`
     /// when the shared container was unavailable; a `fatalError` would tear down the test
     /// runner, so this test reaching its assertion at all proves the trap is gone.
     @Test

--- a/MindboxTests/Configuration/MBConfigurationTests.swift
+++ b/MindboxTests/Configuration/MBConfigurationTests.swift
@@ -135,7 +135,7 @@ struct MBConfigurationTests {
         }
     }
 
-    @Test("operationsDomain accepts path prefix (MOBILE-258)")
+    @Test("operationsDomain accepts path prefix")
     func operationsDomainAcceptsPathPrefix() throws {
         let config = try MBConfiguration(
             endpoint: endpoint,

--- a/MindboxTests/DI/AppGroupUnavailableTests.swift
+++ b/MindboxTests/DI/AppGroupUnavailableTests.swift
@@ -11,7 +11,7 @@ import CoreData
 import MindboxLogger
 @testable import Mindbox
 
-/// #705 core-SDK fallback: an unavailable App Group must degrade to local storage, not crash.
+/// Core-SDK fallback: an unavailable App Group must degrade to local storage, not crash.
 /// Serialized — the cases mutate global `MBInject` / `MBPersistenceStorage.defaults` / `MBPersistentContainer`.
 @Suite("App Group unavailable — core SDK fallback", .serialized)
 struct AppGroupUnavailableTests {
@@ -25,7 +25,7 @@ struct AppGroupUnavailableTests {
         func getDeviceUUID(completion: @escaping (String) -> Void) { completion(UUID().uuidString) }
     }
 
-    /// #705: the getter used to `fatalError` on an unavailable container — a trap would tear down
+    /// The getter used to `fatalError` on an unavailable container — a trap would tear down
     /// the runner, so simply reaching the assertion proves it's gone.
     @Test
     func coreFetcherResolvesWithoutTrapping() {
@@ -71,7 +71,7 @@ struct AppGroupUnavailableTests {
     }
 }
 
-/// Storage-transition reporter (#705 follow-up): reports only when install state is in BOTH stores; read-only.
+/// Storage-transition reporter: reports only when install state is in BOTH stores; read-only.
 @Suite("App Group storage-transition reporter")
 struct AppGroupStorageTransitionReporterTests {
 

--- a/MindboxTests/InApp/Tests/TransparentViewSyncOperationResponseTests.swift
+++ b/MindboxTests/InApp/Tests/TransparentViewSyncOperationResponseTests.swift
@@ -13,7 +13,7 @@ struct TransparentViewSyncOperationResponseTests {
     private let action = "syncOperation"
     private let requestId = UUID()
 
-    // MARK: - HTTP 200 + ValidationError body → .response with raw body (regression: MOBILE-164)
+    // MARK: - HTTP 200 + ValidationError body → .response with raw body (regression)
 
     @Test("HTTP 200 ValidationError body becomes .response with raw body string")
     func validationErrorBody_becomesResponseWithRawBody() throws {
@@ -118,7 +118,7 @@ struct TransparentViewSyncOperationResponseTests {
         }
     }
 
-    // MARK: - Failure payloads: data contents only, no {type, data} envelope (MOBILE-197)
+    // MARK: - Failure payloads: data contents only, no {type, data} envelope
 
     private func decodedErrorPayload(_ outgoing: BridgeMessage) throws -> [String: Any] {
         #expect(outgoing.type == .error)

--- a/MindboxTests/MindboxOperationsTests.swift
+++ b/MindboxTests/MindboxOperationsTests.swift
@@ -10,7 +10,7 @@ import Testing
 import Foundation
 @testable import Mindbox
 
-/// Contract tests for the public operations pipeline (MOBILE-208): the heavy work
+/// Contract tests for the public operations pipeline: the heavy work
 /// runs on the serial eventQueue, yet every externally observable guarantee holds —
 /// call order equals DB write order, the body is snapshotted at call time, invalid
 /// input is dropped before the hop, executeSyncOperation completions always arrive

--- a/MindboxTests/MindboxTests.swift
+++ b/MindboxTests/MindboxTests.swift
@@ -191,7 +191,7 @@ class MindboxTests: XCTestCase {
 
     // Functional validator cases live in OperationNameValidatorTests (Swift Testing).
 
-    // Regression (MOBILE-208): observe() used to invoke the host completion while
+    // Regression: observe() used to invoke the host completion while
     // holding observeSemaphore, so re-entering getDeviceUUID/getAPNSToken from inside
     // a completion deadlocked the controller queue. Now the completion runs after the
     // lock is released; on the old code this test fails by expectation timeout.

--- a/MindboxTests/Network/MBEventRepositorySendRawTests.swift
+++ b/MindboxTests/Network/MBEventRepositorySendRawTests.swift
@@ -219,7 +219,7 @@ struct MBEventRepositorySendRawTests {
         #expect(isMain)
     }
 
-    // MARK: - send<T>: completion always on the main queue (MOBILE-208 contract)
+    // MARK: - send<T>: completion always on the main queue (public contract)
 
     @Test("send<T> network-path completion is delivered on the main queue")
     func sendTyped_completion_onMainQueue() async throws {

--- a/MindboxTests/Network/MBNetworkFetcherResponseHandlingTests.swift
+++ b/MindboxTests/Network/MBNetworkFetcherResponseHandlingTests.swift
@@ -639,7 +639,7 @@ final class MBNetworkFetcherResponseHandlingTests: XCTestCase {
         waitForExpectations(timeout: 1)
     }
 
-    // MARK: - requestRaw: HTTP 200 + ValidationError body → raw Data success (regression: MOBILE-164)
+    // MARK: - requestRaw: HTTP 200 + ValidationError body → raw Data success (regression)
 
     func test_requestRaw_http200_statusValidationError_returnsRawData() throws {
         let fetcher = try makeFetcher()

--- a/MindboxTests/Network/OperationResponseTests.swift
+++ b/MindboxTests/Network/OperationResponseTests.swift
@@ -10,7 +10,7 @@ import Testing
 import Foundation
 @testable import Mindbox
 
-/// Wire-contract tests for `OperationResponse` (MOBILE-303): the API returns promo
+/// Wire-contract tests for `OperationResponse`: the API returns promo
 /// actions under the plural `promoActions` key, and the JSON re-encoded for the
 /// hybrid bridges (`createJSON`) must use the same wire keys as the decoder —
 /// otherwise a field silently vanishes between the API and the JS layer.
@@ -96,7 +96,7 @@ struct OperationResponseTests {
 
     // The two productList shapes share one wire key on decode, but have always
     // re-encoded under their own property names (synthesized behavior). Locked
-    // down here so the MOBILE-303 encode(to:) rewrite changes nothing but promoActions.
+    // down here so the encode(to:) rewrite changes nothing but promoActions.
     @Test("An array productList re-encodes under the productList key")
     func productListArrayKeepsItsKey() throws {
         let response = try JSONDecoder().decode(
@@ -121,7 +121,7 @@ struct OperationResponseTests {
         #expect(!dict.keys.contains("productList"))
     }
 
-    /// Shape of a production sync-operation response reported in MOBILE-303, fully
+    /// Shape of a production sync-operation response from a client report, fully
     /// anonymized: fractional seconds longer than the `.SSS` parse pattern (6 and 5
     /// digits), sibling non-Utc date keys, `timeZoneMode`, and custom fields mixing
     /// booleans with strings. All values are synthetic; the key set and the date

--- a/MindboxTests/Network/OperationsURLRoutingTests.swift
+++ b/MindboxTests/Network/OperationsURLRoutingTests.swift
@@ -164,7 +164,7 @@ struct OperationsURLRoutingTests {
         #expect(url?.path == "/v3/operations/async")
     }
 
-    // MARK: - Path prefix in operationsDomain (MOBILE-258)
+    // MARK: - Path prefix in operationsDomain
 
     @Test("operationsDomain with path prefix appends operation endpoint after the prefix")
     func pathPrefixAppendsEndpointAfterPrefix() throws {
@@ -415,7 +415,7 @@ struct OperationsURLRoutingTests {
         )
     }
 
-    @Test("Policy — saves value with path prefix in canonical form (MOBILE-258)")
+    @Test("Policy — saves value with path prefix in canonical form")
     func policySavesPathPrefixValue() {
         #expect(
             OperationsDomainConfigPolicy.action(for: "api-v2.letu.ru/api/mindbox-regular", currentlyStored: nil)


### PR DESCRIPTION
Provenance lives in git history — commit titles already carry MOBILE-XXXX, so ticket/PR numbers in comments only rot. Text-only change; the two TODOs keep their tracking ticket on purpose.