### PR TITLE
MOBILE-416: Rename the feed's bridge action to filterShowableInapps

### DIFF
--- a/Mindbox/EmbeddedBlocks/Feed/EmbeddedBlockFeedService.swift
+++ b/Mindbox/EmbeddedBlocks/Feed/EmbeddedBlockFeedService.swift
@@ -26,7 +26,7 @@ protocol EmbeddedBlockFeedServing: AnyObject {
 
     /// Answered from what the session already fetched, never the network — an id whose targeting
     /// cannot be checked without one is cut: fail closed, in sync with Android.
-    func renderableInappIds(among ids: [String], completion: @escaping (FeedAnswer) -> Void)
+    func showableInappIds(among ids: [String], completion: @escaping (FeedAnswer) -> Void)
 
     /// Deliberately unchecked: whether to offer the in-app was decided when the page drew it.
     func showInapp(id: String, params: [String: JSONValue])
@@ -42,7 +42,7 @@ final class EmbeddedBlockFeedService: EmbeddedBlockFeedServing {
          fetchInappToShow: ((_ id: String, _ params: [String: JSONValue], _ completion: @escaping (InAppFormData?) -> Void) -> Void)? = nil,
          showNow: ((InAppFormData) -> Void)? = nil) {
         self.ask = ask ?? { ids, completion in
-            DI.injectOrFail(InAppConfigurationManagerProtocol.self).getRenderableInappIds(ids, completion)
+            DI.injectOrFail(InAppConfigurationManagerProtocol.self).getShowableInappIds(ids, completion)
         }
         self.fetchInappToShow = fetchInappToShow ?? { id, params, completion in
             DI.injectOrFail(InAppConfigurationManagerProtocol.self).getInAppToShowById(id, params: params, completion)
@@ -64,7 +64,7 @@ final class EmbeddedBlockFeedService: EmbeddedBlockFeedServing {
         }
     }
 
-    func renderableInappIds(among ids: [String], completion: @escaping (FeedAnswer) -> Void) {
+    func showableInappIds(among ids: [String], completion: @escaping (FeedAnswer) -> Void) {
         guard !ids.isEmpty else {
             completion(.nothing)
             return

--- a/Mindbox/EmbeddedBlocks/WebView/EmbeddedBlockPageHosting.swift
+++ b/Mindbox/EmbeddedBlocks/WebView/EmbeddedBlockPageHosting.swift
@@ -26,9 +26,9 @@ protocol EmbeddedBlockPageHosting: AnyObject {
     /// nobody can vouch for. Delivered on the main thread.
     var onUnreadableContentReport: (() -> Void)? { get set }
 
-    /// The page asks which of these ids it may render. The answer goes back through `completion`
+    /// The page asks which of these ids are showable. The answer goes back through `completion`
     /// — from wherever the selection finishes. Delivered on the main thread.
-    var onFeedQuestion: (([String], @escaping ([String]) -> Void) -> Void)? { get set }
+    var onShowableQuestion: (([String], @escaping ([String]) -> Void) -> Void)? { get set }
 
     /// The page asks to show an in-app by id, with the params that travel into its start
     /// payload untouched. Delivered on the main thread.

--- a/Mindbox/EmbeddedBlocks/WebView/EmbeddedBlockWebViewPage.swift
+++ b/Mindbox/EmbeddedBlocks/WebView/EmbeddedBlockWebViewPage.swift
@@ -20,7 +20,7 @@ final class EmbeddedBlockWebViewPage: NSObject, EmbeddedBlockPageHosting {
 
     var onUnreadableContentReport: (() -> Void)?
 
-    var onFeedQuestion: (([String], @escaping ([String]) -> Void) -> Void)?
+    var onShowableQuestion: (([String], @escaping ([String]) -> Void) -> Void)?
 
     var onShowInAppRequest: ((String, [String: JSONValue]) -> Void)?
 
@@ -161,8 +161,8 @@ extension EmbeddedBlockWebViewPage: WebBridgeContentHosting {
 
 extension EmbeddedBlockWebViewPage: WebBridgeFeedHosting {
 
-    func bridgeDidAskRenderableInapps(_ ids: [String], completion: @escaping ([String]) -> Void) {
-        onFeedQuestion?(ids, completion)
+    func bridgeDidAskShowableInapps(_ ids: [String], completion: @escaping ([String]) -> Void) {
+        onShowableQuestion?(ids, completion)
     }
 
     func bridgeDidRequestShowInApp(id: String, params: [String: JSONValue]) {

--- a/Mindbox/EmbeddedBlocks/WebView/EmbeddedBlockWebViewProvider.swift
+++ b/Mindbox/EmbeddedBlocks/WebView/EmbeddedBlockWebViewProvider.swift
@@ -198,8 +198,8 @@ final class EmbeddedBlockWebViewProvider {
         page.onUnreadableContentReport = { [weak self] in
             self?.handleUnreadableContentReport()
         }
-        page.onFeedQuestion = { [weak self] ids, completion in
-            self?.answerTargeting(ids, completion: completion)
+        page.onShowableQuestion = { [weak self] ids, completion in
+            self?.answerShowableQuestion(ids, completion: completion)
         }
         page.onShowInAppRequest = { [weak self] inappId, params in
             self?.showInapp(id: inappId, params: params)
@@ -223,7 +223,7 @@ final class EmbeddedBlockWebViewProvider {
         cancelDataPushAck()
         page?.onContentRendered = nil
         page?.onUnreadableContentReport = nil
-        page?.onFeedQuestion = nil
+        page?.onShowableQuestion = nil
         page?.onShowInAppRequest = nil
         page?.onDataPushConfirmed = nil
         page?.onLoadFailure = nil
@@ -317,11 +317,11 @@ final class EmbeddedBlockWebViewProvider {
 
     /// A question shows nothing, so it is answered for as long as the block is running — including
     /// while it is still loading, which is exactly when a feed asks.
-    private func answerTargeting(_ ids: [String], completion: @escaping ([String]) -> Void) {
+    private func answerShowableQuestion(_ ids: [String], completion: @escaping ([String]) -> Void) {
         guard isStarted else { return }
 
         let generation = loadGeneration
-        feed.renderableInappIds(among: ids) { [weak self] answer in
+        feed.showableInappIds(among: ids) { [weak self] answer in
             guard let self, self.isStarted, self.loadGeneration == generation else { return }
 
             completion(answer.inappIds)

--- a/Mindbox/InAppMessages/Configuration/InAppConfigurationManager.swift
+++ b/Mindbox/InAppMessages/Configuration/InAppConfigurationManager.swift
@@ -19,7 +19,7 @@ protocol InAppConfigurationManagerProtocol: AnyObject {
     func prepareConfiguration()
     func handleInapps(event: ApplicationEvent?, _ completion: @escaping (InAppFormData?) -> Void)
     func selectInappForPlace(_ place: String, trigger: ApplicationEvent?, _ completion: @escaping (InAppTransitionData?) -> Void)
-    func getRenderableInappIds(_ ids: [String], _ completion: @escaping (FeedAnswer) -> Void)
+    func getShowableInappIds(_ ids: [String], _ completion: @escaping (FeedAnswer) -> Void)
     func getInAppToShowById(_ id: String, params: [String: JSONValue], _ completion: @escaping (InAppFormData?) -> Void)
     func getEmbeddedPlaces(_ completion: @escaping ([String: Set<String>]?) -> Void)
     func resetInappManager()
@@ -114,14 +114,14 @@ class InAppConfigurationManager: InAppConfigurationManagerProtocol {
         }
     }
 
-    func getRenderableInappIds(_ ids: [String], _ completion: @escaping (FeedAnswer) -> Void) {
+    func getShowableInappIds(_ ids: [String], _ completion: @escaping (FeedAnswer) -> Void) {
         awaitConfig("a feed asking about \(ids.count) in-app(s)") { [weak self] candidates in
             guard let self = self, let inappMapper = self.inappMapper, let candidates = candidates else {
                 completion(.nothing)
                 return
             }
 
-            inappMapper.getRenderableInappIds(ids, candidates, completion)
+            inappMapper.getShowableInappIds(ids, candidates, completion)
         }
     }
 

--- a/Mindbox/InAppMessages/InAppConfigurationMapper/InappMapper.swift
+++ b/Mindbox/InAppMessages/InAppConfigurationMapper/InappMapper.swift
@@ -21,9 +21,9 @@ protocol InappMapperProtocol {
     func getInAppById(_ id: String,
                       _ candidates: ConfigCandidates,
                       _ completion: @escaping (InAppTransitionData?) -> Void)
-    func getRenderableInappIds(_ ids: [String],
-                               _ candidates: ConfigCandidates,
-                               _ completion: @escaping (FeedAnswer) -> Void)
+    func getShowableInappIds(_ ids: [String],
+                             _ candidates: ConfigCandidates,
+                             _ completion: @escaping (FeedAnswer) -> Void)
     func getInAppToShowById(_ id: String,
                             params: [String: JSONValue],
                             _ candidates: ConfigCandidates,
@@ -117,9 +117,9 @@ class InappMapper: InappMapperProtocol {
 
     /// Never goes to the network: answers from what the session already fetched, and an id whose
     /// targeting lacks data is cut — fail closed, in sync with Android.
-    func getRenderableInappIds(_ ids: [String],
-                               _ candidates: ConfigCandidates,
-                               _ completion: @escaping (FeedAnswer) -> Void) {
+    func getShowableInappIds(_ ids: [String],
+                             _ candidates: ConfigCandidates,
+                             _ completion: @escaping (FeedAnswer) -> Void) {
         let query = TargetingQuery(
             label: "a feed asking about \(ids.count) in-app(s)",
             event: nil,

--- a/Mindbox/InAppMessages/Presentation/Views/WebView/Bridge/BridgeMessage.swift
+++ b/Mindbox/InAppMessages/Presentation/Views/WebView/Bridge/BridgeMessage.swift
@@ -553,7 +553,7 @@ public struct BridgeMessage: Codable {
         // Bridge payloads say `inappId`/`inappIds` throughout, the start payload included. Feed list
         // entries carry whatever the config spells — forwarded untouched, never corrected.
 
-        /// JS asks which of these in-apps it is allowed to render.
+        /// JS asks which of these in-apps are showable — the page draws only those.
         ///
         /// The page gives up after 3 seconds and renders an empty feed; the SDK does not race that
         /// deadline — it answers when the selection answers.
@@ -566,7 +566,7 @@ public struct BridgeMessage: Codable {
         ///   ```json
         ///   { "inappIds": ["<string>", "..."] }
         ///   ```
-        case checkInappsTargeting
+        case filterShowableInapps
 
         /// JS reports how many items it actually rendered, exactly once per load.
         ///
@@ -655,7 +655,7 @@ public struct BridgeMessage: Codable {
 
             // Both carry an answer the page acts on: one returns the ids that passed, the other
             // reports whether the show was accepted.
-            case .checkInappsTargeting, .showInApp:
+            case .filterShowableInapps, .showInApp:
                 return true
 
             // Operations
@@ -728,7 +728,7 @@ public struct BridgeMessage: Codable {
                 return true
 
             case .motionStop, .ready, .close, .`init`, .click, .hide, .log,
-                 .contentRendered, .checkInappsTargeting,
+                 .contentRendered, .filterShowableInapps,
                  .asyncOperation, .syncOperation,
                  .localStateGet, .localStateSet, .localStateInit,
                  .motionEvent, .navigationIntercepted,

--- a/Mindbox/InAppMessages/Presentation/Views/WebView/Bridge/Handlers/FilterShowableInappsActionHandler.swift
+++ b/Mindbox/InAppMessages/Presentation/Views/WebView/Bridge/Handlers/FilterShowableInappsActionHandler.swift
@@ -1,5 +1,5 @@
 //
-//  CheckInappsTargetingActionHandler.swift
+//  FilterShowableInappsActionHandler.swift
 //  Mindbox
 //
 //  Created by Akylbek Utekeshev on 13.08.2026.
@@ -11,9 +11,9 @@ import MindboxLogger
 
 /// An unreadable question is refused rather than answered with an empty list: the page can
 /// retry a refusal, while an empty answer it would take for the truth.
-final class CheckInappsTargetingActionHandler: WebBridgeActionHandler {
+final class FilterShowableInappsActionHandler: WebBridgeActionHandler {
 
-    let actions: Set<BridgeMessage.Action> = [.checkInappsTargeting]
+    let actions: Set<BridgeMessage.Action> = [.filterShowableInapps]
 
     func handle(_ message: BridgeMessage, host: WebBridgeHost) {
         guard case .array(let requested)? = message.payloadObject?["inappIds"] else {
@@ -27,7 +27,7 @@ final class CheckInappsTargetingActionHandler: WebBridgeActionHandler {
         }
 
         if ids.count != requested.count {
-            Logger.common(message: "[WebView] checkInappsTargeting: \(requested.count - ids.count) of \(requested.count) asked ids are not strings, skipping them",
+            Logger.common(message: "[WebView] filterShowableInapps: \(requested.count - ids.count) of \(requested.count) asked ids are not strings, skipping them",
                           level: .error,
                           category: host.logCategory)
         }
@@ -35,13 +35,13 @@ final class CheckInappsTargetingActionHandler: WebBridgeActionHandler {
         guard let feedHost = host as? WebBridgeFeedHosting else {
             // Left unanswered, not refused: feedless surfaces may conform later, and a refusal
             // would have to be unlearned by every page that starts relying on it.
-            Logger.common(message: "[WebView] Bridge: checkInappsTargeting from '\(host.contentId)' has no feed to ask here, ignoring",
+            Logger.common(message: "[WebView] Bridge: filterShowableInapps from '\(host.contentId)' has no feed to ask here, ignoring",
                           level: .error,
                           category: host.logCategory)
             return
         }
 
-        feedHost.bridgeDidAskRenderableInapps(ids) { [weak host] allowed in
+        feedHost.bridgeDidAskShowableInapps(ids) { [weak host] allowed in
             host?.respond(to: message, payload: .object(["inappIds": .array(allowed.map { .string($0) })]))
         }
     }

--- a/Mindbox/InAppMessages/Presentation/Views/WebView/Bridge/Handlers/WebBridgeActionHandlerFactory.swift
+++ b/Mindbox/InAppMessages/Presentation/Views/WebView/Bridge/Handlers/WebBridgeActionHandlerFactory.swift
@@ -31,7 +31,7 @@ enum WebBridgeActionHandlerFactory {
             OperationActionHandler(),
             LifecycleActionHandler(),
             ContentRenderedActionHandler(),
-            CheckInappsTargetingActionHandler(),
+            FilterShowableInappsActionHandler(),
             ShowInAppActionHandler()
         ]
     }

--- a/Mindbox/InAppMessages/Presentation/Views/WebView/Bridge/Handlers/WebBridgeHost.swift
+++ b/Mindbox/InAppMessages/Presentation/Views/WebView/Bridge/Handlers/WebBridgeHost.swift
@@ -139,9 +139,9 @@ protocol WebBridgeContentHosting: AnyObject {
 
 protocol WebBridgeFeedHosting: AnyObject {
 
-    /// Which of `ids` may be rendered. Answered asynchronously and possibly never: a host that
+    /// Which of `ids` are showable. Answered asynchronously and possibly never: a host that
     /// stopped listening drops the question, and what a missing answer means is the page's call.
-    func bridgeDidAskRenderableInapps(_ ids: [String], completion: @escaping ([String]) -> Void)
+    func bridgeDidAskShowableInapps(_ ids: [String], completion: @escaping ([String]) -> Void)
 
     /// `params` travel into the shown in-app's start payload untouched: for the SDK they are an
     /// opaque dictionary.

--- a/MindboxTests/EmbeddedBlocks/EmbeddedBlockFeedServiceTests.swift
+++ b/MindboxTests/EmbeddedBlocks/EmbeddedBlockFeedServiceTests.swift
@@ -96,7 +96,7 @@ struct EmbeddedBlockFeedServiceTests {
         })
 
         let deliveredOnMainThread: Bool = await withCheckedContinuation { continuation in
-            service.renderableInappIds(among: ["story-1"]) { _ in
+            service.showableInappIds(among: ["story-1"]) { _ in
                 continuation.resume(returning: Thread.isMainThread)
             }
         }
@@ -144,7 +144,7 @@ private final class FeedBed {
     }
 
     func ask(_ ids: [String]) {
-        service.renderableInappIds(among: ids) { [weak self] answer in
+        service.showableInappIds(among: ids) { [weak self] answer in
             self?.answers.append(answer.inappIds)
         }
     }

--- a/MindboxTests/EmbeddedBlocks/EmbeddedBlockMocks.swift
+++ b/MindboxTests/EmbeddedBlocks/EmbeddedBlockMocks.swift
@@ -89,7 +89,7 @@ final class EmbeddedBlockPageMock: EmbeddedBlockPageHosting {
 
     var onUnreadableContentReport: (() -> Void)?
 
-    var onFeedQuestion: (([String], @escaping ([String]) -> Void) -> Void)?
+    var onShowableQuestion: (([String], @escaping ([String]) -> Void) -> Void)?
 
     var onShowInAppRequest: ((String, [String: JSONValue]) -> Void)?
 
@@ -112,7 +112,7 @@ final class EmbeddedBlockPageMock: EmbeddedBlockPageHosting {
     private lazy var host = EmbeddedBlockPageMockHost(page: self)
     private lazy var registry = WebBridgeActionRegistry(handlers: [
         ContentRenderedActionHandler(),
-        CheckInappsTargetingActionHandler(),
+        FilterShowableInappsActionHandler(),
         ShowInAppActionHandler()
     ])
 
@@ -200,8 +200,8 @@ private final class EmbeddedBlockPageMockHost: WebBridgeHost, WebBridgeContentHo
         page.onUnreadableContentReport?()
     }
 
-    func bridgeDidAskRenderableInapps(_ ids: [String], completion: @escaping ([String]) -> Void) {
-        page.onFeedQuestion?(ids, completion)
+    func bridgeDidAskShowableInapps(_ ids: [String], completion: @escaping ([String]) -> Void) {
+        page.onShowableQuestion?(ids, completion)
     }
 
     func bridgeDidRequestShowInApp(id: String, params: [String: JSONValue]) {
@@ -352,7 +352,7 @@ final class EmbeddedBlockFeedServiceMock: EmbeddedBlockFeedServing {
         shown.append((id, params))
     }
 
-    func renderableInappIds(among ids: [String], completion: @escaping (FeedAnswer) -> Void) {
+    func showableInappIds(among ids: [String], completion: @escaping (FeedAnswer) -> Void) {
         askedIds.append(ids)
 
         if isDeferred {

--- a/MindboxTests/EmbeddedBlocks/EmbeddedBlockWebViewPageTests.swift
+++ b/MindboxTests/EmbeddedBlocks/EmbeddedBlockWebViewPageTests.swift
@@ -134,7 +134,7 @@ struct EmbeddedBlockWebViewPageTests {
     func feedQuestionReachesTheBlock() throws {
         let bed = PageBed()
 
-        let question = BridgeMessage.pageRequest(.checkInappsTargeting,
+        let question = BridgeMessage.pageRequest(.filterShowableInapps,
                                                  ["inappIds": .array([.string("one"), .string("two")])])
         bed.receive(question)
 
@@ -335,7 +335,7 @@ private final class PageBed {
         page.onLoadFailure = { [weak self] in
             self?.failures += 1
         }
-        page.onFeedQuestion = { [weak self] ids, completion in
+        page.onShowableQuestion = { [weak self] ids, completion in
             self?.feedQuestions.append(ids)
             self?.feedCompletions.append(completion)
         }

--- a/MindboxTests/EmbeddedBlocks/EmbeddedBlockWebViewProviderTests.swift
+++ b/MindboxTests/EmbeddedBlocks/EmbeddedBlockWebViewProviderTests.swift
@@ -726,7 +726,7 @@ struct EmbeddedBlockWebViewProviderTests {
         bed.provider.start()
 
         let params: [String: JSONValue] = ["formId": .string("160477"),
-                                           "lastChangedDateTimeUtc": .string("2026-08-13T09:00:00.000000Z")]
+                                           "lastContentUpdateDateTimeUtc": .string("2026-08-13T09:00:00.000000Z")]
         bed.page?.send(.showInApp, ["inappId": .string("story-id"), "params": .object(params)])
 
         #expect(bed.feed.shown.first?.params == params)

--- a/MindboxTests/EmbeddedBlocks/EmbeddedBlockWebViewProviderTests.swift
+++ b/MindboxTests/EmbeddedBlocks/EmbeddedBlockWebViewProviderTests.swift
@@ -660,7 +660,7 @@ struct EmbeddedBlockWebViewProviderTests {
         bed.feed.allowed = ["story-1"]
         bed.provider.start()
 
-        bed.page?.send(.checkInappsTargeting, ["inappIds": .array([.string("story-1"), .string("story-2")])])
+        bed.page?.send(.filterShowableInapps, ["inappIds": .array([.string("story-1"), .string("story-2")])])
 
         #expect(bed.feed.askedIds == [["story-1", "story-2"]])
         #expect(bed.page?.responses.map(\.payload) == [.object(["inappIds": .array([.string("story-1")])])])
@@ -672,7 +672,7 @@ struct EmbeddedBlockWebViewProviderTests {
         bed.feed.allowed = ["story-1", "story-2"]
         bed.provider.start()
 
-        bed.page?.send(.checkInappsTargeting, ["inappIds": .array([.string("story-1"), .string("story-2")])])
+        bed.page?.send(.filterShowableInapps, ["inappIds": .array([.string("story-1"), .string("story-2")])])
 
         #expect(bed.feed.vouchCount == 1)
     }
@@ -684,7 +684,7 @@ struct EmbeddedBlockWebViewProviderTests {
         bed.feed.isDeferred = true
         bed.provider.start()
 
-        bed.page?.send(.checkInappsTargeting, ["inappIds": .array([.string("story-1")])])
+        bed.page?.send(.filterShowableInapps, ["inappIds": .array([.string("story-1")])])
         bed.provider.stop()
         bed.feed.flush()
 
@@ -697,7 +697,7 @@ struct EmbeddedBlockWebViewProviderTests {
         bed.feed.isDeferred = true
         bed.provider.start()
 
-        bed.page?.send(.checkInappsTargeting, ["inappIds": .array([.string("story-1")])])
+        bed.page?.send(.filterShowableInapps, ["inappIds": .array([.string("story-1")])])
         bed.provider.stop()
         bed.feed.flush()
 

--- a/MindboxTests/InApp/Tests/InAppConfigResponseTests/EmbeddedBlockResolveTests.swift
+++ b/MindboxTests/InApp/Tests/InAppConfigResponseTests/EmbeddedBlockResolveTests.swift
@@ -70,7 +70,7 @@ struct EmbeddedBlockResolveTests {
 
     private func renderable(_ ids: [String]) async -> [String] {
         await withCheckedContinuation { continuation in
-            mapper.getRenderableInappIds(ids, candidates) { answer in
+            mapper.getShowableInappIds(ids, candidates) { answer in
                 // Delivering the answer, as a block does, is what sends targeting — the selection does not vouch by itself.
                 answer.vouch()
                 continuation.resume(returning: answer.inappIds.sorted())

--- a/MindboxTests/InApp/Tests/InAppConfigResponseTests/EmbeddedBlockResolveTests.swift
+++ b/MindboxTests/InApp/Tests/InAppConfigResponseTests/EmbeddedBlockResolveTests.swift
@@ -68,7 +68,7 @@ struct EmbeddedBlockResolveTests {
         }
     }
 
-    private func renderable(_ ids: [String]) async -> [String] {
+    private func showable(_ ids: [String]) async -> [String] {
         await withCheckedContinuation { continuation in
             mapper.getShowableInappIds(ids, candidates) { answer in
                 // Delivering the answer, as a block does, is what sends targeting — the selection does not vouch by itself.
@@ -139,8 +139,8 @@ struct EmbeddedBlockResolveTests {
     /// Every delivered answer is a new offer — the rule operation targeting lives by (in sync with Android).
     @Test("A feed asking again vouches for the same in-apps again")
     func feedVouchesPerDeliveredAnswer() async {
-        _ = await renderable(everyId)
-        _ = await renderable(everyId)
+        _ = await showable(everyId)
+        _ = await showable(everyId)
 
         let vouched = dataFacade.trackTargetingCalls.filter { $0.id == Constants.unlimitedStoryId }
         #expect(vouched.count == 2)
@@ -253,7 +253,7 @@ struct EmbeddedBlockResolveTests {
 
     @Test("A feed may draw the stories and the modal, but not the block")
     func feedKeepsDirectCallAndDropsTheBlock() async {
-        #expect(await renderable(everyId) == [Constants.unlimitedStoryId, Constants.modalId, Constants.onceStoryId].sorted())
+        #expect(await showable(everyId) == [Constants.unlimitedStoryId, Constants.modalId, Constants.onceStoryId].sorted())
     }
 
     @Test("A watched unlimited story is still drawn")
@@ -261,7 +261,7 @@ struct EmbeddedBlockResolveTests {
         let persistenceStorage = DI.injectOrFail(PersistenceStorage.self)
         persistenceStorage.shownDatesByInApp = [Constants.unlimitedStoryId: [Date()]]
 
-        #expect(await renderable([Constants.unlimitedStoryId]) == [Constants.unlimitedStoryId])
+        #expect(await showable([Constants.unlimitedStoryId]) == [Constants.unlimitedStoryId])
     }
 
     @Test("A once story that was already shown is not drawn")
@@ -269,17 +269,17 @@ struct EmbeddedBlockResolveTests {
         let persistenceStorage = DI.injectOrFail(PersistenceStorage.self)
         persistenceStorage.shownDatesByInApp = [Constants.onceStoryId: [Date()]]
 
-        #expect(await renderable([Constants.onceStoryId]).isEmpty)
+        #expect(await showable([Constants.onceStoryId]).isEmpty)
     }
 
     @Test("An id no config knows is not drawn")
     func feedDropsUnknownId() async {
-        #expect(await renderable(["44444444-4444-4444-4444-444444444444"]).isEmpty)
+        #expect(await showable(["44444444-4444-4444-4444-444444444444"]).isEmpty)
     }
 
     @Test("A feed vouches for every story it allows and for nothing it cuts")
     func feedVouchesForWhatItAllows() async {
-        let allowed = await renderable(everyId)
+        let allowed = await showable(everyId)
         let vouched = Set(dataFacade.trackTargetingCalls.compactMap(\.id))
 
         #expect(vouched == Set(allowed))
@@ -288,7 +288,7 @@ struct EmbeddedBlockResolveTests {
 
     @Test("A story only an operation targets is not drawn for a feed")
     func feedDropsAnOperationTargetedStory() async {
-        #expect(await renderable([Constants.operationStoryId]).isEmpty)
+        #expect(await showable([Constants.operationStoryId]).isEmpty)
     }
 
     // MARK: - The feed answers without the network
@@ -296,7 +296,7 @@ struct EmbeddedBlockResolveTests {
     /// The wire contract gives the page three seconds: the feed is answered from what the session already fetched — fail closed, in sync with Android.
     @Test("A feed's question asks nothing of the network")
     func feedAsksNothingOfTheNetwork() async {
-        _ = await renderable(everyId)
+        _ = await showable(everyId)
 
         #expect(dataFacade.fetchDependenciesCalls == 0)
     }
@@ -312,7 +312,7 @@ struct EmbeddedBlockResolveTests {
     func coldCacheCutsASegmentStory() async {
         dataFacade.targetingChecker.checkedSegmentations = nil
 
-        #expect(await renderable([Constants.segmentStoryId]).isEmpty)
+        #expect(await showable([Constants.segmentStoryId]).isEmpty)
     }
 
     @Test("A segment story on a warm cache is drawn without a fetch")
@@ -322,7 +322,7 @@ struct EmbeddedBlockResolveTests {
                   segment: .init(ids: .init(externalId: "feed-segment")))
         ]
 
-        #expect(await renderable([Constants.segmentStoryId]) == [Constants.segmentStoryId])
+        #expect(await showable([Constants.segmentStoryId]) == [Constants.segmentStoryId])
         #expect(dataFacade.fetchDependenciesCalls == 0)
     }
 
@@ -330,17 +330,17 @@ struct EmbeddedBlockResolveTests {
     func showLimitsDoNotShrinkTheFeedAnswer() async {
         spendEveryShowBudget()
 
-        #expect(await renderable([Constants.unlimitedStoryId]) == [Constants.unlimitedStoryId])
+        #expect(await showable([Constants.unlimitedStoryId]) == [Constants.unlimitedStoryId])
     }
 
     @Test("An empty question gets an empty answer")
     func feedAnswersNothingToNothing() async {
-        #expect(await renderable([]).isEmpty)
+        #expect(await showable([]).isEmpty)
     }
 
     @Test("Answering a feed writes nothing to the show history")
     func feedAnswerWritesNothingToShowHistory() async {
-        _ = await renderable(everyId)
+        _ = await showable(everyId)
 
         let persistenceStorage = DI.injectOrFail(PersistenceStorage.self)
         #expect(persistenceStorage.shownDatesByInApp?.isEmpty == true)
@@ -446,6 +446,6 @@ struct EmbeddedBlockResolveTests {
 
     @Test("A feed keeps a mixed in-app — its overlay half can be drawn")
     func feedKeepsAMixedInapp() async {
-        #expect(await renderable([Constants.mixedId]) == [Constants.mixedId])
+        #expect(await showable([Constants.mixedId]) == [Constants.mixedId])
     }
 }

--- a/MindboxTests/InApp/Tests/InAppConfigurationManagerTests.swift
+++ b/MindboxTests/InApp/Tests/InAppConfigurationManagerTests.swift
@@ -171,7 +171,7 @@ struct InAppConfigurationManagerTests {
         try await waitUntil(api.isFetchPending)
 
         let answers = Answers<[String]>()
-        manager.getRenderableInappIds([Constants.liveStoryId]) { answers.append($0.inappIds) }
+        manager.getShowableInappIds([Constants.liveStoryId]) { answers.append($0.inappIds) }
 
         api.deliver(.data(try fixtureData()))
 
@@ -186,7 +186,7 @@ struct InAppConfigurationManagerTests {
         api.deliver(.data(try fixtureData()))
 
         let answers = Answers<[String]>()
-        manager.getRenderableInappIds([Constants.liveStoryId]) { answers.append($0.inappIds) }
+        manager.getShowableInappIds([Constants.liveStoryId]) { answers.append($0.inappIds) }
 
         try await waitUntil(!answers.isEmpty)
         #expect(answers.all == [[Constants.liveStoryId]])
@@ -197,7 +197,7 @@ struct InAppConfigurationManagerTests {
         manager.prepareConfiguration()
 
         let answers = Answers<[String]>()
-        manager.getRenderableInappIds([Constants.liveStoryId]) { answers.append($0.inappIds) }
+        manager.getShowableInappIds([Constants.liveStoryId]) { answers.append($0.inappIds) }
 
         try await waitUntil(!answers.isEmpty)
         #expect(answers.all == [[]])
@@ -219,7 +219,7 @@ struct InAppConfigurationManagerTests {
         try await waitUntil(api.isFetchPending)
 
         let answers = Answers<[String]>()
-        slowBudgetManager.getRenderableInappIds([Constants.liveStoryId]) { answers.append($0.inappIds) }
+        slowBudgetManager.getShowableInappIds([Constants.liveStoryId]) { answers.append($0.inappIds) }
         api.deliver(.error(MindboxError.connectionError))
 
         try await waitUntil(!answers.isEmpty)
@@ -232,7 +232,7 @@ struct InAppConfigurationManagerTests {
         try await waitUntil(api.isFetchPending)
 
         let answers = Answers<[String]>()
-        manager.getRenderableInappIds([Constants.liveStoryId]) { answers.append($0.inappIds) }
+        manager.getShowableInappIds([Constants.liveStoryId]) { answers.append($0.inappIds) }
         try await waitUntil(!answers.isEmpty)
 
         api.deliver(.data(try fixtureData()))
@@ -258,7 +258,7 @@ struct InAppConfigurationManagerTests {
         api.deliver(.error(MindboxError.connectionError))
 
         let answers = Answers<[String]>()
-        slowBudgetManager.getRenderableInappIds([Constants.liveStoryId]) { answers.append($0.inappIds) }
+        slowBudgetManager.getShowableInappIds([Constants.liveStoryId]) { answers.append($0.inappIds) }
 
         try await waitUntil(!answers.isEmpty)
         #expect(answers.all == [[]])
@@ -297,9 +297,9 @@ struct InAppConfigurationManagerTests {
 
         let feeds = Answers<[String]>()
         let places = Answers<InAppTransitionData?>()
-        manager.getRenderableInappIds([Constants.liveStoryId]) { feeds.append($0.inappIds) }
+        manager.getShowableInappIds([Constants.liveStoryId]) { feeds.append($0.inappIds) }
         manager.selectInappForPlace("stories-list-container", trigger: nil) { places.append($0) }
-        manager.getRenderableInappIds([Constants.liveStoryId]) { feeds.append($0.inappIds) }
+        manager.getShowableInappIds([Constants.liveStoryId]) { feeds.append($0.inappIds) }
         manager.selectInappForPlace("stories-list-container", trigger: nil) { places.append($0) }
 
         try await waitUntil(feeds.all.count == 2 && places.all.count == 2)

--- a/MindboxTests/InApp/Tests/InAppCoreManagerTests.swift
+++ b/MindboxTests/InApp/Tests/InAppCoreManagerTests.swift
@@ -26,7 +26,7 @@ struct InAppCoreManagerTests {
         func getInAppById(_ id: String, _ completion: @escaping (InAppTransitionData?) -> Void) {
             completion(nil)
         }
-        func getRenderableInappIds(_ ids: [String], _ completion: @escaping (FeedAnswer) -> Void) {
+        func getShowableInappIds(_ ids: [String], _ completion: @escaping (FeedAnswer) -> Void) {
             completion(.nothing)
         }
         func getInAppToShowById(_ id: String, params: [String: JSONValue], _ completion: @escaping (InAppFormData?) -> Void) {

--- a/MindboxTests/InApp/Tests/InappScheduleManagerTests.swift
+++ b/MindboxTests/InApp/Tests/InappScheduleManagerTests.swift
@@ -180,9 +180,11 @@ struct InappScheduleManagerTests {
         }
     }
 
+    /// The delay keeps the manager's own timer out of the test: with no delay it fires at once and
+    /// clears the failures itself, which races the "not cleared yet" check below.
     @Test("Eligible in-app cleanup clears buffered failures", .tags(.inAppSchedule))
     func showEligibleInapp_clearsFailuresAfterCleanup() {
-        let inapp = createInAppFormData(id: "clear-on-show", isPriority: false, delayTime: nil)
+        let inapp = createInAppFormData(id: "clear-on-show", isPriority: false, delayTime: "00:01:00")
         scheduleManager.scheduleInApp(inapp, processingDuration: 0)
 
         var presentationTime: TimeInterval?

--- a/MindboxTests/InApp/Tests/WebView/BridgeHandlers/FeedActionHandlersTests.swift
+++ b/MindboxTests/InApp/Tests/WebView/BridgeHandlers/FeedActionHandlersTests.swift
@@ -9,24 +9,24 @@
 import Testing
 @_spi(Internal) @testable import Mindbox
 
-@Suite("CheckInappsTargetingActionHandler", .tags(.webView))
-struct CheckInappsTargetingActionHandlerTests {
+@Suite("FilterShowableInappsActionHandler", .tags(.webView))
+struct FilterShowableInappsActionHandlerTests {
 
-    @Test("Owns the checkInappsTargeting action")
+    @Test("Owns the filterShowableInapps action")
     func ownsAction() {
-        #expect(CheckInappsTargetingActionHandler().actions == [.checkInappsTargeting])
+        #expect(FilterShowableInappsActionHandler().actions == [.filterShowableInapps])
     }
 
     @Test("The feed's answer travels back in the response")
     func feedAnswerTravelsBack() throws {
         let host = FeedHostSpy()
         host.allowed = ["id-1", "id-3"]
-        let message = BridgeMessage.request(.checkInappsTargeting,
+        let message = BridgeMessage.request(.filterShowableInapps,
                                             payload: .object(["inappIds": .array([.string("id-1"),
                                                                                   .string("id-2"),
                                                                                   .string("id-3")])]))
 
-        CheckInappsTargetingActionHandler().handle(message, host: host)
+        FilterShowableInappsActionHandler().handle(message, host: host)
 
         #expect(host.askedIds == [["id-1", "id-2", "id-3"]])
         let response = try #require(host.sent.first)
@@ -40,7 +40,7 @@ struct CheckInappsTargetingActionHandlerTests {
         let host = FeedHostSpy()
         host.isDeferred = true
 
-        CheckInappsTargetingActionHandler().handle(.request(.checkInappsTargeting,
+        FilterShowableInappsActionHandler().handle(.request(.filterShowableInapps,
                                                             payload: .object(["inappIds": .array([.string("id-1")])])),
                                                    host: host)
 
@@ -56,7 +56,7 @@ struct CheckInappsTargetingActionHandlerTests {
     func emptyRequestIsAnswered() {
         let host = FeedHostSpy()
 
-        CheckInappsTargetingActionHandler().handle(.request(.checkInappsTargeting,
+        FilterShowableInappsActionHandler().handle(.request(.filterShowableInapps,
                                                             payload: .object(["inappIds": .array([])])),
                                                    host: host)
 
@@ -69,8 +69,8 @@ struct CheckInappsTargetingActionHandlerTests {
         let host = FeedHostSpy()
         host.allowed = ["id-1"]
 
-        CheckInappsTargetingActionHandler().handle(
-            .request(.checkInappsTargeting, payload: .object(["inappIds": .array([.string("id-1"), .int(7)])])),
+        FilterShowableInappsActionHandler().handle(
+            .request(.filterShowableInapps, payload: .object(["inappIds": .array([.string("id-1"), .int(7)])])),
             host: host
         )
 
@@ -82,7 +82,7 @@ struct CheckInappsTargetingActionHandlerTests {
     func missingArrayIsRefused() throws {
         let host = FeedHostSpy()
 
-        CheckInappsTargetingActionHandler().handle(.request(.checkInappsTargeting, payload: .object([:])), host: host)
+        FilterShowableInappsActionHandler().handle(.request(.filterShowableInapps, payload: .object([:])), host: host)
 
         #expect(host.askedIds.isEmpty)
         let response = try #require(host.sent.first)
@@ -95,7 +95,7 @@ struct CheckInappsTargetingActionHandlerTests {
         let host = FeedHostSpy()
         host.allowed = ["id-1"]
 
-        CheckInappsTargetingActionHandler().handle(.request(.checkInappsTargeting,
+        FilterShowableInappsActionHandler().handle(.request(.filterShowableInapps,
                                                             payload: .string(#"{"inappIds":["id-1"]}"#)),
                                                    host: host)
 
@@ -106,7 +106,7 @@ struct CheckInappsTargetingActionHandlerTests {
     func hostWithoutFeedStaysSilent() {
         let host = HostSpy()
 
-        CheckInappsTargetingActionHandler().handle(.request(.checkInappsTargeting,
+        FilterShowableInappsActionHandler().handle(.request(.filterShowableInapps,
                                                             payload: .object(["inappIds": .array([.string("id-1")])])),
                                                    host: host)
 
@@ -195,7 +195,7 @@ private final class FeedHostSpy: HostSpy, WebBridgeFeedHosting {
 
     private var pending: [([String]) -> Void] = []
 
-    func bridgeDidAskRenderableInapps(_ ids: [String], completion: @escaping ([String]) -> Void) {
+    func bridgeDidAskShowableInapps(_ ids: [String], completion: @escaping ([String]) -> Void) {
         askedIds.append(ids)
 
         if isDeferred {

--- a/MindboxTests/InApp/Tests/WebView/BridgeHandlers/WebBridgeUserPresenceTests.swift
+++ b/MindboxTests/InApp/Tests/WebView/BridgeHandlers/WebBridgeUserPresenceTests.swift
@@ -46,7 +46,7 @@ struct WebBridgeUserPresenceTests {
                       .asyncOperation,
                       .syncOperation,
                       .contentRendered,
-                      .checkInappsTargeting,
+                      .filterShowableInapps,
                       .close,
                       .hide,
                       .click,


### PR DESCRIPTION
The action promised a targeting check, and targeting is one filter of six behind the answer. The new name is the word both SDKs already use for this: `showableInapps`/`applyShowabilityFilters` here, `filterShowableInAppIds` on Android — `ableToShow` appeared in neither. Spelled `inapps` to match the `inappIds` this very action returns.

The cut is hard — no old name accepted — because the action never shipped in a release: it exists only on `mission/stories`. The same word now runs from the wire down to the selection (`bridgeDidAskShowableInapps` → `onShowableQuestion` → `showableInappIds` → `getShowableInappIds`).

Ships with the page side (mobile-webview-inapps !86): the deployed feed page still sends the old name, so SDK and page go out together. 1803/0.