### PR TITLE
MOBILE-415: Answer ready with inappId, the backend's spelling

### DIFF
--- a/Mindbox/InAppMessages/Presentation/Views/WebView/Bridge/BridgeMessage.swift
+++ b/Mindbox/InAppMessages/Presentation/Views/WebView/Bridge/BridgeMessage.swift
@@ -257,7 +257,7 @@ public struct BridgeMessage: Codable {
         ///     "endpointId": "my-app-endpoint",
         ///     "deviceUUID": "A1B2C3D4-E5F6-7890-ABCD-EF1234567890",
         ///     "userVisitCount": "41",
-        ///     "inAppId": "65f3a8b9-2c4d-4e5f-a6b7-c8d9e0f12345",
+        ///     "inappId": "65f3a8b9-2c4d-4e5f-a6b7-c8d9e0f12345",
         ///     "firstInitializationDateTime": "2025-01-15T10:30:00Z",
         ///     "localStateVersion": 1,
         ///     "operationName": "Inapp.Click",
@@ -550,8 +550,8 @@ public struct BridgeMessage: Codable {
 
         // MARK: JS → Native: Feeds
         //
-        // Two spellings by contract: bridge payloads say `inappId`/`inappIds`, feed list entries say
-        // `inAppId` (the config's spelling, forwarded untouched) — neither may be "corrected".
+        // Bridge payloads say `inappId`/`inappIds` throughout, the start payload included. Feed list
+        // entries carry whatever the config spells — forwarded untouched, never corrected.
 
         /// JS asks which of these in-apps it is allowed to render.
         ///

--- a/Mindbox/InAppMessages/Presentation/Views/WebView/Bridge/Handlers/WebViewStartPayloadBuilder.swift
+++ b/Mindbox/InAppMessages/Presentation/Views/WebView/Bridge/Handlers/WebViewStartPayloadBuilder.swift
@@ -16,7 +16,7 @@ private enum PayloadKey {
     static let deviceUuid = "deviceUUID"
     static let userVisitCount = "userVisitCount"
 
-    static let inAppId = "inAppId"
+    static let inappId = "inappId"
     static let operationName = "operationName"
     static let operationBody = "operationBody"
 
@@ -96,7 +96,7 @@ private extension WebViewStartPayloadBuilder {
             PayloadKey.deviceUuid: persistenceStorage.deviceUUID ?? "",
             PayloadKey.userVisitCount: "\(persistenceStorage.userVisitCount ?? 0)",
             PayloadKey.sdkVersionNumeric: "\(Constants.Versions.sdkVersionNumeric)",
-            PayloadKey.inAppId: contentId,
+            PayloadKey.inappId: contentId,
             // Add localState version for WebView JS migration logic
             PayloadKey.localStateVersion: persistenceStorage.webViewLocalStateVersion ?? Constants.WebViewLocalState.defaultVersion
         ]

--- a/MindboxTests/InApp/Tests/WebView/BridgeHandlers/WebViewStartPayloadBuilderTests.swift
+++ b/MindboxTests/InApp/Tests/WebView/BridgeHandlers/WebViewStartPayloadBuilderTests.swift
@@ -46,16 +46,19 @@ struct WebViewStartPayloadBuilderTests {
         let payload = try build()
 
         for key in ["sdkVersion", "sdkVersionNumeric", "endpointId", "deviceUUID",
-                    "userVisitCount", "inAppId", "localStateVersion", "insets"] {
+                    "userVisitCount", "inappId", "localStateVersion", "insets"] {
             #expect(payload[key] != nil, "'\(key)' is missing from the start payload")
         }
     }
 
-    @Test("The content id travels as inAppId — the key the contract already uses")
-    func contentIdTravelsAsInAppId() throws {
+    /// The backend's spelling, and the one every other bridge payload already uses. Pages read
+    /// `inappId` first and fall back to the old `inAppId`, so an older SDK keeps working.
+    @Test("The content id travels as inappId, not the old inAppId")
+    func contentIdTravelsAsInappId() throws {
         let payload = try build(contentId: "block-42")
 
-        #expect(payload["inAppId"] == .string("block-42"))
+        #expect(payload["inappId"] == .string("block-42"))
+        #expect(payload["inAppId"] == nil)
     }
 
     @Test("Insets are reported as four named edges")
@@ -102,7 +105,7 @@ struct WebViewStartPayloadBuilderTests {
     /// Deliberate: a direct call names what this show must carry, so its params outrank the fields
     /// the SDK fills in. Pinned so the day someone protects these keys is a decision, not a slip.
     @Test("A param can displace a field the SDK fills in", arguments: [
-        "deviceUUID", "endpointId", "inAppId", "sdkVersion", "userVisitCount", "localStateVersion"
+        "deviceUUID", "endpointId", "inappId", "sdkVersion", "userVisitCount", "localStateVersion"
     ])
     func customParamsDisplaceSdkFields(key: String) throws {
         let untouched = try build()

--- a/MindboxTests/InApp/Tests/WebView/BridgeHandlers/WebViewStartPayloadBuilderTests.swift
+++ b/MindboxTests/InApp/Tests/WebView/BridgeHandlers/WebViewStartPayloadBuilderTests.swift
@@ -51,8 +51,8 @@ struct WebViewStartPayloadBuilderTests {
         }
     }
 
-    /// The backend's spelling, and the one every other bridge payload already uses. Pages read
-    /// `inappId` first and fall back to the old `inAppId`, so an older SDK keeps working.
+    /// The backend's spelling, and the one every other bridge payload already uses. Safe only in
+    /// this order: the page that reads `inappId` and falls back to `inAppId` ships before this SDK.
     @Test("The content id travels as inappId, not the old inAppId")
     func contentIdTravelsAsInappId() throws {
         let payload = try build(contentId: "block-42")


### PR DESCRIPTION
Стартовый пакет отвечает `inappId` вместо `inAppId` — написание, которое бэк держит по контракту и которое страницы уже читают.

**Не мержить, пока страница с фоллбэком не раскатана на stable.** Проверено 19.08: staging-бандлы (`main.js` и `stories.js` 1.0.36) читают оба написания, а прод `main.js?v=1.0.33` — только старое, поэтому SDK с новым ключом там молча лишит попап операций `Inapp.Click` и `Inapp.Show`. Фронтовая половина: MR !85 в mobile-webview-inapps, влита в main и на staging.

Проверено живьём на staging (endpoint Test-staging.Semko, попап `template.dynamic.onboarding`): показ → `init` → тап даёт `asyncOperation` `{"operation":"Inapp.Click","body":{"inappId":"cc3e6f58-…"}}` → `close`, бэк принял. То же самое прогнано на старом написании — страница работает на обоих.

Android свой `KEY_IN_APP_ID` пока не переименовал.